### PR TITLE
fix(search): read selected radio button again when detecting the search type

### DIFF
--- a/src/main/java/org/omegat/gui/search/SearchWindowController.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowController.java
@@ -217,6 +217,8 @@ public class SearchWindowController {
         modelToType = Map.of(form.m_searchExactSearchRB.getModel(),
                 SearchExpression.SearchExpressionType.EXACT, form.m_searchKeywordSearchRB.getModel(),
                 SearchExpression.SearchExpressionType.KEYWORD, form.m_searchRegexpSearchRB.getModel(),
+                SearchExpression.SearchExpressionType.REGEXP, form.m_replaceExactSearchRB.getModel(),
+                SearchExpression.SearchExpressionType.EXACT, form.m_replaceRegexpSearchRB.getModel(),
                 SearchExpression.SearchExpressionType.REGEXP);
         setComponentNames();
         CoreEvents.registerFontChangedEventListener(this::setFont);
@@ -1096,18 +1098,20 @@ public class SearchWindowController {
         expression.replacement = form.m_replaceField.getEditor().getItem().toString();
     }
 
-    private SearchExpression.SearchExpressionType getSearchExpressionTypeForSearchMode() {
-        SearchExpression.SearchExpressionType searchExpressionType = modelToType
-                .get(form.m_searchExactSearchRB.getModel());
-        if (searchExpressionType == null) {
+    @VisibleForTesting
+    SearchExpression.SearchExpressionType getSearchExpressionTypeForSearchMode() {
+        ButtonModel selection = form.buttonGroupSearch.getSelection();
+        if (selection == null) {
             throw new IllegalStateException("None of radio button is selected.");
         }
-        return searchExpressionType;
+        return modelToType.get(selection);
     }
 
-    private SearchExpression.SearchExpressionType getSearchExpressionTypeForReplaceMode() {
-        SearchExpression.SearchExpressionType searchExpressionType = modelToType
-                .get(form.m_searchExactSearchRB.getModel());
+    @VisibleForTesting
+    SearchExpression.SearchExpressionType getSearchExpressionTypeForReplaceMode() {
+        ButtonModel selection = form.buttonGroupReplace.getSelection();
+        SearchExpression.SearchExpressionType searchExpressionType = selection == null ? null
+                : modelToType.get(selection);
         if (searchExpressionType == null
                 || searchExpressionType == SearchExpression.SearchExpressionType.KEYWORD) {
             throw new IllegalStateException("The radio button selection is not consistent.");

--- a/src/test/java/org/omegat/gui/search/SearchWindowTest.java
+++ b/src/test/java/org/omegat/gui/search/SearchWindowTest.java
@@ -25,11 +25,14 @@
 
 package org.omegat.gui.search;
 
+import static org.junit.Assert.assertEquals;
+
 import java.awt.GraphicsEnvironment;
 
 import org.junit.Assume;
 import org.junit.Test;
 import org.omegat.core.TestCore;
+import org.omegat.core.search.SearchExpression;
 import org.omegat.core.search.SearchMode;
 
 public class SearchWindowTest extends TestCore {
@@ -44,5 +47,48 @@ public class SearchWindowTest extends TestCore {
     public void testLoadSearchAndReplaceWindow() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         new SearchWindowController(SearchMode.REPLACE);
+    }
+
+    /**
+     * The search type must follow the selected radio button; a regression
+     * once made every search run as an exact search, so a regular expression
+     * like "a|b" was quoted and found nothing.
+     */
+    @Test
+    public void testSearchTypeFollowsTheSelectedRadioButton() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        SearchWindowController controller = new SearchWindowController(SearchMode.SEARCH);
+        SearchWindowForm form = (SearchWindowForm) controller.getWindow();
+
+        form.m_searchRegexpSearchRB.setSelected(true);
+        assertEquals(SearchExpression.SearchExpressionType.REGEXP,
+                controller.getSearchExpressionTypeForSearchMode());
+
+        form.m_searchKeywordSearchRB.setSelected(true);
+        assertEquals(SearchExpression.SearchExpressionType.KEYWORD,
+                controller.getSearchExpressionTypeForSearchMode());
+
+        form.m_searchExactSearchRB.setSelected(true);
+        assertEquals(SearchExpression.SearchExpressionType.EXACT,
+                controller.getSearchExpressionTypeForSearchMode());
+    }
+
+    /**
+     * The replace mode has its own radio button group; it must not read the
+     * search mode's buttons.
+     */
+    @Test
+    public void testReplaceTypeFollowsTheSelectedRadioButton() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        SearchWindowController controller = new SearchWindowController(SearchMode.REPLACE);
+        SearchWindowForm form = (SearchWindowForm) controller.getWindow();
+
+        form.m_replaceRegexpSearchRB.setSelected(true);
+        assertEquals(SearchExpression.SearchExpressionType.REGEXP,
+                controller.getSearchExpressionTypeForReplaceMode());
+
+        form.m_replaceExactSearchRB.setSelected(true);
+        assertEquals(SearchExpression.SearchExpressionType.EXACT,
+                controller.getSearchExpressionTypeForReplaceMode());
     }
 }


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Regression from #2235 (BUGS-1327 follow-up), no separate ticket: since cc9c7ffc3 every search runs as an exact search.

## What does this PR change?

- The search-type detection introduced in #2235 always looked up the model of the *Exact* radio button, so regular expressions were quoted into literals (`a|b` found nothing) and keyword queries silently ran as phrases; replace mode additionally read the search-mode radios.
- The lookup now uses the actual button group selection, and the replace-mode radios are part of the model map.
- Two regression tests assert that the detected type follows the selected radio in both modes (verified red on the buggy lookup); the two detection methods became package-private with `@VisibleForTesting` for that.

## Other information

Found while testing a local integration build; root cause confirmed against a pre-#2235 build (regex search there returns the expected matches).
