### PR TITLE
chore(jpkg/deb): fix syntax error

### DIFF
--- a/release/jpackage-specific/postinst
+++ b/release/jpackage-specific/postinst
@@ -50,7 +50,7 @@ case "$1" in
 DESKTOP_COMMANDS_INSTALL
     desktop_commands_status=$?
     set -e
-    if [ "$desktop_commands_status" -ne 0]; then
+    if [ "$desktop_commands_status" -ne 0 ]; then
       echo "Warning: desktop menu registration failed with status $desktop_commands_status; continuing installation." >&2
     fi
     ln -s -b /opt/omegat-org/omegat/bin/OmegaT /usr/bin/omegat


### PR DESCRIPTION


## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- Build and release changes -> [build/release]

## Which ticket is resolved?

- The Debian package postinst script emits "[: missing ]" error during installation
- https://sourceforge.net/p/omegat/bugs/1328/

## What does this PR change?

- Update jpackage-specific/postinst script to fix syntax error in desktop_commands_status condition

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
