### PR TITLE
fix: NPE on Search window closing without action

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -64,7 +64,7 @@
               checks="(DesignForExtension|MagicNumber)"/>
     <suppress checks="WhitespaceAround"
             files="(AlignFilePicker|InstanceEditor|CreateGlossaryEntry|NewTeamProject|FilenamePatternsEditor|FilterEditor|SegmentPropertiesListCell|FilterBarReplace|ProjectFilesList)\.java"/>
-    <suppress checks="ParameterNumber" files="EntryListPane\.java" lines="302"/>
+    <suppress checks="ParameterNumber" files="EntryListPane\.java" lines="300-400"/>
     <suppress checks="LineLength" files="(CreateGlossaryEntry|FilterBarReplace|FilterEditor|InstanceEditor|NewTeamProject|ProjectFilesList)\.java"/>
 
     <!-- Suppress for readability -->

--- a/src/main/java/org/omegat/core/search/SearchExpression.java
+++ b/src/main/java/org/omegat/core/search/SearchExpression.java
@@ -31,6 +31,7 @@
 
 package org.omegat.core.search;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.util.OConsts;
 
 /**
@@ -49,20 +50,26 @@ import org.omegat.util.OConsts;
 public class SearchExpression {
     public enum SearchExpressionType {
         EXACT, KEYWORD, REGEXP
-    };
+    }
 
     public enum SearchPlace {
         SOURCE_TRANSLATION, SOURCE_ONLY, TRANSLATION_ONLY
-    };
+    }
 
     public enum SearchState {
         TRANSLATED_UNTRANSLATED, TRANSLATED, UNTRANSLATED
-    };
+    }
+
+    public SearchExpression() {
+        this.mode = SearchMode.SEARCH;
+        this.searchExpressionType = SearchExpressionType.EXACT;
+        numberOfResults = OConsts.ST_MAX_SEARCH_RESULTS;
+    }
 
     public SearchMode mode;
-    public String text;
-    public String rootDir;
-    public String replacement;
+    public @Nullable String text;
+    public @Nullable String rootDir;
+    public @Nullable String replacement;
     public boolean recursive = true;
     public SearchExpressionType searchExpressionType;
     public boolean caseSensitive = false;
@@ -87,6 +94,6 @@ public class SearchExpression {
     public long dateAfter;
     public boolean searchDateBefore = false;
     public long dateBefore;
-    public int numberOfResults = OConsts.ST_MAX_SEARCH_RESULTS;
+    public int numberOfResults;
     public boolean excludeOrphans = false;
 }

--- a/src/main/java/org/omegat/core/search/SearchMatch.java
+++ b/src/main/java/org/omegat/core/search/SearchMatch.java
@@ -25,6 +25,8 @@
 
 package org.omegat.core.search;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Class for store info about matching position.
  *
@@ -32,7 +34,7 @@ package org.omegat.core.search;
  */
 public class SearchMatch implements Comparable<SearchMatch> {
     private int start, end;
-    private String replacement;
+    private final @Nullable String replacement;
 
     public SearchMatch(int start, int end) {
         this.start = start;
@@ -66,7 +68,7 @@ public class SearchMatch implements Comparable<SearchMatch> {
         return end - start;
     }
 
-    public String getReplacement() {
+    public @Nullable String getReplacement() {
         return replacement;
     }
 

--- a/src/main/java/org/omegat/core/search/SearchMode.java
+++ b/src/main/java/org/omegat/core/search/SearchMode.java
@@ -26,7 +26,7 @@
 package org.omegat.core.search;
 
 /**
- * Search mode sfor separate search and replace.
+ * Search modes for separate search and replace.
  *
  * @author Alex Buloichik (alex73mail@gmail.com)
  */

--- a/src/main/java/org/omegat/core/search/SearchResultEntry.java
+++ b/src/main/java/org/omegat/core/search/SearchResultEntry.java
@@ -51,8 +51,8 @@ public class SearchResultEntry {
      */
     public SearchResultEntry(int num, @Nullable String preamble, @Nullable String srcPrefix, String src,
                              @Nullable String target, @Nullable String note, @Nullable String properties,
-                             SearchMatch@Nullable [] srcMatch, SearchMatch@Nullable [] targetMatch,
-                             SearchMatch@Nullable [] noteMatch, SearchMatch@Nullable [] propertiesMatch) {
+                             SearchMatch @Nullable [] srcMatch, SearchMatch @Nullable [] targetMatch,
+                             SearchMatch @Nullable [] noteMatch, SearchMatch @Nullable [] propertiesMatch) {
         entryNum = num;
         preambleText = preamble;
         this.srcPrefix = srcPrefix;
@@ -109,19 +109,19 @@ public class SearchResultEntry {
         return srcPrefix;
     }
 
-    public SearchMatch@Nullable [] getSrcMatch() {
+    public SearchMatch @Nullable [] getSrcMatch() {
         return srcMatch;
     }
 
-    public SearchMatch@Nullable [] getTargetMatch() {
+    public SearchMatch @Nullable [] getTargetMatch() {
         return targetMatch;
     }
 
-    public SearchMatch@Nullable [] getNoteMatch() {
+    public SearchMatch @Nullable [] getNoteMatch() {
         return noteMatch;
     }
 
-    public SearchMatch@Nullable [] getPropertiesMatch() {
+    public SearchMatch @Nullable [] getPropertiesMatch() {
         return propertiesMatch;
     }
 
@@ -132,10 +132,10 @@ public class SearchResultEntry {
     private final @Nullable String targetText;
     private final @Nullable String note;
     private final @Nullable String propertiesString;
-    private final SearchMatch@Nullable [] srcMatch;
-    private final SearchMatch@Nullable [] targetMatch;
-    private final SearchMatch@Nullable [] noteMatch;
-    private final SearchMatch@Nullable [] propertiesMatch;
+    private final SearchMatch @Nullable [] srcMatch;
+    private final SearchMatch @Nullable [] targetMatch;
+    private final SearchMatch @Nullable [] noteMatch;
+    private final SearchMatch @Nullable [] propertiesMatch;
 
     public static Builder builder() {
         return new Builder();
@@ -149,10 +149,10 @@ public class SearchResultEntry {
         private @Nullable String targetText;
         private @Nullable String note;
         private @Nullable String propertiesString;
-        private SearchMatch@Nullable [] srcMatch;
-        private SearchMatch@Nullable [] targetMatch;
-        private SearchMatch@Nullable [] noteMatch;
-        private SearchMatch@Nullable [] propertiesMatch;
+        private SearchMatch @Nullable [] srcMatch;
+        private SearchMatch @Nullable [] targetMatch;
+        private SearchMatch @Nullable [] noteMatch;
+        private SearchMatch @Nullable [] propertiesMatch;
 
         public Builder entryNum(int newEntryNum) {
             this.entryNum = newEntryNum;
@@ -213,8 +213,8 @@ public class SearchResultEntry {
             if (sourceText == null) {
                 throw new IllegalArgumentException("sourceText cannot be null");
             }
-            return new SearchResultEntry(entryNum, preambleText, srcPrefix, sourceText, targetText,
-                    note, propertiesString, srcMatch, targetMatch, noteMatch, propertiesMatch);
+            return new SearchResultEntry(entryNum, preambleText, srcPrefix, sourceText, targetText, note,
+                    propertiesString, srcMatch, targetMatch, noteMatch, propertiesMatch);
         }
     }
 }

--- a/src/main/java/org/omegat/core/search/SearchResultEntry.java
+++ b/src/main/java/org/omegat/core/search/SearchResultEntry.java
@@ -51,8 +51,8 @@ public class SearchResultEntry {
      */
     public SearchResultEntry(int num, @Nullable String preamble, @Nullable String srcPrefix, String src,
                              @Nullable String target, @Nullable String note, @Nullable String properties,
-                             @Nullable SearchMatch[] srcMatch, @Nullable SearchMatch[] targetMatch,
-                             @Nullable SearchMatch[] noteMatch, @Nullable SearchMatch[] propertiesMatch) {
+                             SearchMatch@Nullable [] srcMatch, SearchMatch@Nullable [] targetMatch,
+                             SearchMatch@Nullable [] noteMatch, SearchMatch@Nullable [] propertiesMatch) {
         entryNum = num;
         preambleText = preamble;
         this.srcPrefix = srcPrefix;
@@ -109,19 +109,19 @@ public class SearchResultEntry {
         return srcPrefix;
     }
 
-    public @Nullable SearchMatch[] getSrcMatch() {
+    public SearchMatch@Nullable [] getSrcMatch() {
         return srcMatch;
     }
 
-    public @Nullable SearchMatch[] getTargetMatch() {
+    public SearchMatch@Nullable [] getTargetMatch() {
         return targetMatch;
     }
 
-    public @Nullable SearchMatch[] getNoteMatch() {
+    public SearchMatch@Nullable [] getNoteMatch() {
         return noteMatch;
     }
 
-    public @Nullable SearchMatch[] getPropertiesMatch() {
+    public SearchMatch@Nullable [] getPropertiesMatch() {
         return propertiesMatch;
     }
 
@@ -132,10 +132,10 @@ public class SearchResultEntry {
     private final @Nullable String targetText;
     private final @Nullable String note;
     private final @Nullable String propertiesString;
-    private final @Nullable SearchMatch[] srcMatch;
-    private final @Nullable SearchMatch[] targetMatch;
-    private final @Nullable SearchMatch[] noteMatch;
-    private final @Nullable SearchMatch[] propertiesMatch;
+    private final SearchMatch@Nullable [] srcMatch;
+    private final SearchMatch@Nullable [] targetMatch;
+    private final SearchMatch@Nullable [] noteMatch;
+    private final SearchMatch@Nullable [] propertiesMatch;
 
     public static Builder builder() {
         return new Builder();
@@ -145,14 +145,14 @@ public class SearchResultEntry {
         private int entryNum;
         private @Nullable String preambleText;
         private @Nullable String srcPrefix;
-        private String sourceText;
+        private @Nullable String sourceText;
         private @Nullable String targetText;
         private @Nullable String note;
         private @Nullable String propertiesString;
-        private SearchMatch @Nullable [] srcMatch;
-        private SearchMatch @Nullable [] targetMatch;
-        private SearchMatch @Nullable [] noteMatch;
-        private SearchMatch @Nullable [] propertiesMatch;
+        private SearchMatch@Nullable [] srcMatch;
+        private SearchMatch@Nullable [] targetMatch;
+        private SearchMatch@Nullable [] noteMatch;
+        private SearchMatch@Nullable [] propertiesMatch;
 
         public Builder entryNum(int newEntryNum) {
             this.entryNum = newEntryNum;
@@ -210,6 +210,9 @@ public class SearchResultEntry {
         }
 
         public SearchResultEntry build() {
+            if (sourceText == null) {
+                throw new IllegalArgumentException("sourceText cannot be null");
+            }
             return new SearchResultEntry(entryNum, preambleText, srcPrefix, sourceText, targetText,
                     note, propertiesString, srcMatch, targetMatch, noteMatch, propertiesMatch);
         }

--- a/src/main/java/org/omegat/core/search/package-info.java
+++ b/src/main/java/org/omegat/core/search/package-info.java
@@ -1,11 +1,11 @@
 /**************************************************************************
  OmegaT - Computer Assisted Translation (CAT) tool
- with fuzzy matching, translation memory, keyword search,
- glossaries, and translation leveraging into updated projects.
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2026 Hiroshi Miura
- Home page: https://www.omegat.org/
- Support center: https://omegat.org/support
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
 
  This file is part of OmegaT.
 

--- a/src/main/java/org/omegat/core/search/package-info.java
+++ b/src/main/java/org/omegat/core/search/package-info.java
@@ -1,0 +1,29 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+ with fuzzy matching, translation memory, keyword search,
+ glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+ Home page: https://www.omegat.org/
+ Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+@NullMarked
+package org.omegat.core.search;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/gui/search/EntryListPane.java
+++ b/src/main/java/org/omegat/gui/search/EntryListPane.java
@@ -8,6 +8,7 @@
                2010 Alex Buloichik, Didier Briel
                2014 Piotr Kulik
                2015 Yu Tang
+               2026 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -81,13 +82,14 @@ import org.omegat.util.gui.UIThreadsUtil;
 /**
  * EntryListPane displays translation segments and, upon doubleclick of a
  * segment, instructs the main UI to jump to that segment this replaces the
- * previous huperlink interface and is much more flexible in the fonts it
+ * previous hyperlink interface and is much more flexible in the fonts it
  * displays than the HTML text
  *
  * @author Keith Godfrey
  * @author Henry Pijffers (henry.pijffers@saxnot.com)
  * @author Alex Buloichik (alex73mail@gmail.com)
  * @author Didier Briel
+ * @author Hiroshi Miura
  */
 @SuppressWarnings("serial")
 class EntryListPane extends JTextPane {
@@ -98,13 +100,13 @@ class EntryListPane extends JTextPane {
     private static final String KEY_TRANSFER_FOCUS = "transferFocus";
     private static final String KEY_TRANSFER_FOCUS_BACKWARD = "transferFocusBackward";
     private static final String KEY_JUMP_TO_ENTRY_IN_EDITOR = "jumpToEntryInEditor";
-    private static final int ENTRY_LIST_INDEX_NO_ENTRIES  = -1;
+    private static final int ENTRY_LIST_INDEX_NO_ENTRIES = -1;
     private static final int ENTRY_LIST_INDEX_END_OF_TEXT = -2;
 
     private static void bindKeyStrokesFromMainMenuShortcuts(InputMap map) {
         // Add KeyStrokes Ctrl+N/P (Cmd+N/P for MacOS) to the map
-        PropertiesShortcuts.getMainMenuShortcuts().bindKeyStrokes(map,
-                KEY_GO_TO_NEXT_SEGMENT, KEY_GO_TO_PREVIOUS_SEGMENT, KEY_JUMP_TO_ENTRY_IN_EDITOR);
+        PropertiesShortcuts.getMainMenuShortcuts().bindKeyStrokes(map, KEY_GO_TO_NEXT_SEGMENT,
+                KEY_GO_TO_PREVIOUS_SEGMENT, KEY_JUMP_TO_ENTRY_IN_EDITOR);
     }
 
     private static InputMap createDefaultInputMap(InputMap parent) {
@@ -114,8 +116,8 @@ class EntryListPane extends JTextPane {
 
         // Add KeyStrokes: Enter, Ctrl+Enter (Cmd+Enter for MacOS)
         map.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), KEY_GO_TO_NEXT_SEGMENT);
-        map.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER,
-                Java8Compat.getMenuShortcutKeyMaskEx()), KEY_GO_TO_PREVIOUS_SEGMENT);
+        map.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, Java8Compat.getMenuShortcutKeyMaskEx()),
+                KEY_GO_TO_PREVIOUS_SEGMENT);
         return map;
     }
 
@@ -126,14 +128,12 @@ class EntryListPane extends JTextPane {
 
         // Add KeyStrokes: Tab, Shift+Tab, Ctrl+Tab, Ctrl+Shift+Tab
         // (Cmd+Tab is used by the system on OS X)
-        map.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0),
-                KEY_GO_TO_NEXT_SEGMENT);
+        map.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, 0), KEY_GO_TO_NEXT_SEGMENT);
         map.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.SHIFT_DOWN_MASK),
                 KEY_GO_TO_PREVIOUS_SEGMENT);
-        map.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK),
-                KEY_TRANSFER_FOCUS);
-        map.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK),
-                KEY_TRANSFER_FOCUS_BACKWARD);
+        map.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK), KEY_TRANSFER_FOCUS);
+        map.put(KeyStroke.getKeyStroke(KeyEvent.VK_TAB,
+                InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK), KEY_TRANSFER_FOCUS_BACKWARD);
         // Enter to jump to selected segment in editor
         map.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), KEY_JUMP_TO_ENTRY_IN_EDITOR);
         return map;
@@ -198,7 +198,7 @@ class EntryListPane extends JTextPane {
         setFocusTraversalKeysEnabled(!useTabForAdvance);
         InputMap parent = getInputMap().getParent();
         InputMap newMap = useTabForAdvance ? createDefaultInputMapUseTab(parent)
-                                           : createDefaultInputMap(parent);
+                : createDefaultInputMap(parent);
         setInputMap(WHEN_FOCUSED, newMap);
     }
 
@@ -210,7 +210,7 @@ class EntryListPane extends JTextPane {
     }
 
     /**
-     * Show search result for user
+     * Show search result for user.
      */
     public void displaySearchResult(Searcher searcher, int numberOfResults) {
         UIThreadsUtil.mustBeSwingThread();
@@ -261,6 +261,11 @@ class EntryListPane extends JTextPane {
         return ENTRY_LIST_INDEX_END_OF_TEXT;
     }
 
+    /**
+     * The DisplayMatches class is responsible for displaying and formatting search results
+     * within a text-based user interface. It processes a list of search result entries,
+     * formats them, and associates match information for later use in highlighting and navigation.
+     */
     protected class DisplayMatches {
         private final List<SearchMatch> matches = new ArrayList<SearchMatch>();
         private final List<SearchMatch> replMatches = new ArrayList<SearchMatch>();
@@ -276,14 +281,14 @@ class EntryListPane extends JTextPane {
             }
 
             if (entries.size() >= numberOfResults) {
-                addMessage(stringBuf, StringUtil.format(OStrings.getString("SW_MAX_FINDS_REACHED"),
-                        numberOfResults));
+                addMessage(stringBuf,
+                        StringUtil.format(OStrings.getString("SW_MAX_FINDS_REACHED"), numberOfResults));
             }
 
             for (SearchResultEntry e : entries) {
                 addEntry(stringBuf, e.getEntryNum(), e.getPreamble(), e.getSrcPrefix(), e.getSrcText(),
-                        e.getTranslation(), e.getNote(), e.getProperties(), e.getSrcMatch(), e.getTargetMatch(), e.getNoteMatch(),
-                        e.getPropertiesMatch(), isReplace);
+                        e.getTranslation(), e.getNote(), e.getProperties(), e.getSrcMatch(),
+                        e.getTargetMatch(), e.getNoteMatch(), e.getPropertiesMatch(), isReplace);
             }
 
             Document doc = getDocument();
@@ -299,11 +304,38 @@ class EntryListPane extends JTextPane {
             }
         }
 
+        /**
+         * Construct and append content of a result entry produced by the
+         * Search.
+         *
+         * @param stringBuf
+         *            StringBuffer object to output the result.
+         * @param num
+         *            Entry number of the segment.
+         * @param preamble
+         *            where this entry comes from
+         * @param srcPrefix
+         * @param src
+         *            source text of the segment.
+         * @param loc
+         *            localized text of the segment.
+         * @param note
+         *            note text entry of the segment properties.
+         * @param properties
+         *            properties of the segment.
+         * @param srcMatches
+         * @param targetMatches
+         * @param noteMatches
+         * @param propertiesMatches
+         * @param isReplace
+         *            A flag that the entry for replace operation.
+         */
         // add entry text - remember what its number is and where it ends
-        public void addEntry(StringBuilder stringBuf, int num, @Nullable String preamble, @Nullable String srcPrefix,
-                @Nullable String src, @Nullable String loc, @Nullable String note, @Nullable String properties,
-                SearchMatch@Nullable[] srcMatches, SearchMatch@Nullable[] targetMatches,
-                SearchMatch@Nullable[] noteMatches, SearchMatch@Nullable[] propertiesMatches, boolean isReplace) {
+        public void addEntry(StringBuilder stringBuf, int num, @Nullable String preamble,
+                @Nullable String srcPrefix, @Nullable String src, @Nullable String loc, @Nullable String note,
+                @Nullable String properties, SearchMatch @Nullable [] srcMatches,
+                SearchMatch @Nullable [] targetMatches, SearchMatch @Nullable [] noteMatches,
+                SearchMatch @Nullable [] propertiesMatches, boolean isReplace) {
             if (!stringBuf.isEmpty()) {
                 stringBuf.append(ENTRY_SEPARATOR);
             }
@@ -328,7 +360,8 @@ class EntryListPane extends JTextPane {
                 String repl = null;
                 int shift = 0;
                 if (targetMatches != null && targetMatches.length > 0) {
-                    // Save first match position to select it in Editor pane later
+                    // Save first match position to select it in Editor pane
+                    // later
                     if (num > 0) {
                         SearchMatch m = targetMatches[0];
                         firstMatchList.put(num, new CaretPosition(m.getStart(), m.getEnd()));
@@ -345,7 +378,8 @@ class EntryListPane extends JTextPane {
                             repl = repl.substring(0, m.getStart() - shift) + m.getReplacement()
                                     + repl.substring(m.getEnd() - shift);
                             int start = m.getStart() + stringBuf.length() - shift;
-                            start += loc.length() + 4; // (loc + "\n-> ").length()
+                            start += loc.length() + 4; // (loc + "\n->
+                                                       // ").length()
                             replMatches.add(new SearchMatch(start, start + m.getReplacement().length()));
                             shift += m.getEnd() - m.getStart() - m.getReplacement().length();
                         }
@@ -389,6 +423,9 @@ class EntryListPane extends JTextPane {
             offsetList.add(stringBuf.length());
         }
 
+        /**
+         * Marks search matches in the entry list.
+         */
         public void doMarks() {
             UIThreadsUtil.mustBeSwingThread();
 
@@ -409,7 +446,8 @@ class EntryListPane extends JTextPane {
                 doc.setCharacterAttributes(m.getStart(), m.getLength(), foundMark, true);
             }
             matchesToMark.clear();
-            List<SearchMatch> replToMark = replMatches.subList(0, Math.min(MARKS_PER_REQUEST, replMatches.size()));
+            List<SearchMatch> replToMark = replMatches.subList(0,
+                    Math.min(MARKS_PER_REQUEST, replMatches.size()));
             for (SearchMatch m : replToMark) {
                 doc.setCharacterAttributes(m.getStart(), m.getLength(), replaceMark, true);
             }
@@ -437,6 +475,9 @@ class EntryListPane extends JTextPane {
         stringBuf.append(message);
     }
 
+    /**
+     * Resets the entry list pane.
+     */
     public void reset() {
         this.numberOfResults = 0;
         currentlyDisplayedMatches = null;
@@ -446,14 +487,29 @@ class EntryListPane extends JTextPane {
         setText("");
     }
 
+    /**
+     * Returns the number of entries in the entry list.
+     *
+     * @return The number of entries.
+     */
     public int getNrEntries() {
         return entryList.size();
     }
 
+    /**
+     * Returns the list of entries in the entry list.
+     *
+     * @return The list of entries.
+     */
     public List<Integer> getEntryList() {
         return entryList;
     }
 
+    /**
+     * Returns the searcher associated with the entry list.
+     *
+     * @return The searcher object corresponding to the entry list.
+     */
     public Searcher getSearcher() {
         Searcher result = searcher;
         if (result == null) {
@@ -464,9 +520,9 @@ class EntryListPane extends JTextPane {
 
     /**
      * Move the active (highlighted) search result one entry forward, wrapping
-     * around to the first result after the last one, and show it in the
-     * editor regardless of the auto-sync option. Used by the Find Next button
-     * and its shortcut (feature requests #1125 and #1380).
+     * around to the first result after the last one, and show it in the editor
+     * regardless of the auto-sync option. Used by the Find Next button and its
+     * shortcut (feature requests #1125 and #1380).
      *
      * @return true when the navigation wrapped around the end of the results
      */
@@ -557,13 +613,13 @@ class EntryListPane extends JTextPane {
         int activeEntryListIndex = getActiveEntryListIndex();
 
         switch (activeEntryListIndex) {
-            case ENTRY_LIST_INDEX_NO_ENTRIES:
-                return new EmptyDisplayedEntry();
-            case ENTRY_LIST_INDEX_END_OF_TEXT:
-                // end of text (out of entries range)
-                return new DisplayedEntryImpl(getNrEntries());
-            default:
-                return new DisplayedEntryImpl(activeEntryListIndex);
+        case ENTRY_LIST_INDEX_NO_ENTRIES:
+            return new EmptyDisplayedEntry();
+        case ENTRY_LIST_INDEX_END_OF_TEXT:
+            // end of text (out of entries range)
+            return new DisplayedEntryImpl(getNrEntries());
+        default:
+            return new DisplayedEntryImpl(activeEntryListIndex);
         }
     }
 
@@ -693,8 +749,8 @@ class EntryListPane extends JTextPane {
         private final AttributeSet attrActive;
 
         private int entryListIndex = -1;
-        private int offset         = -1;
-        private int length         = -1;
+        private int offset = -1;
+        private int length = -1;
 
         SegmentHighlighter() {
             MutableAttributeSet attrNormal = new SimpleAttributeSet();
@@ -713,7 +769,8 @@ class EntryListPane extends JTextPane {
         public void run() {
             int activeEntryListIndex = getActiveEntryListIndex();
             if (activeEntryListIndex == ENTRY_LIST_INDEX_END_OF_TEXT) {
-                // end of text (out of entries range) should belongs to the last segment
+                // end of text (out of entries range) should belongs to the last
+                // segment
                 activeEntryListIndex = getNrEntries() - 1;
             }
 
@@ -745,7 +802,10 @@ class EntryListPane extends JTextPane {
 
             int offset = entryListIndex == 0 ? 0
                     : offsetList.get(entryListIndex - 1) + ENTRY_SEPARATOR.length();
-            int length = offsetList.get(entryListIndex) - offset - 1; // except tail line break
+            int length = offsetList.get(entryListIndex) - offset - 1; // except
+                                                                      // tail
+                                                                      // line
+                                                                      // break
 
             getStyledDocument().setCharacterAttributes(offset, length, attrActive, false);
 

--- a/src/main/java/org/omegat/gui/search/EntryListPane.java
+++ b/src/main/java/org/omegat/gui/search/EntryListPane.java
@@ -58,6 +58,7 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.search.SearchMatch;
@@ -223,7 +224,7 @@ class EntryListPane extends JTextPane {
         offsetList.clear();
         firstMatchList.clear();
 
-        if (searcher == null || searcher.getSearchResults() == null) {
+        if (searcher.getSearchResults().isEmpty()) {
             // empty marks - just reset
             setText("");
             return;
@@ -299,16 +300,17 @@ class EntryListPane extends JTextPane {
         }
 
         // add entry text - remember what its number is and where it ends
-        public void addEntry(StringBuilder stringBuf, int num, String preamble, String srcPrefix,
-                String src, String loc, String note, String properties, SearchMatch[] srcMatches,
-                SearchMatch[] targetMatches, SearchMatch[] noteMatches, SearchMatch[] propertiesMatches, boolean isReplace) {
-            if (stringBuf.length() > 0) {
+        public void addEntry(StringBuilder stringBuf, int num, @Nullable String preamble, @Nullable String srcPrefix,
+                @Nullable String src, @Nullable String loc, @Nullable String note, @Nullable String properties,
+                SearchMatch@Nullable[] srcMatches, SearchMatch@Nullable[] targetMatches,
+                SearchMatch@Nullable[] noteMatches, SearchMatch@Nullable[] propertiesMatches, boolean isReplace) {
+            if (!stringBuf.isEmpty()) {
                 stringBuf.append(ENTRY_SEPARATOR);
             }
-            if (preamble != null && !preamble.equals("")) {
+            if (!StringUtil.isEmpty(preamble)) {
                 stringBuf.append(preamble).append("\n");
             }
-            if (src != null && !src.equals("")) {
+            if (!StringUtil.isEmpty(src)) {
                 stringBuf.append("-- ");
                 if (srcPrefix != null) {
                     stringBuf.append(srcPrefix);
@@ -322,7 +324,7 @@ class EntryListPane extends JTextPane {
                 stringBuf.append(src);
                 stringBuf.append('\n');
             }
-            if (loc != null && !loc.equals("")) {
+            if (!StringUtil.isEmpty(loc)) {
                 String repl = null;
                 int shift = 0;
                 if (targetMatches != null && targetMatches.length > 0) {
@@ -359,7 +361,7 @@ class EntryListPane extends JTextPane {
                 }
             }
 
-            if (note != null && !note.equals("")) {
+            if (!StringUtil.isEmpty(note)) {
                 stringBuf.append("= ");
                 if (noteMatches != null) {
                     for (SearchMatch m : noteMatches) {
@@ -371,7 +373,7 @@ class EntryListPane extends JTextPane {
                 stringBuf.append('\n');
             }
 
-            if (properties != null && !properties.equals("")) {
+            if (!StringUtil.isEmpty(properties)) {
                 stringBuf.append("# ");
                 if (propertiesMatches != null) {
                     for (SearchMatch m : propertiesMatches) {
@@ -428,7 +430,7 @@ class EntryListPane extends JTextPane {
      */
     private void addMessage(StringBuilder stringBuf, String message) {
         // Insert entry/message separator if necessary
-        if (stringBuf.length() > 0) {
+        if (!stringBuf.isEmpty()) {
             stringBuf.append(ENTRY_SEPARATOR);
         }
         // Insert the message text
@@ -436,7 +438,12 @@ class EntryListPane extends JTextPane {
     }
 
     public void reset() {
-        displaySearchResult(null, 0);
+        this.numberOfResults = 0;
+        currentlyDisplayedMatches = null;
+        entryList.clear();
+        offsetList.clear();
+        firstMatchList.clear();
+        setText("");
     }
 
     public int getNrEntries() {
@@ -448,7 +455,11 @@ class EntryListPane extends JTextPane {
     }
 
     public Searcher getSearcher() {
-        return searcher;
+        Searcher result = searcher;
+        if (result == null) {
+            throw new IllegalStateException("Searcher has not been initialized");
+        }
+        return result;
     }
 
     /**
@@ -744,11 +755,11 @@ class EntryListPane extends JTextPane {
         }
     }
 
-    private volatile Searcher searcher;
+    private volatile @Nullable Searcher searcher;
     private final List<Integer> entryList = new ArrayList<>();
     private final List<Integer> offsetList = new ArrayList<>();
     private final Map<Integer, CaretPosition> firstMatchList = new HashMap<>();
-    private DisplayMatches currentlyDisplayedMatches;
+    private @Nullable DisplayMatches currentlyDisplayedMatches;
     private int numberOfResults;
     private boolean useTabForAdvance;
     private boolean autoSyncWithEditor;

--- a/src/main/java/org/omegat/gui/search/SearchWindowController.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowController.java
@@ -52,9 +52,11 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.swing.AbstractAction;
+import javax.swing.ButtonModel;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.InputMap;
 import javax.swing.JComponent;
@@ -71,6 +73,7 @@ import javax.swing.text.BadLocationException;
 import javax.swing.undo.UndoManager;
 
 import org.jetbrains.annotations.VisibleForTesting;
+import org.jspecify.annotations.Nullable;
 import org.omegat.gui.editor.IEditor;
 import org.openide.awt.Mnemonics;
 
@@ -122,7 +125,9 @@ public class SearchWindowController {
     private final int initialEntry;
     private final CaretPosition initialCaret;
 
-    private LongProcessHandle<Void> handle;
+    private @Nullable LongProcessHandle<Void> handle;
+
+    private final Map<ButtonModel, SearchExpression.SearchExpressionType> modelToType;
 
     public SearchWindowController(SearchMode mode) {
         form = new SearchWindowForm();
@@ -208,6 +213,11 @@ public class SearchWindowController {
         default:
             throw new IllegalArgumentException("Unknown mode: " + mode);
         }
+        modelToType = Map.of(
+                form.m_searchExactSearchRB.getModel(),   SearchExpression.SearchExpressionType.EXACT,
+                form.m_searchKeywordSearchRB.getModel(), SearchExpression.SearchExpressionType.KEYWORD,
+                form.m_searchRegexpSearchRB.getModel(),  SearchExpression.SearchExpressionType.REGEXP
+        );
         setComponentNames();
         CoreEvents.registerFontChangedEventListener(this::setFont);
     }
@@ -807,7 +817,7 @@ public class SearchWindowController {
     /**
      * Show search result for user
      */
-    public void displaySearchResult(final Searcher searcher) {
+    public void displaySearchResult(Searcher searcher) {
         UIThreadsUtil.executeInSwingThread(() -> {
             EntryListPane viewer = (EntryListPane) form.m_viewer;
             viewer.displaySearchResult(searcher, ((Integer) form.m_numberOfResults.getValue()));
@@ -969,7 +979,7 @@ public class SearchWindowController {
 
     void doCancel() {
         UIThreadsUtil.mustBeSwingThread();
-        handle.cancel();
+        cancelHandlerIfRunning();
         form.dispose();
     }
 
@@ -977,7 +987,11 @@ public class SearchWindowController {
      * Completes the asynchronous operation associated with the search process.
      */
     @VisibleForTesting
+    @SuppressWarnings("unused")
     void complete() {
+        if (handle == null) {
+            throw new IllegalStateException("Searcher has not been initialized");
+        }
         handle.completion().whenComplete((result, error) -> {
             if (error != null) {
                 Log.logErrorRB(error, "ST_SEARCH_COMPLETE_ERROR");
@@ -988,10 +1002,14 @@ public class SearchWindowController {
     }
 
     public void dispose() {
+        cancelHandlerIfRunning();
+        form.dispose();
+    }
+
+    private void cancelHandlerIfRunning() {
         if (handle != null && !handle.completion().isDone()) {
             handle.cancel();
         }
-        form.dispose();
     }
 
     /**
@@ -1048,26 +1066,19 @@ public class SearchWindowController {
     }
 
     private SearchExpression.SearchExpressionType getSearchExpressionTypeForSearchMode() {
-        if (form.m_searchExactSearchRB.isSelected()) {
-            return SearchExpression.SearchExpressionType.EXACT;
+        SearchExpression.SearchExpressionType searchExpressionType = modelToType.get(form.m_searchExactSearchRB.getModel());
+        if (searchExpressionType == null) {
+            throw new IllegalStateException("None of radio button is selected.");
         }
-        if (form.m_searchKeywordSearchRB.isSelected()) {
-            return SearchExpression.SearchExpressionType.KEYWORD;
-        }
-        if (form.m_searchRegexpSearchRB.isSelected()) {
-            return SearchExpression.SearchExpressionType.REGEXP;
-        }
-        return null;
+        return searchExpressionType;
     }
 
     private SearchExpression.SearchExpressionType getSearchExpressionTypeForReplaceMode() {
-        if (form.m_replaceExactSearchRB.isSelected()) {
-            return SearchExpression.SearchExpressionType.EXACT;
+        SearchExpression.SearchExpressionType searchExpressionType = modelToType.get(form.m_searchExactSearchRB.getModel());
+        if (searchExpressionType == null || searchExpressionType == SearchExpression.SearchExpressionType.KEYWORD) {
+            throw new IllegalStateException("The radio button selection is not consistent.");
         }
-        if (form.m_replaceRegexpSearchRB.isSelected()) {
-            return SearchExpression.SearchExpressionType.REGEXP;
-        }
-        return null;
+        return searchExpressionType;
     }
 
     private void applySearchState(SearchExpression expression) {
@@ -1331,7 +1342,7 @@ public class SearchWindowController {
      * @param params
      *            error text parameters
      */
-    public void displayErrorRB(final Throwable ex, final String errorKey, final Object... params) {
+    public void displayErrorRB(Throwable ex, String errorKey, Object@Nullable... params) {
         UIThreadsUtil.executeInSwingThread(() -> {
             String msg;
             if (params != null) {
@@ -1339,11 +1350,7 @@ public class SearchWindowController {
             } else {
                 msg = OStrings.getString(errorKey);
             }
-
-            String fulltext = msg;
-            if (ex != null) {
-                fulltext += "\n" + ex.getLocalizedMessage();
-            }
+            String fulltext = msg + "\n" + ex.getLocalizedMessage();
             JOptionPane.showMessageDialog(form, fulltext, OStrings.getString("TF_ERROR"),
                     JOptionPane.ERROR_MESSAGE);
         });

--- a/src/main/java/org/omegat/gui/search/SearchWindowController.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowController.java
@@ -5,12 +5,13 @@
 
  Copyright (C) 2000-2006 Keith Godfrey and Maxym Mykhalchuk
                2006 Henry Pijffers
-               2009 Didier Briel
-               2010 Martin Fleurke, Antonio Vilei, Didier Briel
-               2012 Didier Briel
-               2013 Aaron Madlon-Kay, Alex Buloichik
-               2014 Aaron Madlon-Kay, Piotr Kulik
-               2015 Yu Tang, Aaron Madlon-Kay, Hiroshi Miura
+               2009-2012 Didier Briel
+               2010 Martin Fleurke, Antonio Vilei
+               2013 Alex Buloichik
+               2013-2015 Aaron Madlon-Kay,
+               2014 Piotr Kulik
+               2015 Yu Tang
+               2015,2026 Hiroshi Miura
                2017-2018 Thomas Cordonnier
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
@@ -102,8 +103,8 @@ import org.omegat.util.gui.StaticUIUtils;
 import org.omegat.util.gui.UIThreadsUtil;
 
 /**
- * This is a window that appears when a user wants to search for something.
- * For each new user's request a new window is created. Actual search is done by
+ * This is a window that appears when a user wants to search for something. For
+ * each new user's request a new window is created. Actual search is done by
  * SearchThread.
  *
  * @author Keith Godfrey
@@ -213,20 +214,19 @@ public class SearchWindowController {
         default:
             throw new IllegalArgumentException("Unknown mode: " + mode);
         }
-        modelToType = Map.of(
-                form.m_searchExactSearchRB.getModel(),   SearchExpression.SearchExpressionType.EXACT,
-                form.m_searchKeywordSearchRB.getModel(), SearchExpression.SearchExpressionType.KEYWORD,
-                form.m_searchRegexpSearchRB.getModel(),  SearchExpression.SearchExpressionType.REGEXP
-        );
+        modelToType = Map.of(form.m_searchExactSearchRB.getModel(),
+                SearchExpression.SearchExpressionType.EXACT, form.m_searchKeywordSearchRB.getModel(),
+                SearchExpression.SearchExpressionType.KEYWORD, form.m_searchRegexpSearchRB.getModel(),
+                SearchExpression.SearchExpressionType.REGEXP);
         setComponentNames();
         CoreEvents.registerFontChangedEventListener(this::setFont);
     }
 
     /**
-     * Update the results label after walking through the results with the
-     * Find Previous and Find Next buttons: while the navigation has just
-     * wrapped around the end of the results, a short note is appended to the
-     * number of results, and it disappears with the next step.
+     * Update the results' label after walking through the results with the Find
+     * Previous and Find Next buttons: while the navigation has just wrapped
+     * around the end of the results, a short note is appended to the number of
+     * results, and it disappears with the next step.
      *
      * @param wrapped
      *            whether the last navigation step wrapped around
@@ -241,10 +241,10 @@ public class SearchWindowController {
     }
 
     /**
-     * Let F3 and Shift+F3 walk through the search results from anywhere in
-     * the Search window, mirroring the Find Next and Find Previous buttons
-     * (feature requests #1125 and #1380). The keys go through the buttons so
-     * that they stay inactive while there are no results.
+     * Let F3 and Shift+F3 walk through the search results from anywhere in the
+     * Search window, mirroring the Find Next and Find Previous buttons (feature
+     * requests #1125 and #1380). The keys go through the buttons so that they
+     * stay inactive while there are no results.
      */
     private void bindResultNavigationKeys() {
         InputMap inputMap = form.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
@@ -311,10 +311,10 @@ public class SearchWindowController {
         form.m_searchButton.addActionListener(e -> doSearch());
 
         if (mode == SearchMode.SEARCH) {
-            form.m_findPreviousButton.addActionListener(e -> showResultNavigationStatus(
-                    ((EntryListPane) form.m_viewer).selectPreviousEntry()));
-            form.m_findNextButton.addActionListener(e -> showResultNavigationStatus(
-                    ((EntryListPane) form.m_viewer).selectNextEntry()));
+            form.m_findPreviousButton.addActionListener(
+                    e -> showResultNavigationStatus(((EntryListPane) form.m_viewer).selectPreviousEntry()));
+            form.m_findNextButton.addActionListener(
+                    e -> showResultNavigationStatus(((EntryListPane) form.m_viewer).selectNextEntry()));
             bindResultNavigationKeys();
         }
 
@@ -977,6 +977,9 @@ public class SearchWindowController {
         handle = Core.getLongProcessExecutor().submit(task::run);
     }
 
+    /**
+     * Cancels the asynchronous operation associated with the search process.
+     */
     void doCancel() {
         UIThreadsUtil.mustBeSwingThread();
         cancelHandlerIfRunning();
@@ -995,7 +998,8 @@ public class SearchWindowController {
         handle.completion().whenComplete((result, error) -> {
             if (error != null) {
                 Log.logErrorRB(error, "ST_SEARCH_COMPLETE_ERROR");
-                Objects.requireNonNull(Core.getMainWindow()).displayErrorRB(error, "ST_SEARCH_COMPLETE_ERROR");
+                Objects.requireNonNull(Core.getMainWindow()).displayErrorRB(error,
+                        "ST_SEARCH_COMPLETE_ERROR");
             }
             form.dispose();
         });
@@ -1066,7 +1070,8 @@ public class SearchWindowController {
     }
 
     private SearchExpression.SearchExpressionType getSearchExpressionTypeForSearchMode() {
-        SearchExpression.SearchExpressionType searchExpressionType = modelToType.get(form.m_searchExactSearchRB.getModel());
+        SearchExpression.SearchExpressionType searchExpressionType = modelToType
+                .get(form.m_searchExactSearchRB.getModel());
         if (searchExpressionType == null) {
             throw new IllegalStateException("None of radio button is selected.");
         }
@@ -1074,8 +1079,10 @@ public class SearchWindowController {
     }
 
     private SearchExpression.SearchExpressionType getSearchExpressionTypeForReplaceMode() {
-        SearchExpression.SearchExpressionType searchExpressionType = modelToType.get(form.m_searchExactSearchRB.getModel());
-        if (searchExpressionType == null || searchExpressionType == SearchExpression.SearchExpressionType.KEYWORD) {
+        SearchExpression.SearchExpressionType searchExpressionType = modelToType
+                .get(form.m_searchExactSearchRB.getModel());
+        if (searchExpressionType == null
+                || searchExpressionType == SearchExpression.SearchExpressionType.KEYWORD) {
             throw new IllegalStateException("The radio button selection is not consistent.");
         }
         return searchExpressionType;
@@ -1260,7 +1267,8 @@ public class SearchWindowController {
 
         // author options
         form.m_authorCB.setSelected(Preferences.isPreference(Preferences.SEARCHWINDOW_SEARCH_AUTHOR));
-        form.m_authorField.setText(Preferences.getPreferenceDefault(Preferences.SEARCHWINDOW_AUTHOR_NAME, ""));
+        form.m_authorField
+                .setText(Preferences.getPreferenceDefault(Preferences.SEARCHWINDOW_AUTHOR_NAME, ""));
 
         // date options
         try {
@@ -1307,15 +1315,15 @@ public class SearchWindowController {
         form.m_dateToButton.setEnabled(form.m_dateToCB.isSelected());
     }
 
-
     /**
-     * Recursively sets the enabled state of a container and all its child components.
+     * Recursively sets the enabled state of a container and all its child
+     * components.
      *
      * @param component
-     *        The container whose enabled state is to be updated.
+     *            The container whose enabled state is to be updated.
      * @param enabled
-     *        The desired enabled state. If true, the container and its components
-     *        will be enabled; if false, they will be disabled.
+     *            The desired enabled state. If true, the container and its
+     *            components will be enabled; if false, they will be disabled.
      */
     private void setEnabled(Container component, boolean enabled) {
         component.setEnabled(enabled);
@@ -1342,7 +1350,7 @@ public class SearchWindowController {
      * @param params
      *            error text parameters
      */
-    public void displayErrorRB(Throwable ex, String errorKey, Object@Nullable... params) {
+    public void displayErrorRB(Throwable ex, String errorKey, Object @Nullable... params) {
         UIThreadsUtil.executeInSwingThread(() -> {
             String msg;
             if (params != null) {

--- a/src/main/java/org/omegat/gui/search/package-info.java
+++ b/src/main/java/org/omegat/gui/search/package-info.java
@@ -1,11 +1,11 @@
 /**************************************************************************
  OmegaT - Computer Assisted Translation (CAT) tool
- with fuzzy matching, translation memory, keyword search,
- glossaries, and translation leveraging into updated projects.
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2026 Hiroshi Miura
- Home page: https://www.omegat.org/
- Support center: https://omegat.org/support
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
 
  This file is part of OmegaT.
 

--- a/src/main/java/org/omegat/gui/search/package-info.java
+++ b/src/main/java/org/omegat/gui/search/package-info.java
@@ -1,0 +1,29 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+ with fuzzy matching, translation memory, keyword search,
+ glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+ Home page: https://www.omegat.org/
+ Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+@NullMarked
+package org.omegat.gui.search;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Fix the NPE bug when closing search window without search/replace action and also enhance null check relevant codes.

## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]

## Which ticket is resolved?

- NPE when closing a search window without any search/replace action
- https://sourceforge.net/p/omegat/bugs/1327/

## What does this PR change?

- Add @Nullable/@NullMarked annotations in o.o.core.search and o.o.gui.search packages

- SearchWindowController class
    - Change nullity of the handler in the SearchWindowController when complete method called.
    - Introduce cancelHandlerIfRunning method which is used in doCancel and dispose methods.
    - Improve seach type detection with a map of radio buttons to enum
- EntryListPane class
    - add @Nullable to addEntry method arguments
    - refactor an empty check with StringUtil.isEmpty
    - Update reset to make searcher field non-nullable
    - Update getSearcher method to check searcher nullity and throw IllegalStateException when undesignated null status
- SearchExpression and SearchResultEntry classes
    - fix the Nullable annotation of the array of fields consistency.

## Other information

