### PR TITLE
fix(jpackage): fix test syntax in desktop menu commands error handling logic

### DIFF
--- a/release/jpackage-specific/postinst
+++ b/release/jpackage-specific/postinst
@@ -50,7 +50,7 @@ case "$1" in
 DESKTOP_COMMANDS_INSTALL
     desktop_commands_status=$?
     set -e
-    if [ "$desktop_commands_status" -ne 0]; then
+    if [ "$desktop_commands_status" -ne 0 ]; then
       echo "Warning: desktop menu registration failed with status $desktop_commands_status; continuing installation." >&2
     fi
     ln -s -b /opt/omegat-org/omegat/bin/OmegaT /usr/bin/omegat


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?
 
- The Debian package postinst script emits "[: missing ]" error during installation 
- https://sourceforge.net/p/omegat/bugs/1328/

## What does this PR change?

This PR fixes the syntax of the `[` construct.

## Other information

This PR supersedes #2240 to fix compliance of [✅ Good Branch Naming - Git Workflow - OmegaT documentation](https://omegat.readthedocs.io/en/latest/06.GitWorkFlows.html#good-branch-naming) .