### PR TITLE
[6.1] fix: NPE on Search window closing without action

### DIFF
--- a/src/org/omegat/gui/search/EntryListPane.java
+++ b/src/org/omegat/gui/search/EntryListPane.java
@@ -432,7 +432,12 @@ class EntryListPane extends JTextPane {
     }
 
     public void reset() {
-        displaySearchResult(null, 0);
+        this.numberOfResults = 0;
+        currentlyDisplayedMatches = null;
+        entryList.clear();
+        offsetList.clear();
+        firstMatchList.clear();
+        setText("");
     }
 
     public int getNrEntries() {

--- a/src/org/omegat/gui/search/SearchWindowController.java
+++ b/src/org/omegat/gui/search/SearchWindowController.java
@@ -908,7 +908,7 @@ public class SearchWindowController {
 
     void doCancel() {
         UIThreadsUtil.mustBeSwingThread();
-        handle.cancel();
+        cancelHandlerIfRunning();
         form.dispose();
     }
 
@@ -927,10 +927,14 @@ public class SearchWindowController {
     }
 
     public void dispose() {
+        cancelHandlerIfRunning();
+        form.dispose();
+    }
+
+    private void cancelHandlerIfRunning() {
         if (handle != null && !handle.completion().isDone()) {
             handle.cancel();
         }
-        form.dispose();
     }
 
     /**


### PR DESCRIPTION


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Bug fix -> [bug]


## Which ticket is resolved?

- NPE when closing a search window without any search/replace action
- https://sourceforge.net/p/omegat/bugs/1327/

## What does this PR change?

- Check handle nullity both SearchWindowController#doCancela and SearchWindowController#dispose 


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
