### PR TITLE
[6.1] chore(build): set project `group` property and add developer changelog

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
@@ -178,9 +178,9 @@ manualLangsProvider.get().each { lang ->
 
     // Create a new publication for this language
     def publication = publishing.publications.create("manual${lang.capitalize()}", MavenPublication) {
-        groupId = 'org.omegat'
+        groupId = project.property('org.omegat.groupId')
         artifactId = "omegat-manual-${lang}"
-        version = '6.1.0'
+        version = project.ext.omtVersion.mavenStyleVersion
 
         // Add the jar task to the publication
         artifact(zipTask)

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ tasks.withType(Wrapper.class).configureEach {
     gradleVersion = "9.3.1" // set the same version as in gradle/wrapper/gradle-wrapper.properties
 }
 
+group = project.property('org.omegat.groupId')
 version = omtVersion.version
 
 // Definition of bundled JRE file names

--- a/src_docs/developer/changes/6.1.1.md
+++ b/src_docs/developer/changes/6.1.1.md
@@ -1,0 +1,15 @@
+# OmegaT 6.1.1
+
+## Build / Tooling
+
+- Fix `initializeSonatypeStagingRepository` failure ("Failed to find staging
+  profile for package group: ") by setting the root project's `group`, which
+  was never assigned even though `mavenJava` publication set `groupId`
+  explicitly. `nexusPublishing.packageGroup` derives from `project.group` by
+  default, so it resolved to an empty string.-
+- Fix hardcoded `groupId` and `version` (`'org.omegat'` / `'6.1.0'`) in the
+  per-language manual `MavenPublication` definitions
+  (`org.omegat.document-conventions.gradle`), which would otherwise continue
+  publishing stale Maven coordinates after future releases. Now derived from
+  `org.omegat.groupId` and `omtVersion.mavenStyleVersion`, matching the
+  `mavenJava` publication. 

--- a/src_docs/developer/changes/index.md
+++ b/src_docs/developer/changes/index.md
@@ -1,0 +1,12 @@
+# Developer Changelog
+
+Technical changes for contributors and plugin developers: build system,
+dependencies, internal refactors, and API/SPI changes. For user-facing
+release notes, see `changes.txt`.
+
+```{toctree}
+:maxdepth: 1
+:glob:
+
+*
+```

--- a/src_docs/developer/index.md
+++ b/src_docs/developer/index.md
@@ -79,6 +79,7 @@
 ## Architecture Designs 
 
 * [Architecture Decisional Records](adr/index.md)
+* [Changelog](changes/index.md)
 
 ## Other information
 


### PR DESCRIPTION

## Pull request type
- Build and release changes -> [build/release]

## Which ticket is resolved?
none
## What does this PR change?

- Fix `initializeSonatypeStagingRepository` failure by assigning `project.group` for proper `nexusPublishing.packageGroup` resolution.
- Also set manual publications from proprty
- Add developer changelog documentation under `src_docs/developer/changes/`.


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
