### PR TITLE
feat(issues): new project option to validate number translations by value instead of by string plus optional color marker for numbers

### DIFF
--- a/src/docs/manual/en/Dialogs_ProjectProperties.xml
+++ b/src/docs/manual/en/Dialogs_ProjectProperties.xml
@@ -198,7 +198,7 @@
          </varlistentry>
          <varlistentry xml:id="dialogs.project.properties.match.numbers">
             <term xml:id="dialogs.project.properties.match.numbers.title">
-               <option>Consider numbers in fuzzy matching</option>
+               <option>Consider numbers in matches</option>
             </term>
             <listitem>
                <para>By default, the word-based match percentages ignore numbers, and
@@ -209,7 +209,11 @@
                   		  tokens by their numeric value: numbers written in different
                   		  numbering systems (Roman numerals, ideographic numbers,
                   		  Arabic-Indic or full-width digits, and so on) count as equal to
-                  		  their Western counterpart of the same value. Two segments that
+                  		  their Western counterpart of the same value. The sign-written
+                  		  systems (Ethiopic, cuneiform, Mayan and others) and the
+                  		  precomposed fraction glyphs are read the same way, and an
+                  		  inserted match rewrites each number in the notation the match
+                  		  itself uses. Two segments that
                   		  consist only of numbers are scored against each other as number
                   		  sequences, with a small fixed penalty, so differing dates or bare
                   		  numbers surface as fuzzy matches at all.</para>
@@ -218,6 +222,21 @@
                   <link linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"></link> pane to see how its score was
                   		  computed; a warning is shown there when the numbers of the match
                   		  differ in value from those of the segment.</para>
+            </listitem>
+         </varlistentry>
+         <varlistentry xml:id="dialogs.project.properties.check.numbers">
+            <term xml:id="dialogs.project.properties.check.numbers.title">
+               <option>Check numerals by value</option>
+            </term>
+            <listitem>
+               <para>Makes the tag checks compare the numerals of the source text
+                  		  and the translation by their numeric value, whatever the numeral
+                  		  system, and report a changed or missing value in the
+                  <guilabel>Issues</guilabel> window. A value rewritten in the
+                  		  notation of the target language raises no issue.</para>
+               <para>Turn the option off for language pairs where numbers are
+                  		  legitimately rewritten beyond recognition, such as a target
+                  		  language that spells numbers out in words.</para>
             </listitem>
          </varlistentry>
          <varlistentry xml:id="dialogs.project.properties.external.processing.command">

--- a/src/docs/manual/en/Menus_Tools.xml
+++ b/src/docs/manual/en/Menus_Tools.xml
@@ -52,7 +52,10 @@
                   <para>
                      <guilabel>Tag Issues</guilabel> (always selected): detects
                      missing or misplaced tags, including custom tags and flagged
-                     text. See the 
+                     text. If the
+                     <link linkend="dialogs.project.properties.check.numbers" endterm="dialogs.project.properties.check.numbers.title"></link> project
+                     property is enabled, numerals are also compared by their
+                     numeric value, whatever the numeral system. See the
                      <link linkend="dialogs.preferences.tag.processing" endterm="dialogs.preferences.tag.processing.title"></link> preferences for
                      details.</para>
                   <note>

--- a/src/docs/manual/en/OmegaT_EditorsPanes.xml
+++ b/src/docs/manual/en/OmegaT_EditorsPanes.xml
@@ -472,6 +472,13 @@ When enabled, all formatting in the source segments are hidden.</programlisting>
                   <link endterm="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation.title" linkend="dialogs.preferences.tag.processing.regular.expressions.for.fragments.that.should.be.removed.from.translation"></link>
                   		  preference.</para>
             </listitem>
+            <listitem>
+               <para>Underlining numerals by assigning the
+                  <guilabel>Numerals</guilabel> colour in the
+                  <link endterm="dialogs.preferences.colours.title" linkend="dialogs.preferences.colours"></link> preferences, when the
+                  <link linkend="dialogs.project.properties.check.numbers" endterm="dialogs.project.properties.check.numbers.title"></link> project
+                  		  property is enabled.</para>
+            </listitem>
          </itemizedlist>
          <para>See the 
             <link linkend="dialogs.preferences.editor" endterm="dialogs.preferences.editor.title"></link> preferences and the 

--- a/src/docs/manual/en/OmegaT_Preferences.xml
+++ b/src/docs/manual/en/OmegaT_Preferences.xml
@@ -395,6 +395,12 @@
             with
             <guibutton>OK</guibutton> or
             <guibutton>Apply</guibutton>.</para>
+         <para>The <guilabel>Numerals</guilabel> colour drives the underline
+            that marks the numerals of every writing system in the editor, as
+            long as the
+            <link linkend="dialogs.project.properties.check.numbers" endterm="dialogs.project.properties.check.numbers.title"></link> project
+            property is enabled. It ships without a colour; the marks appear
+            once you assign one.</para>
          <para>Scripts can be used to set predefined themes. OmegaT is bundled with
             a script called 
             <link linkend="windows.scripts.distribution.switch.colour.theme" endterm="windows.scripts.distribution.switch.colour.theme.title"></link> that

--- a/src/docs/tips/de/fuzzy_match_numbers.html
+++ b/src/docs/tips/de/fuzzy_match_numbers.html
@@ -34,7 +34,7 @@
 anderen Zahlen: &bdquo;Mit 12&nbsp;Nm anziehen&ldquo; und &bdquo;Mit
 8&nbsp;Nm anziehen&ldquo; &ndash; und reine Zahlensegmente (Datum, Betrag)
 finden normalerweise gar keinen unscharfen Treffer.</p>
-<p><b>Zahlen bei unscharfen Treffern berücksichtigen</b> in den
+<p><b>Zahlen in Treffern berücksichtigen</b> in den
 Projekteigenschaften lässt das Fuzzy-Matches-Fenster Zahlen nach Wert
 vergleichen:</p>
 <ul>

--- a/src/docs/tips/de/numbers_checked_in_every_system.html
+++ b/src/docs/tips/de/numbers_checked_in_every_system.html
@@ -30,9 +30,9 @@
     <link rel="stylesheet" type="text/css" href="../tips.css">
 </head><body>
 <h3 class="title">Zahlen werden in jedem Zahlsystem geprüft</h3>
-<p>OmegaT vergleicht die Zahlen von Quelltext und Übersetzung nach ihrem
-Zahlenwert, in welchem Zahlsystem sie auch geschrieben sind, und meldet einen
-geänderten oder fehlenden Wert im Fenster <b>Probleme</b>.</p>
-<p>Die Option <b>Zahlen nach Wert prüfen</b> unter <b>Projekt &gt;
-Eigenschaften</b> schaltet die Prüfung für das Projekt ab.</p>
+<p>OmegaT vergleicht Zahlen in Quelltext und Übersetzung nach Wert, in
+welchem Zahlsystem sie auch geschrieben sind, und meldet geänderte oder
+fehlende Werte im Fenster <b>Probleme</b>.</p>
+<p><b>Zahlen nach Wert prüfen</b> unter <b>Projekt &gt; Eigenschaften</b>
+schaltet die Prüfung je Projekt ab.</p>
 </body></html>

--- a/src/docs/tips/de/numbers_checked_in_every_system.html
+++ b/src/docs/tips/de/numbers_checked_in_every_system.html
@@ -1,4 +1,4 @@
-<html lang="en">
+<html lang="de">
 <!--
   ~  OmegaT - Computer Assisted Translation (CAT) tool
   ~           with fuzzy matching, translation memory, keyword search,
@@ -26,25 +26,13 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Let fuzzy matching understand numbers</title>
+    <title>Zahlen werden in jedem Zahlsystem geprüft</title>
     <link rel="stylesheet" type="text/css" href="../tips.css">
 </head><body>
-<h3 class="title">Let fuzzy matching understand numbers</h3>
-<p>Manuals, price lists and reports repeat the same sentence with different
-numbers: "Tighten to 12&nbsp;Nm" and "Tighten to 8&nbsp;Nm" &mdash; and
-number-only segments (a date, an amount) normally find no fuzzy match at
-all.</p>
-<p><b>Consider numbers in matches</b> in the project properties makes
-the Fuzzy Matches pane compare numbers by value:</p>
-<ul>
-<li>Number-only segments (dates, quantities, prices) match each other, with a
-small penalty.</li>
-<li>Equal value counts as equal across writing systems: XIV,
-&#21313;&#22235;, &#1633;&#1636; and the full-width &#65297;&#65300; all
-equal 14.</li>
-<li>A tooltip shows how each score was computed and warns when the match's
-numbers differ from your segment's &mdash; no wrong number slips in
-unnoticed.</li>
-</ul>
-<p>Stored in the project, so the whole team benefits.</p>
+<h3 class="title">Zahlen werden in jedem Zahlsystem geprüft</h3>
+<p>OmegaT vergleicht die Zahlen von Quelltext und Übersetzung nach ihrem
+Zahlenwert, in welchem Zahlsystem sie auch geschrieben sind, und meldet einen
+geänderten oder fehlenden Wert im Fenster <b>Probleme</b>.</p>
+<p>Die Option <b>Zahlen nach Wert prüfen</b> unter <b>Projekt &gt;
+Eigenschaften</b> schaltet die Prüfung für das Projekt ab.</p>
 </body></html>

--- a/src/docs/tips/de/tips.yaml
+++ b/src/docs/tips/de/tips.yaml
@@ -82,3 +82,5 @@ tips:
   name: "MT-4tw-3"
 - file: "machine_translation_4tw_3.html"
   name: "MT-4tw-4"
+- file: "numbers_checked_in_every_system.html"
+  name: "Zahlen werden in jedem Zahlsystem geprüft"

--- a/src/docs/tips/en/numbers_checked_in_every_system.html
+++ b/src/docs/tips/en/numbers_checked_in_every_system.html
@@ -26,25 +26,13 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Let fuzzy matching understand numbers</title>
+    <title>Numbers are checked in every numeral system</title>
     <link rel="stylesheet" type="text/css" href="../tips.css">
 </head><body>
-<h3 class="title">Let fuzzy matching understand numbers</h3>
-<p>Manuals, price lists and reports repeat the same sentence with different
-numbers: "Tighten to 12&nbsp;Nm" and "Tighten to 8&nbsp;Nm" &mdash; and
-number-only segments (a date, an amount) normally find no fuzzy match at
-all.</p>
-<p><b>Consider numbers in matches</b> in the project properties makes
-the Fuzzy Matches pane compare numbers by value:</p>
-<ul>
-<li>Number-only segments (dates, quantities, prices) match each other, with a
-small penalty.</li>
-<li>Equal value counts as equal across writing systems: XIV,
-&#21313;&#22235;, &#1633;&#1636; and the full-width &#65297;&#65300; all
-equal 14.</li>
-<li>A tooltip shows how each score was computed and warns when the match's
-numbers differ from your segment's &mdash; no wrong number slips in
-unnoticed.</li>
-</ul>
-<p>Stored in the project, so the whole team benefits.</p>
+<h3 class="title">Numbers are checked in every numeral system</h3>
+<p>OmegaT compares the numbers of the source text and the translation by their
+numeric value, whatever numeral system they are written in, and reports a
+changed or missing value in the <b>Issues</b> window.</p>
+<p>The option <b>Check numerals by value</b> in <b>Project &gt;
+Properties</b> turns the check off for the project.</p>
 </body></html>

--- a/src/docs/tips/en/numbers_checked_in_every_system.html
+++ b/src/docs/tips/en/numbers_checked_in_every_system.html
@@ -30,9 +30,9 @@
     <link rel="stylesheet" type="text/css" href="../tips.css">
 </head><body>
 <h3 class="title">Numbers are checked in every numeral system</h3>
-<p>OmegaT compares the numbers of the source text and the translation by their
-numeric value, whatever numeral system they are written in, and reports a
-changed or missing value in the <b>Issues</b> window.</p>
-<p>The option <b>Check numerals by value</b> in <b>Project &gt;
-Properties</b> turns the check off for the project.</p>
+<p>OmegaT compares source and translation numbers by value, whatever numeral
+system they are written in, and reports changed or missing values in the
+<b>Issues</b> window.</p>
+<p><b>Check numerals by value</b> in <b>Project &gt; Properties</b> turns the
+check off per project.</p>
 </body></html>

--- a/src/docs/tips/en/tips.yaml
+++ b/src/docs/tips/en/tips.yaml
@@ -74,3 +74,5 @@ tips:
   name: Ignore a word in the dictionary
 - file: fuzzy_match_numbers.html
   name: Let fuzzy matching understand numbers
+- file: numbers_checked_in_every_system.html
+  name: Numbers are checked in every numeral system

--- a/src/main/java/org/omegat/core/Core.java
+++ b/src/main/java/org/omegat/core/Core.java
@@ -47,6 +47,7 @@ import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.spellchecker.ISpellChecker;
 import org.omegat.core.spellchecker.SpellCheckerManager;
 import org.omegat.core.tagvalidation.ITagValidation;
+import org.omegat.core.tagvalidation.TagValidation;
 import org.omegat.core.tagvalidation.TagValidationTool;
 import org.omegat.core.threads.IAutoSave;
 import org.omegat.core.threads.LongProcessExecutor;
@@ -263,6 +264,7 @@ public final class Core {
     static void initializeGUIimpl(IMainWindow me) throws Exception {
         MarkerController.init();
         LanguageToolWrapper.init();
+        TagValidation.registerCheckNumbersTeamSetting();
 
         CoreState coreState = CoreState.getInstance();
         coreState.setSegmenter(new Segmenter(Preferences.getSRX()));
@@ -295,6 +297,7 @@ public final class Core {
      */
     public static void initializeConsole() {
         CoreState coreState = CoreState.getInstance();
+        TagValidation.registerCheckNumbersTeamSetting();
         coreState.setTagValidation(new TagValidationTool());
         coreState.setProject(new NotLoadedProject());
         coreState.setMainWindow(new ConsoleWindow());

--- a/src/main/java/org/omegat/core/data/IProject.java
+++ b/src/main/java/org/omegat/core/data/IProject.java
@@ -29,6 +29,7 @@
 package org.omegat.core.data;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -106,6 +107,51 @@ public interface IProject {
      * @throws Exception if any error occurs during the commit process
      */
     void commitSourceFiles() throws Exception;
+
+    /**
+     * Sets a registered team project setting and commits the project
+     * settings file (omegat/project_settings.properties) to the team
+     * repository, so the whole team gets the value. The setting lives in
+     * its own file because older OmegaT versions reject unknown elements in
+     * omegat.project but ignore extra files. No operation for non-team
+     * projects. Must run through Core.executeExclusively, like saveProject.
+     *
+     * @param key
+     *            key of a setting registered in {@link TeamSettingsRegistry}
+     * @param value
+     *            raw value to distribute, null for the default
+     * @throws Exception
+     *             if writing or committing the file fails
+     */
+    default void publishProjectSetting(String key, @Nullable String value) throws Exception {
+    }
+
+    /**
+     * Sets a registered team project setting for this session and writes it
+     * to the local project settings file only: the next open of the team
+     * project supersedes it with the remote value again. No operation for
+     * non-team projects. Must run through Core.executeExclusively, like
+     * saveProject.
+     *
+     * @param key
+     *            key of a setting registered in {@link TeamSettingsRegistry}
+     * @param value
+     *            raw value to restore, null for the default
+     * @throws Exception
+     *             if writing the file fails
+     */
+    default void useLocalProjectSetting(String key, @Nullable String value) throws Exception {
+    }
+
+    /**
+     * The local raw values that the team values superseded during the last
+     * load of a team project, keyed by setting key; an entry with null value
+     * means the local side had the default. Empty when everything agreed,
+     * always empty for non-team projects.
+     */
+    default Map<String, @Nullable String> getSupersededLocalSettings() {
+        return Collections.emptyMap();
+    }
 
     /**
      * Get project properties.

--- a/src/main/java/org/omegat/core/data/ProjectProperties.java
+++ b/src/main/java/org/omegat/core/data/ProjectProperties.java
@@ -432,6 +432,20 @@ public class ProjectProperties {
     }
 
     /**
+     * Returns whether the tag checks compare numbers by value for this
+     * project, whatever the numeral system (feature request #465). Default,
+     * yes.
+     */
+    public boolean isCheckNumbersEnabled() {
+        return checkNumbersEnabled;
+    }
+
+    /** Sets whether the tag checks compare numbers by value for this project */
+    public void setCheckNumbersEnabled(boolean checkNumbersEnabled) {
+        this.checkNumbersEnabled = checkNumbersEnabled;
+    }
+
+    /**
      * Sets level(s) of TMs to be exported by project. Accepts three booleans as
      * arguments, corresponding to OmegaT, Level 1 and Level 2
      */
@@ -688,6 +702,7 @@ public class ProjectProperties {
 
     private boolean sentenceSegmentingEnabled;
     private boolean matchNumbersEnabled;
+    private boolean checkNumbersEnabled = true;
     private boolean supportDefaultTranslations;
     private boolean removeTags;
     private List<String> exportTmLevels;

--- a/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
+++ b/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
@@ -1,0 +1,168 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+import org.jspecify.annotations.Nullable;
+
+import org.omegat.util.Log;
+
+/**
+ * Storage of optional per-project settings in
+ * {@code omegat/project_settings.properties}. The settings live in their own
+ * file instead of {@code omegat.project} on purpose: the project file parser
+ * of released OmegaT versions rejects unknown elements, so a new element
+ * there would make the project unreadable for every team member on an older
+ * version, while an extra file in the {@code omegat} folder is ignored.
+ *
+ * The file is written deterministically (sorted keys, no timestamp comment),
+ * so distributing an unchanged file to a team repository stays recognisable
+ * as a byte-identical no-op.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class ProjectSettingsStorage {
+
+    public static final String FILE_PROJECT_SETTINGS = "project_settings.properties";
+
+    private ProjectSettingsStorage() {
+    }
+
+    /** The settings file of the given project. */
+    public static File getFile(ProjectProperties config) {
+        return new File(config.getProjectInternal(), FILE_PROJECT_SETTINGS);
+    }
+
+    /**
+     * The stored raw value of given key: null when the file or the key is
+     * absent or the file is unreadable, so callers can distinguish "not
+     * configured" from an explicit value.
+     */
+    public static @Nullable String load(ProjectProperties config, String key) {
+        File file = getFile(config);
+        if (!file.isFile()) {
+            return null;
+        }
+        Properties props = new Properties();
+        try (Reader in = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+            props.load(in);
+        } catch (IOException ex) {
+            Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+            return null;
+        }
+        String value = props.getProperty(key);
+        return value == null ? null : value.trim();
+    }
+
+    /**
+     * Store the raw value under given key (null removes the key), keeping
+     * any other keys of the file so settings can share it. Removing a key
+     * from an absent file is a no-op, so it never materialises the file.
+     */
+    public static void save(ProjectProperties config, String key, @Nullable String value)
+            throws IOException {
+        File file = getFile(config);
+        if (value == null && !file.isFile()) {
+            return;
+        }
+        Map<String, String> entries = new TreeMap<>();
+        if (file.isFile()) {
+            Properties existing = new Properties();
+            try (Reader in = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+                existing.load(in);
+            }
+            existing.stringPropertyNames().forEach(k -> entries.put(k, existing.getProperty(k)));
+        }
+        if (value == null) {
+            entries.remove(key);
+        } else {
+            entries.put(key, value);
+        }
+        File dir = file.getParentFile();
+        if (dir != null && !dir.isDirectory() && !dir.mkdirs()) {
+            throw new IOException("Cannot create " + dir);
+        }
+        try (Writer out = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+            for (Map.Entry<String, String> e : entries.entrySet()) {
+                out.write(escape(e.getKey(), true) + "=" + escape(e.getValue(), false) + "\n");
+            }
+        }
+    }
+
+    /**
+     * Escape a key or value the way {@code Properties.store} would, minus
+     * the Latin-1 escaping (the file is read and written as UTF-8), so
+     * foreign keys of other settings survive the load/save round trip
+     * unchanged.
+     */
+    private static String escape(String s, boolean isKey) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+            case '\\':
+                sb.append("\\\\");
+                break;
+            case '\t':
+                sb.append("\\t");
+                break;
+            case '\n':
+                sb.append("\\n");
+                break;
+            case '\r':
+                sb.append("\\r");
+                break;
+            case '\f':
+                sb.append("\\f");
+                break;
+            case '=':
+            case ':':
+            case '#':
+            case '!':
+                sb.append('\\').append(c);
+                break;
+            case ' ':
+                if (isKey || i == 0) {
+                    sb.append('\\');
+                }
+                sb.append(c);
+                break;
+            default:
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -252,11 +252,214 @@ public class RealProject implements IProject {
             FilterMaster.saveConfig(config.getProjectFilters(),
                     new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
             ProjectFileStorage.writeProjectFile(config);
+            persistSessionSettings(config, supersededLocalSettings.keySet());
         } finally {
             lockProject();
         }
         Preferences.setPreference(Preferences.SOURCE_LOCALE, config.getSourceLanguage().toString());
         Preferences.setPreference(Preferences.TARGET_LOCALE, config.getTargetLanguage().toString());
+    }
+
+    /**
+     * Persist the session values of all registered team settings to the
+     * sidecar file. Opt-in: only materialised once a setting was used, so
+     * default projects stay byte-identical to older OmegaT versions. While
+     * a superseded local value awaits the user's decision, the session runs
+     * on the team value but the file keeps the local one - persisting the
+     * session value here would silently turn a dismissed question into
+     * "take the team value". Static for testability.
+     */
+    static void persistSessionSettings(ProjectProperties config, Set<String> supersededKeys)
+            throws IOException {
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            String sessionValue = setting.read(config);
+            if (!supersededKeys.contains(setting.getKey())
+                    && (sessionValue != null || ProjectSettingsStorage.getFile(config).isFile())) {
+                ProjectSettingsStorage.save(config, setting.getKey(), sessionValue);
+            }
+        }
+    }
+
+    /**
+     * The local raw values that the just synced team values superseded
+     * during the load, keyed by setting key (null value = local default), or
+     * empty when everything agreed. Read by the question shown after a team
+     * project opened.
+     */
+    private volatile Map<String, @Nullable String> supersededLocalSettings = Collections.emptyMap();
+
+    @Override
+    public Map<String, @Nullable String> getSupersededLocalSettings() {
+        return supersededLocalSettings;
+    }
+
+    @Override
+    public void publishProjectSetting(String key, @Nullable String value) throws Exception {
+        if (!remoteRepositoryProvider.isManaged()) {
+            return;
+        }
+        TeamSetting setting = requireRegistered(key);
+        // The session and the local file keep the user's value even when the
+        // commit fails: the file then still diverges from the team and the
+        // next open asks again.
+        setting.apply(config, value);
+        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        // A checkout parked between teamSyncPrepare and teamSync must not be
+        // moved to latest behind the sync's back (same cleanup as
+        // saveProject).
+        tmxPrepared = null;
+        glossaryPrepared = null;
+        remoteRepositoryProvider.cleanPrepared();
+        commitProjectSettings(remoteRepositoryProvider, config);
+        clearSupersededLocalSetting(key);
+    }
+
+    @Override
+    public void useLocalProjectSetting(String key, @Nullable String value) throws Exception {
+        if (!remoteRepositoryProvider.isManaged()) {
+            return;
+        }
+        TeamSetting setting = requireRegistered(key);
+        setting.apply(config, value);
+        // Local write only: the next open of the team project syncs the
+        // remote file back in, notices a divergence and asks again.
+        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        clearSupersededLocalSetting(key);
+    }
+
+    private static TeamSetting requireRegistered(String key) {
+        TeamSetting setting = TeamSettingsRegistry.byKey(key);
+        if (setting == null) {
+            throw new IllegalArgumentException("Unknown team setting: " + key);
+        }
+        return setting;
+    }
+
+    private void clearSupersededLocalSetting(String key) {
+        if (supersededLocalSettings.containsKey(key)) {
+            Map<String, @Nullable String> remaining = new HashMap<>(supersededLocalSettings);
+            remaining.remove(key);
+            supersededLocalSettings = Collections.unmodifiableMap(remaining);
+        }
+    }
+
+    /**
+     * Commit the project settings file to the team repositories. Skips the
+     * commit when every repository copy is already byte-identical, because
+     * git reports the no-op commit of an unchanged file the same way as a
+     * rejected push. Static for testability.
+     */
+    static void commitProjectSettings(RemoteRepositoryProvider provider, ProjectProperties config)
+            throws Exception {
+        // The checkout may be stale, and a commit onto an old base would be
+        // rejected on push.
+        provider.switchAllToLatest();
+        String underRoot = config.getProjectInternalRelative()
+                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
+        if (!provider.isIdenticalInRepositoriesIgnoringEol(underRoot)) {
+            provider.copyFilesFromProjectToRepos(underRoot, null);
+            if (!provider.commitFilesChecked(underRoot, "Update the shared project settings")) {
+                throw new IOException(OStrings.getString("TEAM_SETTING_SHARE_ERROR"));
+            }
+        }
+    }
+
+    /**
+     * Apply the stored project settings to the session. For an online team
+     * project the team's state wins: the sync just overwrote a diverging
+     * local file with the remote one, and a purely local file (which the
+     * sync leaves alone, because it never existed remotely) does not count
+     * either - the team default stays active until the value is shared.
+     * Either way the superseded local values are kept for the question shown
+     * after the load, so every open asks again until the value is shared or
+     * dropped, as the share prompt promises.
+     *
+     * @param preSyncValues
+     *            the locally stored normalized values from before the team
+     *            sync, keyed by setting key
+     */
+    private void loadProjectSettings(Map<String, @Nullable String> preSyncValues) {
+        if (TeamSettingsRegistry.all().isEmpty()) {
+            supersededLocalSettings = Collections.emptyMap();
+            return;
+        }
+        boolean teamOnline = remoteRepositoryProvider.isManaged() && isOnlineMode;
+        boolean identical = false;
+        if (teamOnline) {
+            try {
+                // After the sync a settings file that exists remotely is
+                // byte-identical locally; a non-identical or absent file
+                // means the team does not carry the setting, so the local
+                // file is a local-only divergence.
+                identical = remoteRepositoryProvider.isIdenticalInRepositories(
+                        config.getProjectInternalRelative()
+                                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+            } catch (IOException ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                // fall back to trusting the local file
+                identical = true;
+            }
+        }
+        Map<String, @Nullable String> superseded = new HashMap<>();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            String preSync = preSyncValues.get(setting.getKey());
+            String postSync = setting.normalize(ProjectSettingsStorage.load(config, setting.getKey()));
+            SettingResolution state = resolveSetting(preSync, postSync, identical, teamOnline);
+            setting.apply(config, state.effective);
+            if (state.asks) {
+                superseded.put(setting.getKey(), state.supersededLocal);
+            }
+        }
+        supersededLocalSettings = Collections.unmodifiableMap(superseded);
+    }
+
+    /** Snapshot of the stored normalized values of all registered settings. */
+    private Map<String, @Nullable String> readStoredSettings() {
+        Map<String, @Nullable String> values = new HashMap<>();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            values.put(setting.getKey(),
+                    setting.normalize(ProjectSettingsStorage.load(config, setting.getKey())));
+        }
+        return values;
+    }
+
+    /** Resolution of one team setting after a load. */
+    static final class SettingResolution {
+        final @Nullable String effective;
+        final boolean asks;
+        final @Nullable String supersededLocal;
+
+        SettingResolution(@Nullable String effective, boolean asks, @Nullable String supersededLocal) {
+            this.effective = effective;
+            this.asks = asks;
+            this.supersededLocal = supersededLocal;
+        }
+    }
+
+    /**
+     * Decide which raw value a load activates and whether it superseded a
+     * diverging local value that the user should be asked about. Works on
+     * normalized values (default = null). Pure function for testability.
+     *
+     * @param preSyncStored
+     *            locally stored value from before the team sync, null when
+     *            file or key were absent
+     * @param postSyncStored
+     *            stored value after the team sync
+     * @param identicalInRepositories
+     *            whether the settings file is byte-identical in every team
+     *            repository (meaningless when teamOnline is false)
+     * @param teamOnline
+     *            whether this is a team project loaded in online mode
+     */
+    static SettingResolution resolveSetting(@Nullable String preSyncStored,
+            @Nullable String postSyncStored, boolean identicalInRepositories, boolean teamOnline) {
+        if (!teamOnline) {
+            return new SettingResolution(postSyncStored, false, null);
+        }
+        String team = identicalInRepositories ? postSyncStored : null;
+        boolean asks = !Objects.equals(preSyncStored, team);
+        return new SettingResolution(team, asks, asks ? preSyncStored : null);
     }
 
     /**
@@ -343,6 +546,7 @@ public class RealProject implements IProject {
 
             Core.getMainWindow().showStatusMessageRB("CT_LOADING_PROJECT");
 
+            Map<String, @Nullable String> preSyncSettings = readStoredSettings();
             if (remoteRepositoryProvider.isManaged()) {
                 try {
                     tmxPrepared = null;
@@ -360,6 +564,7 @@ public class RealProject implements IProject {
                 config.loadProjectFilters();
                 config.loadProjectSRX();
             }
+            loadProjectSettings(preSyncSettings);
 
             loadFilterSettings();
             loadSegmentationSettings();

--- a/src/main/java/org/omegat/core/data/TeamSetting.java
+++ b/src/main/java/org/omegat/core/data/TeamSetting.java
@@ -1,0 +1,146 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+import org.jspecify.annotations.Nullable;
+import org.openide.awt.Mnemonics;
+
+import org.omegat.util.OStrings;
+
+/**
+ * Descriptor of one per-project setting negotiated with team, stored in
+ * sidecar file handled by {@link ProjectSettingsStorage}. Feature code
+ * registers descriptor through {@link TeamSettingsRegistry}; core then
+ * loads, saves, distributes and questions the setting generically. Raw
+ * values are strings; null means "not configured", i.e. default.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSetting {
+
+    private final String key;
+    private final String nameKey;
+    private final Function<ProjectProperties, @Nullable String> reader;
+    private final BiConsumer<ProjectProperties, @Nullable String> applier;
+    private final Function<@Nullable String, String> valueDescriber;
+    private final UnaryOperator<@Nullable String> normalizer;
+
+    private TeamSetting(String key, String nameKey, Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+        this.key = key;
+        this.nameKey = nameKey;
+        this.reader = reader;
+        this.applier = applier;
+        this.valueDescriber = valueDescriber;
+        this.normalizer = normalizer;
+    }
+
+    /**
+     * Descriptor with fully custom behaviour, for non-boolean settings.
+     *
+     * @param key
+     *            key in project_settings.properties
+     * @param nameKey
+     *            resource key of localized display name
+     * @param reader
+     *            current session value as normalized raw string, null for
+     *            default
+     * @param applier
+     *            applies raw value (null = default) to session; must be an
+     *            idempotent setter, it also runs with unchanged values
+     * @param valueDescriber
+     *            localized description of raw value for dialogs
+     * @param normalizer
+     *            canonical form of raw value; must map default to null
+     */
+    public static TeamSetting of(String key, String nameKey,
+            Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+        return new TeamSetting(key, nameKey, reader, applier, valueDescriber, normalizer);
+    }
+
+    /**
+     * Boolean setting; absent key means given default, only the non-default
+     * value materialises in the file, so default projects stay byte-identical
+     * to projects of older OmegaT versions.
+     */
+    public static TeamSetting ofBoolean(String key, String nameKey, boolean defaultValue,
+            Predicate<ProjectProperties> getter, BiConsumer<ProjectProperties, Boolean> setter) {
+        UnaryOperator<@Nullable String> normalizer = raw -> {
+            boolean value = raw == null ? defaultValue : Boolean.parseBoolean(raw.trim());
+            return value == defaultValue ? null : Boolean.toString(value);
+        };
+        return new TeamSetting(key, nameKey,
+                config -> getter.test(config) == defaultValue ? null : Boolean.toString(!defaultValue),
+                (config, raw) -> setter.accept(config,
+                        raw == null ? defaultValue : Boolean.parseBoolean(raw.trim())),
+                raw -> OStrings.getString(
+                        (raw == null ? defaultValue : Boolean.parseBoolean(raw.trim()))
+                                ? "TEAM_SETTING_VALUE_ON"
+                                : "TEAM_SETTING_VALUE_OFF"),
+                normalizer);
+    }
+
+    /** Key in project_settings.properties. */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Localized display name for dialogs. Mnemonic markers are stripped, so
+     * existing menu or checkbox label keys work as name key.
+     */
+    public String getDisplayName() {
+        return Mnemonics.removeMnemonics(OStrings.getString(nameKey));
+    }
+
+    /** Current session value as normalized raw string, null for default. */
+    public @Nullable String read(ProjectProperties config) {
+        return normalize(reader.apply(config));
+    }
+
+    /** Applies raw value (null = default) to session. */
+    public void apply(ProjectProperties config, @Nullable String raw) {
+        applier.accept(config, normalize(raw));
+    }
+
+    /** Localized description of raw value for dialogs. */
+    public String describe(@Nullable String raw) {
+        return valueDescriber.apply(raw);
+    }
+
+    /** Canonical form of raw value; default maps to null. */
+    public @Nullable String normalize(@Nullable String raw) {
+        return normalizer.apply(raw);
+    }
+}

--- a/src/main/java/org/omegat/core/data/TeamSettingsRegistry.java
+++ b/src/main/java/org/omegat/core/data/TeamSettingsRegistry.java
@@ -1,0 +1,70 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Registry of team-negotiated project settings. Feature code registers its
+ * {@link TeamSetting} at plugin load; core iterates registered settings when
+ * loading, saving and distributing projects. Empty registry means every
+ * related code path stays no-op.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSettingsRegistry {
+
+    private static final List<TeamSetting> SETTINGS = new CopyOnWriteArrayList<>();
+
+    private TeamSettingsRegistry() {
+    }
+
+    /** Registers setting; rejects duplicate key. */
+    public static void register(TeamSetting setting) {
+        if (byKey(setting.getKey()) != null) {
+            throw new IllegalArgumentException("Team setting already registered: " + setting.getKey());
+        }
+        SETTINGS.add(setting);
+    }
+
+    /** Removes setting with given key, for plugin unload and tests. */
+    public static void unregister(String key) {
+        SETTINGS.removeIf(s -> s.getKey().equals(key));
+    }
+
+    /** All registered settings, in registration order. */
+    public static List<TeamSetting> all() {
+        return List.copyOf(SETTINGS);
+    }
+
+    /** Setting with given key, null when unknown. */
+    public static @Nullable TeamSetting byKey(String key) {
+        return SETTINGS.stream().filter(s -> s.getKey().equals(key)).findFirst().orElse(null);
+    }
+}

--- a/src/main/java/org/omegat/core/statistics/FindMatches.java
+++ b/src/main/java/org/omegat/core/statistics/FindMatches.java
@@ -668,54 +668,18 @@ public class FindMatches {
         for (int i = 0; i < tokens.length; i++) {
             Token token = tokens[i];
             String text = token.getTextFromString(str);
-            BigInteger value = numeralValue(text);
+            // Roman numerals count here: a word misread as one only shifts the
+            // similarity a little, and reading them is the point of the option.
+            BigInteger value = NumeralValueParser.parseTokenWhole(text, true).orElse(null);
             String mappedText;
             if (value != null) {
-                mappedText = placeholder ? " #" : " #" + value;
+                mappedText = placeholder ? "\0#" : "\0#" + value;
             } else {
                 mappedText = text.toLowerCase(srcLocale);
             }
             mapped[i] = new Token(mappedText, token.getOffset(), token.getLength());
         }
         return mapped;
-    }
-
-    /**
-     * Matches a canonical uppercase Roman numeral; lowercase or non-canonical
-     * letter runs (like "mix" or "civil") stay ordinary words.
-     */
-    private static final Pattern CANONICAL_ROMAN = Pattern
-            .compile("M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})");
-    private static final Pattern ANY_ROMAN_DIGIT = Pattern.compile(".*[IVX].*");
-    /** Han numeral ideographs, the unambiguous CJK number tokens. */
-    private static final Pattern HAN_NUMERALS = Pattern.compile(
-            "[〇零一二三四五六七八九"
-                    + "十百千万萬億兆两兩]+");
-
-    /**
-     * The numeric value of a token, or null when the token must not be treated
-     * as a number. Tokens containing a decimal digit or letter numeral of any
-     * script always count; letter-only tokens count only in unambiguous forms
-     * (canonical uppercase Roman, Han numerals), so ordinary words are never
-     * misread as numerals.
-     */
-    private static BigInteger numeralValue(String text) {
-        boolean numeric = false;
-        for (int i = 0; i < text.length();) {
-            int cp = text.codePointAt(i);
-            int type = Character.getType(cp);
-            if (type == Character.DECIMAL_DIGIT_NUMBER || type == Character.LETTER_NUMBER) {
-                numeric = true;
-                break;
-            }
-            i += Character.charCount(cp);
-        }
-        if (!numeric
-                && !(CANONICAL_ROMAN.matcher(text).matches() && ANY_ROMAN_DIGIT.matcher(text).matches())
-                && !HAN_NUMERALS.matcher(text).matches()) {
-            return null;
-        }
-        return NumeralValueParser.parseWhole(text).orElse(null);
     }
 
     private void checkStopped(IStopped stop) throws StoppedException {

--- a/src/main/java/org/omegat/core/tagvalidation/TagValidation.java
+++ b/src/main/java/org/omegat/core/tagvalidation/TagValidation.java
@@ -28,14 +28,23 @@ package org.omegat.core.tagvalidation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.ibm.icu.text.Normalizer2;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.TeamSetting;
+import org.omegat.core.data.TeamSettingsRegistry;
 import org.omegat.core.tagvalidation.ErrorReport.TagError;
+import org.omegat.util.NumeralValueParser;
 import org.omegat.util.PatternConsts;
 import org.omegat.util.Preferences;
 import org.omegat.util.TagUtil;
@@ -46,7 +55,27 @@ import org.omegat.util.TagUtil.Tag;
  */
 public final class TagValidation {
 
+    /** Key of the team-negotiated numeral check setting. */
+    public static final String CHECK_NUMBERS_TEAM_SETTING_KEY = "check_numbers";
+
+    private static final Normalizer2 NFKC = Normalizer2.getNFKCInstance();
+
+    /** Characters that would extend a compatibility spelling into a different word or number. */
+    private static final String COMPAT_BOUNDARY = "[\\p{L}\\p{Nd}/]";
+
     private TagValidation() {
+    }
+
+    /**
+     * Registers the numeral check as team-negotiated opt-out setting (absent
+     * key = enabled); safe to call from every bootstrap.
+     */
+    public static void registerCheckNumbersTeamSetting() {
+        if (TeamSettingsRegistry.byKey(CHECK_NUMBERS_TEAM_SETTING_KEY) == null) {
+            TeamSettingsRegistry.register(TeamSetting.ofBoolean(CHECK_NUMBERS_TEAM_SETTING_KEY,
+                    "PP_CHECK_NUMBERS", true, ProjectProperties::isCheckNumbersEnabled,
+                    ProjectProperties::setCheckNumbersEnabled));
+        }
     }
 
     public static void inspectJavaMessageFormat(ErrorReport report) {
@@ -140,12 +169,198 @@ public final class TagValidation {
 
     public static void inspectOmegaTTags(SourceTextEntry ste, ErrorReport report) {
         // extract tags from src and loc string
-        List<Tag> srcTags = TagUtil.buildTagList(report.source, ste.getProtectedParts());
+        List<Tag> srcTags = new ArrayList<>(TagUtil.buildTagList(report.source, ste.getProtectedParts()));
         List<Tag> locTags = new ArrayList<>(TagUtil.buildTagList(report.translation, ste.getProtectedParts()));
         // Add extra tags in target that are not in protected parts
         TagUtil.addExtraTags(locTags, srcTags, report.translation);
 
+        if (isNumeralCheckEnabled()) {
+            inspectNumerals(srcTags, locTags, report);
+        }
+
         inspectOrderedTags(srcTags, locTags, Preferences.isPreference(Preferences.LOOSE_TAG_ORDERING), report);
+    }
+
+    /**
+     * Whether the current project checks numbers by value; on unless the
+     * project properties turn it off.
+     */
+    public static boolean isNumeralCheckEnabled() {
+        if (Core.getProject() == null) {
+            return true;
+        }
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        return props == null || props.isCheckNumbersEnabled();
+    }
+
+    /**
+     * The numeral check: numbers compare by value, not by spelling, whatever
+     * the writing system and whatever the custom-tag pattern. A source
+     * numeral - a custom tag or plain text alike - with no verbatim
+     * counterpart in the translation is satisfied by a translation numeral of
+     * equal value in any notation, so a value rewritten in the target's own
+     * number system raises no alarm while a changed or missing value still
+     * does. A separator-written number counts by each value its spelling can
+     * mean, so a decimal or grouped rewrite (a half as 0,5; a thousand as
+     * 1.000) is equal too, and the compatibility spelling counts as well,
+     * which covers the notations the numeral pattern cannot tokenize: a
+     * Roman code point written out with Latin letters, a vulgar fraction
+     * written with a plain slash. A satisfied numeral tag leaves the ordered
+     * tag check; a source numeral outside the tag machinery reports its
+     * missing value here.
+     */
+    static void inspectNumerals(List<Tag> srcTags, List<Tag> locTags, ErrorReport report) {
+        String translation = report.translation;
+        if (translation == null) {
+            return;
+        }
+        // Tokenize both sides, delegate tags inside larger numeral tokens
+        // (the digit runs of a decimal number) to the value check, and pool
+        // the values the translation offers outside its tags.
+        List<NumeralToken> offeredTokens = numeralTokens(translation, locTags);
+        subsumeTags(locTags, offeredTokens);
+        List<NumeralToken> sourceTokens = numeralTokens(report.source, srcTags);
+        subsumeTags(srcTags, sourceTokens);
+        List<List<NumeralValueParser.Rational>> offered = new ArrayList<>();
+        for (NumeralToken token : offeredTokens) {
+            if (!token.tagOwned && !token.values.isEmpty()) {
+                offered.add(token.values);
+            }
+        }
+        // Numeral tags match by value: a satisfied tag leaves the ordered
+        // tag check. One verbatim occurrence in the translation pairs one
+        // source tag there; only the tags beyond that budget match by value.
+        Map<String, Integer> verbatim = new HashMap<>();
+        for (Tag tag : locTags) {
+            verbatim.merge(tag.tag, 1, Integer::sum);
+        }
+        for (Iterator<Tag> it = srcTags.iterator(); it.hasNext();) {
+            Tag tag = it.next();
+            Optional<NumeralValueParser.Rational> value = NumeralValueParser.parseTokenValue(tag.tag,
+                    false);
+            if (value.isEmpty()) {
+                continue;
+            }
+            if (verbatim.getOrDefault(tag.tag, 0) > 0) {
+                verbatim.merge(tag.tag, -1, Integer::sum);
+                continue;
+            }
+            if (consume(offered, value.get()) || containsCompatibilityForm(translation, tag.tag)) {
+                it.remove();
+            }
+        }
+        // Source numerals outside the tag machinery get the same check.
+        for (NumeralToken token : sourceTokens) {
+            if (token.tagOwned || token.values.isEmpty()) {
+                continue;
+            }
+            boolean satisfied = false;
+            for (NumeralValueParser.Rational value : token.values) {
+                if (consume(offered, value)) {
+                    satisfied = true;
+                    break;
+                }
+            }
+            if (!satisfied && !containsCompatibilityForm(translation, token.text)) {
+                report.srcErrors.put(new Tag(token.start, token.text), TagError.MISSING);
+            }
+        }
+    }
+
+    /** One numeral spelling of a text, with every value it can mean. */
+    private static final class NumeralToken {
+        private final int start;
+        private final int end;
+        private final String text;
+        private final List<NumeralValueParser.Rational> values;
+        /** A tag reaching beyond this token owns it; the tag checks apply, not the value check. */
+        private final boolean tagOwned;
+
+        NumeralToken(int start, String text, List<NumeralValueParser.Rational> values, List<Tag> tags) {
+            this.start = start;
+            this.end = start + text.length();
+            this.text = text;
+            this.values = values;
+            this.tagOwned = tags.stream()
+                    .anyMatch(tag -> overlaps(tag) && !strictlyContains(tag));
+        }
+
+        private boolean overlaps(Tag tag) {
+            return start < tag.pos + tag.tag.length() && tag.pos < end;
+        }
+
+        /** Whether the tag lies inside this token without being all of it. */
+        private boolean strictlyContains(Tag tag) {
+            return tag.pos >= start && tag.pos + tag.tag.length() <= end
+                    && tag.tag.length() < text.length();
+        }
+    }
+
+    /**
+     * The numeral tokens of a text: each separator-written digit spelling as
+     * one token with its candidate values, each plain numeral with its single
+     * value. A separated spelling that reads as no number at all (an
+     * enumeration like 5,6,7) falls back to its plain digit runs, so those
+     * keep their ordinary checks.
+     */
+    private static List<NumeralToken> numeralTokens(String text, List<Tag> tags) {
+        List<NumeralToken> tokens = new ArrayList<>();
+        Matcher m = PatternConsts.NUMERALS_WITH_SEPARATORS.matcher(text);
+        while (m.find()) {
+            List<NumeralValueParser.Rational> values = NumeralValueParser
+                    .parseSeparatedValues(m.group(), false);
+            if (values.isEmpty() && !PatternConsts.NUMERALS.matcher(m.group()).matches()) {
+                Matcher plain = PatternConsts.NUMERALS.matcher(m.group());
+                while (plain.find()) {
+                    tokens.add(new NumeralToken(m.start() + plain.start(), plain.group(),
+                            NumeralValueParser.parseTokenValue(plain.group(), false).map(List::of)
+                                    .orElse(List.of()),
+                            tags));
+                }
+                continue;
+            }
+            tokens.add(new NumeralToken(m.start(), m.group(), values, tags));
+        }
+        return tokens;
+    }
+
+    /**
+     * Remove the tags that larger numeral tokens delegate to the value
+     * check: the digit runs of a decimal number must not demand verbatim
+     * pairing when the number as a whole matches by value.
+     */
+    private static void subsumeTags(List<Tag> tags, List<NumeralToken> tokens) {
+        tags.removeIf(tag -> tokens.stream().anyMatch(
+                token -> !token.tagOwned && !token.values.isEmpty() && token.strictlyContains(tag)));
+    }
+
+    /** Consume one offered token that can mean the value; false when none can. */
+    private static boolean consume(List<List<NumeralValueParser.Rational>> offered,
+            NumeralValueParser.Rational value) {
+        for (Iterator<List<NumeralValueParser.Rational>> it = offered.iterator(); it.hasNext();) {
+            if (it.next().contains(value)) {
+                it.remove();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether the translation spells the numeral in its compatibility form,
+     * as a whole: a spelling embedded in a longer word or number (the Roman
+     * twelve inside a thirteen or inside taxiing, a quarter inside an eleven
+     * forty-seconds) does not count.
+     */
+    private static boolean containsCompatibilityForm(String translation, String numeral) {
+        // U+2044 FRACTION SLASH, the separator of the decomposed vulgar fractions
+        String compat = NFKC.normalize(numeral).replace('\u2044', '/');
+        if (compat.equals(numeral)) {
+            return false;
+        }
+        return Pattern.compile(
+                "(?<!" + COMPAT_BOUNDARY + ")" + Pattern.quote(compat) + "(?!" + COMPAT_BOUNDARY + ")")
+                .matcher(translation).find();
     }
 
     public static void inspectRemovePattern(ErrorReport report) {

--- a/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -28,6 +28,7 @@ package org.omegat.core.team2;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -196,6 +197,60 @@ public class RemoteRepositoryProvider {
         return !getMappings(path).isEmpty();
     }
 
+    /**
+     * Whether every checked-out repository copy of the given project file is
+     * byte-identical to the file in the project directory, i.e. committing
+     * it would be a no-op. Only meaningful for files that are copied without
+     * EOL conversion, and after the repositories have been switched to a
+     * version.
+     */
+    public boolean isIdenticalInRepositories(String localPath) throws IOException {
+        File localFile = new File(projectRoot, localPath);
+        boolean found = false;
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile == null) {
+                continue;
+            }
+            if (!repoFile.exists() || !FileUtils.contentEquals(localFile, repoFile)) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
+    /**
+     * Like {@link #isIdenticalInRepositories}, but treating CRLF and LF line
+     * endings as equal: repository checkouts may re-line-end text files (git
+     * autocrlf on Windows), and that must not disguise an unchanged file as
+     * a change, whose empty commit then reports like a rejected push.
+     */
+    public boolean isIdenticalInRepositoriesIgnoringEol(String localPath) throws IOException {
+        File localFile = new File(projectRoot, localPath);
+        boolean found = false;
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile == null) {
+                continue;
+            }
+            if (!repoFile.exists() || !contentEqualsIgnoringEol(localFile, repoFile)) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
+    private static boolean contentEqualsIgnoringEol(File a, File b) throws IOException {
+        return normalizeEol(FileUtils.readFileToByteArray(a))
+                .equals(normalizeEol(FileUtils.readFileToByteArray(b)));
+    }
+
+    private static String normalizeEol(byte[] content) {
+        return new String(content, StandardCharsets.ISO_8859_1).replace("\r\n", "\n");
+    }
+
     public void cleanPrepared() throws IOException {
         FileUtils.deleteDirectory(new File(projectRoot, REPO_PREPARE_SUBDIR));
     }
@@ -297,6 +352,23 @@ public class RemoteRepositoryProvider {
         for (IRemoteRepository2 repo : repos.values()) {
             repo.commit(null, commentText);
         }
+    }
+
+    /**
+     * Same as commitFiles, but reports whether every affected repository
+     * accepted the commit: a rejected push (for example non-fast-forward)
+     * makes IRemoteRepository2.commit return null instead of throwing.
+     */
+    public boolean commitFilesChecked(String path, String commentText) throws Exception {
+        Map<String, IRemoteRepository2> repos = new TreeMap<>();
+        for (Mapping m : getMappings(path)) {
+            repos.put(m.repoDefinition.getUrl(), m.repo);
+        }
+        boolean accepted = true;
+        for (IRemoteRepository2 repo : repos.values()) {
+            accepted &= repo.commit(null, commentText) != null;
+        }
+        return accepted;
     }
 
     /**
@@ -509,6 +581,29 @@ public class RemoteRepositoryProvider {
          */
         public boolean matches() {
             return filterPrefix != null;
+        }
+
+        /**
+         * The file for the given project path inside this mapping's
+         * checked-out repository copy, or null when the path is outside the
+         * mapping.
+         */
+        @Nullable
+        File fileInRepository(String path) {
+            String p = withLeadingSlash(withoutTrailingSlash(path));
+            String local = withSlashes(repoMapping.getLocal());
+            String relative;
+            if (withTrailingSlash(p).equals(local)) {
+                // file mapping: the repository part is the file itself
+                relative = "";
+            } else if (p.startsWith(local)) {
+                relative = p.substring(local.length());
+            } else {
+                return null;
+            }
+            File base = new File(getRepositoryDir(repoDefinition),
+                    withoutLeadingSlash(repoMapping.getRepository()));
+            return new File(base, relative);
         }
 
         public void copyFromRepoToProject(final String postfix) throws IOException {

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
@@ -415,6 +415,14 @@ public class ProjectPropertiesDialog extends JDialog {
         gbc.anchor = GridBagConstraints.LINE_START;
         optionsBox.add(matchNumbersCheckBox, gbc);
 
+        // Numbers compared by value in the tag checks
+        Mnemonics.setLocalizedText(checkNumbersCheckBox, OStrings.getString("PP_CHECK_NUMBERS"));
+        checkNumbersCheckBox.setName(CHECK_NUMBERS_CB_NAME);
+        gbc.gridx = 0;
+        gbc.gridy = 4;
+        gbc.anchor = GridBagConstraints.LINE_START;
+        optionsBox.add(checkNumbersCheckBox, gbc);
+
         return optionsBox;
     }
     
@@ -667,6 +675,7 @@ public class ProjectPropertiesDialog extends JDialog {
         allowDefaultsCheckBox.setEnabled(false);
         removeTagsCheckBox.setEnabled(false);
         matchNumbersCheckBox.setEnabled(false);
+        checkNumbersCheckBox.setEnabled(false);
         externalCommandTextArea.setEnabled(false);
         insertButton.setEnabled(false);
         variablesList.setEnabled(false);
@@ -776,6 +785,9 @@ public class ProjectPropertiesDialog extends JDialog {
 
     // Numbers in fuzzy matching
     JCheckBox matchNumbersCheckBox = new JCheckBox();
+
+    // Numbers compared by value in the tag checks
+    JCheckBox checkNumbersCheckBox = new JCheckBox();
     JButton exportTMBrowse = new JButton();
     JButton sentenceSegmentingButton = new JButton();
 
@@ -839,6 +851,7 @@ public class ProjectPropertiesDialog extends JDialog {
     public static final String ALLOW_DEFAULTS_CB_NAME = "project_properties_allow_defaults_cb";
     public static final String REMOVE_TAGS_CB_NAME = "project_properties_remove_tags_cb";
     public static final String MATCH_NUMBERS_CB_NAME = "project_properties_match_numbers_cb";
+    public static final String CHECK_NUMBERS_CB_NAME = "project_properties_check_numbers_cb";
     public static final String EXPORT_TM_BROWSE_BUTTON_NAME = "project_properties_export_tm_browse_button";
     public static final String FILE_FILTER_BUTTON_NAME = "project_properties_file_filter_button";
     public static final String EXPORT_TM_ROOT_FIELD_NAME = "project_properties_export_tm_root_field";

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
@@ -128,6 +128,7 @@ public class ProjectPropertiesDialogController {
         dialog.allowDefaultsCheckBox.setSelected(projectProperties.isSupportDefaultTranslations());
         dialog.removeTagsCheckBox.setSelected(projectProperties.isRemoveTags());
         dialog.matchNumbersCheckBox.setSelected(projectProperties.isMatchNumbersEnabled());
+        dialog.checkNumbersCheckBox.setSelected(projectProperties.isCheckNumbersEnabled());
 
         dialog.sourceLocaleField.setSelectedItem(projectProperties.getSourceLanguage());
         dialog.targetLocaleField.setSelectedItem(projectProperties.getTargetLanguage());
@@ -546,6 +547,7 @@ public class ProjectPropertiesDialogController {
         projectProperties.setSupportDefaultTranslations(dialog.allowDefaultsCheckBox.isSelected());
         projectProperties.setRemoveTags(dialog.removeTagsCheckBox.isSelected());
         projectProperties.setMatchNumbersEnabled(dialog.matchNumbersCheckBox.isSelected());
+        projectProperties.setCheckNumbersEnabled(dialog.checkNumbersCheckBox.isSelected());
         projectProperties.setExportTmLevels(dialog.exportTMOmegaTCheckBox.isSelected(),
                 dialog.exportTMLevel1CheckBox.isSelected(), dialog.exportTMLevel2CheckBox.isSelected());
         projectProperties.setExternalCommand(dialog.externalCommandTextArea.getText());

--- a/src/main/java/org/omegat/gui/editor/MarkerController.java
+++ b/src/main/java/org/omegat/gui/editor/MarkerController.java
@@ -50,6 +50,7 @@ import org.omegat.gui.editor.mark.FontFallbackMarker;
 import org.omegat.gui.editor.mark.IMarker;
 import org.omegat.gui.editor.mark.Mark;
 import org.omegat.gui.editor.mark.NBSPMarker;
+import org.omegat.gui.editor.mark.NumeralMarker;
 import org.omegat.gui.editor.mark.ProtectedPartsMarker;
 import org.omegat.gui.editor.mark.RemoveTagMarker;
 import org.omegat.gui.editor.mark.ReplaceMarker;
@@ -81,6 +82,7 @@ public class MarkerController {
         Core.registerMarker(new ProtectedPartsMarker());
         Core.registerMarker(new RemoveTagMarker());
         Core.registerMarker(new NBSPMarker());
+        Core.registerMarker(new NumeralMarker());
         Core.registerMarker(new TransTipsMarker());
         Core.registerMarker(new BidiMarkers());
         Core.registerMarker(new ReplaceMarker());

--- a/src/main/java/org/omegat/gui/editor/mark/NumeralMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/NumeralMarker.java
@@ -1,0 +1,128 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.mark;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+
+import javax.swing.text.Highlighter.HighlightPainter;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.tagvalidation.TagValidation;
+import org.omegat.gui.editor.UnderlineFactory;
+import org.omegat.util.NumeralValueParser;
+import org.omegat.util.PatternConsts;
+import org.omegat.util.TagUtil;
+import org.omegat.util.TagUtil.Tag;
+import org.omegat.util.gui.Styles;
+
+/**
+ * Marker underlining the numerals the numeral check watches over, in the
+ * manner of the glossary match underline: every numeral of any writing
+ * system, in the source and in the translation, outside the tags. The
+ * marker has no view option of its own - it follows the per-project numeral
+ * check - and it ships without a color, so nothing is painted until the
+ * user picks a color under Options &gt; Preferences &gt; Colours.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class NumeralMarker implements IMarker {
+
+    @Override
+    public List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText, String translationText,
+            boolean isActive) {
+        // read per call so that color preference changes take effect
+        // without restarting the application
+        Color color = Styles.EditorColor.COLOR_NUMERALS.getColor();
+        if (color == null || !TagValidation.isNumeralCheckEnabled()) {
+            return null;
+        }
+        HighlightPainter underliner = new UnderlineFactory.SolidBoldUnderliner(color);
+
+        List<Mark> result = new ArrayList<>();
+        if (sourceText != null
+                && (isActive || Core.getEditor().getSettings().isDisplaySegmentSources()
+                        || translationText == null)) {
+            addMarks(result, Mark.ENTRY_PART.SOURCE, sourceText, ste, underliner);
+        }
+        if (translationText != null) {
+            addMarks(result, Mark.ENTRY_PART.TRANSLATION, translationText, ste, underliner);
+        }
+        return result;
+    }
+
+    private void addMarks(List<Mark> result, Mark.ENTRY_PART part, String text, SourceTextEntry ste,
+            HighlightPainter underliner) {
+        List<Tag> tags = tagSpans(text, ste);
+        Matcher m = PatternConsts.NUMERALS_WITH_SEPARATORS.matcher(text);
+        while (m.find()) {
+            if (overlapsTag(m.start(), m.end(), tags)) {
+                continue;
+            }
+            Mark mark = new Mark(part, m.start(), m.end());
+            mark.painter = underliner;
+            mark.toolTipText = toolTip(m.group());
+            result.add(mark);
+        }
+    }
+
+    /** The tags of the text; numerals inside them belong to the tag checks, not to this marker. */
+    private List<Tag> tagSpans(String text, SourceTextEntry ste) {
+        List<Tag> tags = ste == null ? new ArrayList<>()
+                : new ArrayList<>(TagUtil.buildTagList(text, ste.getProtectedParts()));
+        Matcher m = PatternConsts.OMEGAT_TAG.matcher(text);
+        while (m.find()) {
+            tags.add(new Tag(m.start(), m.group()));
+        }
+        return tags;
+    }
+
+    private boolean overlapsTag(int start, int end, List<Tag> tags) {
+        for (Tag tag : tags) {
+            if (start < tag.pos + tag.tag.length() && tag.pos < end) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The plain-digit value, for a numeral whose own spelling reads
+     * differently; a numeral already written in plain digits needs none,
+     * and an ambiguous separated spelling gets none either.
+     */
+    private String toolTip(String numeral) {
+        List<NumeralValueParser.Rational> values = NumeralValueParser.parseSeparatedValues(numeral, false);
+        if (values.size() != 1) {
+            return null;
+        }
+        String value = values.get(0).toString();
+        return value.equals(numeral) ? null : "= " + value;
+    }
+}

--- a/src/main/java/org/omegat/gui/editor/mark/NumeralMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/NumeralMarker.java
@@ -45,7 +45,7 @@ import org.omegat.util.gui.Styles;
 /**
  * Marker underlining the numerals the numeral check watches over, in the
  * manner of the glossary match underline: every numeral of any writing
- * system, in the source and in the translation, outside the tags. The
+ * system, in the source and in the translation, outside the real tags. The
  * marker has no view option of its own - it follows the per-project numeral
  * check - and it ships without a color, so nothing is painted until the
  * user picks a color under Options &gt; Preferences &gt; Colours.
@@ -92,10 +92,23 @@ public class NumeralMarker implements IMarker {
         }
     }
 
-    /** The tags of the text; numerals inside them belong to the tag checks, not to this marker. */
+    /**
+     * The real tags of the text; numerals inside them belong to the tag
+     * checks, not to this marker. A protected part that is itself a numeral
+     * the parser reads - typically a number turned into a custom tag by the
+     * default custom tag expression - is no tag to this marker: the numeral
+     * check compares such a part by value, exactly like a plain numeral, so
+     * the marker underlines it too.
+     */
     private List<Tag> tagSpans(String text, SourceTextEntry ste) {
-        List<Tag> tags = ste == null ? new ArrayList<>()
-                : new ArrayList<>(TagUtil.buildTagList(text, ste.getProtectedParts()));
+        List<Tag> tags = new ArrayList<>();
+        if (ste != null) {
+            for (Tag tag : TagUtil.buildTagList(text, ste.getProtectedParts())) {
+                if (NumeralValueParser.parseTokenValue(tag.tag, false).isEmpty()) {
+                    tags.add(tag);
+                }
+            }
+        }
         Matcher m = PatternConsts.OMEGAT_TAG.matcher(text);
         while (m.find()) {
             tags.add(new Tag(m.start(), m.group()));

--- a/src/main/java/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/main/java/org/omegat/gui/main/ProjectUICommands.java
@@ -40,7 +40,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
@@ -58,9 +60,12 @@ import org.omegat.convert.ConvertProject;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.KnownException;
+import org.omegat.core.data.IProject;
 import org.omegat.core.data.ProjectFactory;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.RuntimePreferenceStore;
+import org.omegat.core.data.TeamSetting;
+import org.omegat.core.data.TeamSettingsRegistry;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.segmentation.SRXManager;
@@ -329,13 +334,104 @@ public final class ProjectUICommands {
             protected void done() {
                 try {
                     get();
-                    SwingUtilities.invokeLater(Core.getEditor()::requestFocus);
+                    SwingUtilities.invokeLater(() -> {
+                        Core.getEditor().requestFocus();
+                        promptForSupersededSettings();
+                    });
                 } catch (Exception ex) {
                     Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                     Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                 }
             }
         }.execute();
+    }
+
+    /**
+     * The team's project settings file of the just opened team project
+     * carried different values than this checkout, and the team values are
+     * now active. Asks the user per setting what to do with the local value:
+     * share it with the team, use the team's value, or restore it for this
+     * session only - the next open supersedes and asks again. Dismissing a
+     * dialog leaves the team's value active.
+     */
+    private static void promptForSupersededSettings() {
+        IProject project = Core.getProject();
+        if (!project.isProjectLoaded()) {
+            return;
+        }
+        for (Map.Entry<String, @Nullable String> entry : project.getSupersededLocalSettings().entrySet()) {
+            TeamSetting setting = TeamSettingsRegistry.byKey(entry.getKey());
+            if (setting == null) {
+                continue;
+            }
+            String localValue = entry.getValue();
+            String teamValue = setting.read(project.getProjectProperties());
+            String[] options = { OStrings.getString("TEAM_SETTING_SHARE"),
+                    OStrings.getString("TEAM_SETTING_TAKE_TEAM"),
+                    OStrings.getString("TEAM_SETTING_KEEP_THIS_TIME") };
+            int answer = JOptionPane.showOptionDialog(Core.getMainWindow().getApplicationFrame(),
+                    OStrings.getString("TEAM_SETTING_DIVERGED_MESSAGE", setting.getDisplayName(),
+                            setting.describe(localValue), setting.describe(teamValue)),
+                    OStrings.getString("TEAM_SETTING_DIVERGED_TITLE"), JOptionPane.DEFAULT_OPTION,
+                    JOptionPane.QUESTION_MESSAGE, null, options, options[1]);
+            if (answer != 0 && answer != 1 && answer != 2) {
+                // Dismissed: the team's value stays active for this session,
+                // the local file keeps the local value, and the next open
+                // asks again.
+                continue;
+            }
+            boolean share = answer == 0;
+            String value = answer == 1 ? teamValue : localValue;
+            // The repository work must stay off the EDT and must not run
+            // beside the auto-save thread. Taking the team's value persists
+            // it locally, so the divergence is settled instead of
+            // resurfacing on every open.
+            new SwingWorker<Void, Void>() {
+                @Override
+                protected Void doInBackground() throws Exception {
+                    Core.executeExclusively(true, () -> {
+                        try {
+                            if (share) {
+                                project.publishProjectSetting(entry.getKey(), value);
+                            } else {
+                                project.useLocalProjectSetting(entry.getKey(), value);
+                            }
+                        } catch (Exception ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    });
+                    return null;
+                }
+
+                @Override
+                protected void done() {
+                    try {
+                        get();
+                    } catch (Exception ex) {
+                        String key = share ? "TEAM_SETTING_SHARE_ERROR" : "TEAM_SETTING_APPLY_ERROR";
+                        Log.logErrorRB(ex, key);
+                        Core.getMainWindow().displayErrorRB(ex, key);
+                    }
+                }
+            }.execute();
+        }
+    }
+
+    /** Session values of all registered team settings, keyed by setting key. */
+    private static Map<String, @Nullable String> readSessionTeamSettings() {
+        Map<String, @Nullable String> values = new HashMap<>();
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            values.put(setting.getKey(), setting.read(props));
+        }
+        return values;
+    }
+
+    private static void applySessionTeamSettings(Map<String, @Nullable String> values) {
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            setting.apply(props, values.get(setting.getKey()));
+        }
     }
 
     private static @Nullable File selectProjectRootFolder(File projectDirectory) {
@@ -864,18 +960,64 @@ public final class ProjectUICommands {
         // commit the current entry first
         Core.getEditor().commitAndLeave();
 
+        // The dialog edits the live properties, so the current values have
+        // to be captured before it is shown.
+        final Map<String, @Nullable String> teamSettingsBefore = readSessionTeamSettings();
+
         // displaying the dialog to change paths and other properties
         final ProjectProperties newProps =
                 ProjectPropertiesDialogController.showDialog(frame, Core.getProject().getProjectProperties(),
                 Core.getProject().getProjectProperties().getProjectName(),
                 ProjectPropertiesDialog.Mode.EDIT_PROJECT);
         if (newProps == null) {
+            // The dialog edits the live properties even before a validation
+            // stops its OK, so cancelling must not leave flipped values.
+            applySessionTeamSettings(teamSettingsBefore);
             return;
         }
+
+        // Changing a team setting right here is the natural moment to offer
+        // its distribution; declining keeps it local, and the next open of
+        // the project asks again.
+        final Map<String, @Nullable String> changedTeamSettings = new HashMap<>();
+        if (Core.getProject().isRemoteProject()) {
+            for (TeamSetting setting : TeamSettingsRegistry.all()) {
+                String after = setting.read(newProps);
+                if (!Objects.equals(teamSettingsBefore.get(setting.getKey()), after)) {
+                    changedTeamSettings.put(setting.getKey(), after);
+                }
+            }
+        }
+        final Map<String, @Nullable String> settingsToShare = new HashMap<>();
+        changedTeamSettings.forEach((key, value) -> {
+            TeamSetting setting = TeamSettingsRegistry.byKey(key);
+            if (setting != null && promptToShareSettingChange(setting, value)) {
+                settingsToShare.put(key, value);
+            }
+        });
 
         int res = JOptionPane.showConfirmDialog(frame, OStrings.getString("MW_REOPEN_QUESTION"),
                 OStrings.getString("MW_REOPEN_TITLE"), JOptionPane.YES_NO_OPTION);
         if (res != JOptionPane.YES_OPTION) {
+            if (!settingsToShare.isEmpty()) {
+                new SwingWorker<Void, Void>() {
+                    @Override
+                    protected Void doInBackground() throws Exception {
+                        Core.executeExclusively(true, () -> publishSettingsLoggingErrors(settingsToShare));
+                        return null;
+                    }
+
+                    @Override
+                    protected void done() {
+                        try {
+                            get();
+                        } catch (Exception ex) {
+                            Log.logErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                            Core.getMainWindow().displayErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                        }
+                    }
+                }.execute();
+            }
             return;
         }
 
@@ -885,10 +1027,30 @@ public final class ProjectUICommands {
             @Override
             protected Void doInBackground() throws Exception {
                 Core.executeExclusively(true, () -> {
+                    if (!settingsToShare.isEmpty()) {
+                        // A failed share must not abort the reload; the
+                        // local file keeps the value, so the next open
+                        // offers the distribution again.
+                        publishSettingsLoggingErrors(settingsToShare);
+                    }
                     Core.getProject().saveProject(true);
                     ProjectFactory.closeProject();
 
                     ProjectFactory.loadProject(newProps, true);
+                    changedTeamSettings.forEach((key, value) -> {
+                        if (!settingsToShare.containsKey(key)) {
+                            // The share was declined, so the freshly chosen
+                            // value must stay local: without this, the
+                            // reload would classify it as local-only
+                            // divergence and fall back to the team default
+                            // without a word.
+                            try {
+                                Core.getProject().useLocalProjectSetting(key, value);
+                            } catch (Exception ex) {
+                                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                            }
+                        }
+                    });
                 });
                 return null;
             }
@@ -908,6 +1070,32 @@ public final class ProjectUICommands {
                 }
             }
         }.execute();
+    }
+
+    /**
+     * The properties dialog of a team project just changed a registered
+     * team setting; asks whether to distribute the change.
+     */
+    private static boolean promptToShareSettingChange(TeamSetting setting, @Nullable String value) {
+        String[] options = { OStrings.getString("TEAM_SETTING_SHARE"),
+                OStrings.getString("TEAM_SETTING_KEEP_FOR_NOW") };
+        return JOptionPane.showOptionDialog(Core.getMainWindow().getApplicationFrame(),
+                OStrings.getString("TEAM_SETTING_CHANGED_MESSAGE", setting.getDisplayName(),
+                        setting.describe(value)),
+                OStrings.getString("TEAM_SETTING_DIVERGED_TITLE"), JOptionPane.DEFAULT_OPTION,
+                JOptionPane.QUESTION_MESSAGE, null, options, options[0]) == 0;
+    }
+
+    private static void publishSettingsLoggingErrors(Map<String, @Nullable String> settings) {
+        settings.forEach((key, value) -> {
+            try {
+                Core.getProject().publishProjectSetting(key, value);
+            } catch (Exception ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                SwingUtilities.invokeLater(
+                        () -> Core.getMainWindow().displayErrorRB(ex, "TEAM_SETTING_SHARE_ERROR"));
+            }
+        });
     }
 
     public static void projectCompile() {

--- a/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
@@ -403,20 +403,50 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
      * Render the given source number in the digit script of the target token it
      * replaces, which is what makes a full-width target keep full-width digits
      * (feature request #1193). A target written in a system this code cannot
-     * write back, a Han numeral for one, receives plain digits instead: the right
-     * number in a foreign notation beats the wrong number in the right one.
+     * write back, a Tamil numeral for one, receives plain digits instead: the
+     * right number in a foreign notation beats the wrong number in the right
+     * one.
      */
     private static String renderLike(String number, String template) {
         int zero = digitZeroOf(template);
         if (zero < 0) {
+            // The target writes a numeral system, not digits: write the source
+            // value in that system, whatever system the source itself uses.
+            Optional<NumeralValueParser.Rational> sourceValue = NumeralValueParser.parseTokenValue(number,
+                    ALLOW_ROMAN);
+            if (sourceValue.isPresent()) {
+                if (BigInteger.ONE.equals(sourceValue.get().denominator())) {
+                    Optional<String> rendered = NumeralValueParser
+                            .renderInSystemOf(sourceValue.get().numerator(), template);
+                    if (rendered.isPresent()) {
+                        return rendered.get();
+                    }
+                } else {
+                    // A fraction value: a vulgar-fraction target receives the
+                    // matching precomposed glyph; a value without a glyph is
+                    // spelled out, because the right number in a foreign
+                    // notation beats the target's own, wrong one.
+                    Optional<String> glyph = NumeralValueParser
+                            .renderVulgarFractionOf(sourceValue.get(), template);
+                    return glyph.orElseGet(() -> sourceValue.get().numerator() + "/"
+                            + sourceValue.get().denominator());
+                }
+            }
             return StringUtil.normalizeWidth(number);
         }
         if (!hasDecimalDigit(number)) {
-            // The source number is written in an algorithmic system (a Han
-            // numeral) while the target writes digits: spell the value out.
-            Optional<BigInteger> value = NumeralValueParser.parseTokenWhole(number, ALLOW_ROMAN);
+            // The source number is written in a non-digit system (a Han
+            // numeral, a sign numeral such as cuneiform or Ethiopic) while
+            // the target writes digits: spell the whole value out.
+            Optional<NumeralValueParser.Rational> value = NumeralValueParser.parseTokenValue(number,
+                    ALLOW_ROMAN);
             if (value.isPresent()) {
-                return toDigitScript(value.get().toString(), zero);
+                if (BigInteger.ONE.equals(value.get().denominator())) {
+                    return toDigitScript(value.get().numerator().toString(), zero);
+                }
+                // A fractional sign value is spelled out as a digit fraction
+                // in the target's digit script.
+                return toDigitScript(value.get().numerator() + "/" + value.get().denominator(), zero);
             }
         }
         return toDigitScript(number, zero);

--- a/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
@@ -41,14 +41,15 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.io.File;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -78,6 +79,8 @@ import org.omegat.gui.preferences.PreferencesWindowController;
 import org.omegat.gui.preferences.view.TMMatchesPreferencesController;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
 import org.omegat.tokenizer.ITokenizer;
+import org.omegat.util.NumeralValueParser;
+import org.omegat.util.NumeralValueParser.Rational;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
@@ -329,29 +332,34 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
         List<String> sourceNumbers = Stream.of(sourceTok.tokenizeVerbatimToStrings(source))
                 .filter(MatchesTextArea::isNumber).collect(Collectors.toList());
 
-        // Compare and map numbers on their width-normalized form so that
-        // full-width (ASCII) digits (U+FF10-U+FF19, common in Japanese) are
-        // treated as equivalent to their half-width counterparts. See feature
-        // request #1193.
-        List<String> normSourceMatchNumbers = normalizeDigitWidth(sourceMatchNumbers);
-        List<String> normTargetMatchNumbers = normalizeDigitWidth(targetMatchNumbers);
+        // Compare and pair the numbers by their value, not by their spelling, so
+        // that the same number written differently counts as the same number:
+        // decimal digits of any script including full-width ones (feature
+        // request #1193) and Han numerals. What counts as one number is the
+        // tokenizer's decision, so a percentage or a dotted date, which arrive
+        // as a single token without a value, are out of reach here.
+        List<Rational> sourceMatchValues = values(sourceMatchNumbers);
+        List<Rational> targetMatchValues = values(targetMatchNumbers);
 
         if (sourceMatchNumbers.size() != sourceNumbers.size()
                 || sourceMatchNumbers.size() != targetMatchNumbers.size()
-                || !new HashSet<>(normSourceMatchNumbers).equals(new HashSet<>(normTargetMatchNumbers))) {
+                || !sameNumbers(sourceMatchValues, targetMatchValues)) {
             return targetMatch;
         }
 
-        Map<Integer, Integer> locationMap = mapIndices(normSourceMatchNumbers, normTargetMatchNumbers);
+        // Map each target number to the source number belonging there. Asking in
+        // that direction keeps the mapping correct for any permutation of the
+        // numbers, and complete for repeated numbers.
+        Map<Integer, Integer> locationMap = mapIndices(targetMatchValues, sourceMatchValues);
 
-        // Substitute new numbers in the target match. The inserted number
-        // adopts the digit width of the target token it replaces, so the
-        // target match's digit convention is preserved.
+        // Substitute new numbers in the target match. The inserted number adopts
+        // the notation of the target token it replaces, so the target match's own
+        // convention is preserved.
         StringBuilder result = new StringBuilder();
         int i = 0;
         for (String tok : targetTokens) {
             if (isNumber(tok)) {
-                result.append(toDigitWidthOf(sourceNumbers.get(locationMap.get(i)), tok));
+                result.append(renderLike(sourceNumbers.get(locationMap.get(i)), tok));
                 i++;
             } else {
                 result.append(tok);
@@ -361,67 +369,119 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
         return result.toString();
     }
 
-    /**
-     * Return a copy of the given number strings with every digit normalized to
-     * half-width, so that full-width and half-width digits compare equal.
-     * Feature request #1193.
-     */
-    private static List<String> normalizeDigitWidth(List<String> numbers) {
-        return numbers.stream().map(StringUtil::normalizeWidth).collect(Collectors.toList());
+    /** The values of number tokens that {@link #isNumber} accepted. */
+    private static List<Rational> values(List<String> numbers) {
+        return numbers.stream()
+                .map(n -> NumeralValueParser.parseTokenValue(n, ALLOW_ROMAN).orElseThrow())
+                .collect(Collectors.toList());
     }
 
     /**
-     * Render the given number with the digit width used by the template token:
-     * full-width when the template contains full-width digits, half-width
-     * otherwise. This makes a substituted number follow the target match's
-     * digit convention. Feature request #1193.
+     * Whether both lists hold the same numbers with the same multiplicities.
+     * Comparing as multisets rather than as sets keeps a repeated number from
+     * standing in for a missing one, which would leave a target number without a
+     * counterpart.
      */
-    private static String toDigitWidthOf(String number, String template) {
-        return hasFullwidthDigit(template) ? toFullwidthDigits(number)
-                : StringUtil.normalizeWidth(number);
+    private static boolean sameNumbers(List<Rational> first, List<Rational> second) {
+        Map<Rational, Integer> pending = new HashMap<>();
+        first.forEach(value -> pending.merge(value, 1, Integer::sum));
+        for (Rational value : second) {
+            Integer count = pending.get(value);
+            if (count == null) {
+                return false;
+            }
+            if (count == 1) {
+                pending.remove(value);
+            } else {
+                pending.put(value, count - 1);
+            }
+        }
+        return pending.isEmpty();
     }
 
-    private static boolean hasFullwidthDigit(String text) {
-        for (int i = 0; i < text.length(); i++) {
-            char c = text.charAt(i);
-            if (c >= '０' && c <= '９') {
+    /**
+     * Render the given source number in the digit script of the target token it
+     * replaces, which is what makes a full-width target keep full-width digits
+     * (feature request #1193). A target written in a system this code cannot
+     * write back, a Han numeral for one, receives plain digits instead: the right
+     * number in a foreign notation beats the wrong number in the right one.
+     */
+    private static String renderLike(String number, String template) {
+        int zero = digitZeroOf(template);
+        if (zero < 0) {
+            return StringUtil.normalizeWidth(number);
+        }
+        if (!hasDecimalDigit(number)) {
+            // The source number is written in an algorithmic system (a Han
+            // numeral) while the target writes digits: spell the value out.
+            Optional<BigInteger> value = NumeralValueParser.parseTokenWhole(number, ALLOW_ROMAN);
+            if (value.isPresent()) {
+                return toDigitScript(value.get().toString(), zero);
+            }
+        }
+        return toDigitScript(number, zero);
+    }
+
+    private static boolean hasDecimalDigit(String text) {
+        for (int i = 0; i < text.length();) {
+            int cp = text.codePointAt(i);
+            if (Character.digit(cp, 10) >= 0) {
                 return true;
             }
+            i += Character.charCount(cp);
         }
         return false;
     }
 
-    private static String toFullwidthDigits(String number) {
+    /**
+     * The code point of digit zero in the script of the template's first decimal
+     * digit, or -1 when the template holds no decimal digit.
+     */
+    private static int digitZeroOf(String template) {
+        for (int i = 0; i < template.length();) {
+            int cp = template.codePointAt(i);
+            int digit = Character.digit(cp, 10);
+            if (digit >= 0) {
+                return cp - digit;
+            }
+            i += Character.charCount(cp);
+        }
+        return -1;
+    }
+
+    /** The number with every decimal digit rewritten in the given digit script. */
+    private static String toDigitScript(String number, int zero) {
         StringBuilder sb = new StringBuilder(number.length());
-        for (int i = 0; i < number.length(); i++) {
-            char c = number.charAt(i);
-            sb.append(c >= '0' && c <= '9' ? (char) (c - '0' + 0xFF10) : c);
+        for (int i = 0; i < number.length();) {
+            int cp = number.codePointAt(i);
+            int digit = Character.digit(cp, 10);
+            sb.appendCodePoint(digit < 0 ? cp : zero + digit);
+            i += Character.charCount(cp);
         }
         return sb.toString();
     }
 
     /**
-     * Determine whether the given string is a number. Integers and simple
-     * doubles (not localized) are recognized.
+     * Whether a Roman numeral written with Latin letters counts as a number when
+     * inserting a match. It does not: "I", "V", "X", "MIX" and "DIV" are ordinary
+     * uppercase words at least as often as they are numbers, and here a false
+     * positive does not cost a few similarity points, it rewrites the text the
+     * translator is handed. Roman numerals written with the dedicated code points
+     * are unambiguous and remain numbers.
+     */
+    private static final boolean ALLOW_ROMAN = false;
+
+    /**
+     * Determine whether the given string is a number: a token that may be read
+     * as one and has an exact value. Decimal digits of every script, Han
+     * numerals, decimals and fractions are recognized; ordinary words are not.
      *
      * @param text
      *            A string
      * @return True if the string represents a number
      */
     private static boolean isNumber(String text) {
-        try {
-            Integer.parseInt(text);
-            return true;
-        } catch (NumberFormatException nfe) {
-            // Eat exception silently
-        }
-        try {
-            Double.parseDouble(text);
-            return true;
-        } catch (NumberFormatException nfe) {
-            // Eat exception silently
-        }
-        return false;
+        return NumeralValueParser.parseTokenValue(text, ALLOW_ROMAN).isPresent();
     }
 
     /**

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -29,12 +29,16 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParsePosition;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import com.ibm.icu.lang.UCharacter;
+import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.RuleBasedNumberFormat;
 import com.ibm.icu.util.ULocale;
@@ -55,8 +59,7 @@ import com.ibm.icu.util.ULocale;
  *
  * A value is only returned when a candidate system consumes the WHOLE (trimmed)
  * string, so partial or ambiguous input is rejected and the caller can fall
- * back to plain text ordering. Kaktovik/Inuktitut numerals are not available in
- * the bundled ICU version and are therefore not recognized.
+ * back to plain text ordering.
  *
  * On top of the integer core, {@link #parseValue} and {@link #firstValue}
  * expose signed real numbers as an exact reduced {@link Rational}
@@ -71,13 +74,15 @@ import com.ibm.icu.util.ULocale;
  * irreducibly locale-ambiguous), so "1,000" and "1,5" contribute only their
  * leading integer. Division by zero yields no value.
  *
- * As a final step, a single code point that carries a Unicode numeric value but
- * is neither a decimal digit nor an algorithmic numeral is resolved from its
- * value: enclosed and parenthesized numbers and many
- * historic script numerals (Aegean, cuneiform, Aramaic, Greek acrophonic ...).
- * Only single, non-negative integer values are taken; multi-sign additive
- * sequences are not composed. Symbols without a numeric value (such as the emoji
- * for a hundred points or the keycap ten) are correctly ignored.
+ * As a final step, code points that carry a Unicode numeric value but are
+ * neither decimal digits nor algorithmic numerals are resolved from their
+ * values: enclosed and parenthesized numbers and many historic script numerals
+ * (Aegean, cuneiform, Aramaic, Greek acrophonic ...). A single sign is taken
+ * directly, including small exact fractions; a sequence of signs from one of
+ * the named numeral blocks reads positionally where the block is a digit block
+ * (Mayan and Kaktovik, base twenty) and as an additive largest-first sum
+ * otherwise. Symbols without a numeric value (such as the emoji for a hundred
+ * points or the keycap ten) are correctly ignored.
  *
  * The class is stateless from the caller's perspective; the (non-thread-safe)
  * ICU formatters are cached per thread.
@@ -164,6 +169,12 @@ public final class NumeralValueParser {
             return decimal;
         }
         if (!mayBeAlgorithmicNumeral(s)) {
+            return Optional.empty();
+        }
+        // No rule set reads the sign-block scripts, so their tokens would fail
+        // through every parser at real cost; the sign-value path reads them.
+        // (Number Forms come back here through their NFKC form, which is Latin.)
+        if (SIGN_BLOCKS.contains(Character.UnicodeBlock.of(s.codePointAt(0)))) {
             return Optional.empty();
         }
         for (RuleBasedNumberFormat parser : PARSERS.get()) {
@@ -618,19 +629,23 @@ public final class NumeralValueParser {
         if (algorithmic.isPresent()) {
             return algorithmic;
         }
-        // Last resort: a single Nl/No code point that carries a Unicode numeric
-        // value but is neither a decimal digit nor an algorithmic numeral -
-        // enclosed/parenthesized numbers and many historic script
-        // numerals (Aegean, cuneiform, Aramaic, Greek acrophonic ...). Only a
-        // single, non-negative integer value is taken; fractional forms and
-        // multi-sign additive sequences are left for a later, dedicated step.
-        return singleCodePointNumericValue(u);
+        // Last resort: sign numerals read through their Unicode numeric values -
+        // enclosed/parenthesized numbers and the historic script numerals
+        // (Aegean, cuneiform, Aramaic, Greek acrophonic ...). A single code
+        // point is taken directly; a sequence of signs from one block is read
+        // positionally where the block is a digit block, additively otherwise.
+        Optional<Rational> single = singleCodePointNumericValue(u);
+        if (single.isPresent()) {
+            return single;
+        }
+        return signSequenceValue(u);
     }
 
     /**
      * The value of a single Nl/No code point via its Unicode numeric value, if it
-     * is a non-negative integer. Symbols without a numeric value, the emoji for a
-     * hundred points or the keycap ten say, and fractional values yield empty.
+     * is non-negative. Small exact fractions (a cuneiform two-thirds, a North
+     * Indic quarter) resolve to their rational; symbols without a numeric value,
+     * the emoji for a hundred points or the keycap ten say, yield empty.
      */
     private static Optional<Rational> singleCodePointNumericValue(String u) {
         if (u.codePointCount(0, u.length()) != 1) {
@@ -642,10 +657,84 @@ public final class NumeralValueParser {
             return Optional.empty();
         }
         double v = UCharacter.getUnicodeNumericValue(cp);
-        if (v == UCharacter.NO_NUMERIC_VALUE || v < 0 || Double.isInfinite(v) || v != Math.floor(v)) {
+        if (v == UCharacter.NO_NUMERIC_VALUE || v < 0 || Double.isInfinite(v)) {
             return Optional.empty();
         }
-        return Optional.of(Rational.ofInteger(BigDecimal.valueOf(v).toBigIntegerExact()));
+        if (v == Math.floor(v)) {
+            return Optional.of(Rational.ofInteger(BigDecimal.valueOf(v).toBigIntegerExact()));
+        }
+        return rationalize(v);
+    }
+
+    /**
+     * The denominators Unicode numeric values of fractional numerals use; the
+     * largest (320) belongs to the Tamil and Malayalam fraction series.
+     */
+    private static final int[] FRACTION_DENOMINATORS = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16, 20, 32, 40,
+            64, 80, 160, 320 };
+
+    /** A small exact fraction for a Unicode numeric value, if one matches. */
+    private static Optional<Rational> rationalize(double v) {
+        for (int den : FRACTION_DENOMINATORS) {
+            double num = v * den;
+            if (Math.abs(num - Math.rint(num)) < 1e-9) {
+                return Optional.of(Rational.of(BigInteger.valueOf((long) Math.rint(num)),
+                        BigInteger.valueOf(den)));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * The value of a sequence of numeral signs from one Unicode block. A digit
+     * block (a contiguous zero-based run of sign values: Mayan and Kaktovik,
+     * base twenty) reads positionally; any other block reads as an additive
+     * sum, provided the signs come largest first (the canonical order of the
+     * additive systems) - an ascending pair rejects the token, so a
+     * multiplicative notation such as Tamil is never misread as a sum.
+     */
+    private static Optional<Rational> signSequenceValue(String u) {
+        int count = u.codePointCount(0, u.length());
+        if (count < 2 || count > MAX_COMPOSED_SIGNS) {
+            return Optional.empty();
+        }
+        Character.UnicodeBlock block = Character.UnicodeBlock.of(u.codePointAt(0));
+        if (block == null || !SIGN_BLOCKS.contains(block)) {
+            return Optional.empty();
+        }
+        List<BigInteger> sequence = new ArrayList<>();
+        for (int i = 0; i < u.length();) {
+            int cp = u.codePointAt(i);
+            int type = Character.getType(cp);
+            double v = UCharacter.getUnicodeNumericValue(cp);
+            if (!block.equals(Character.UnicodeBlock.of(cp))
+                    || (type != Character.LETTER_NUMBER && type != Character.OTHER_NUMBER)
+                    || (type == Character.OTHER_NUMBER && UCharacter.getIntPropertyValue(cp,
+                            UProperty.DECOMPOSITION_TYPE) != UCharacter.DecompositionType.NONE)
+                    || v == UCharacter.NO_NUMERIC_VALUE || v < 0 || v != Math.floor(v)) {
+                return Optional.empty();
+            }
+            sequence.add(BigDecimal.valueOf(v).toBigIntegerExact());
+            i += Character.charCount(cp);
+        }
+        Optional<BigInteger> base = positionalBase(blockSigns(u.codePointAt(0)));
+        if (base.isPresent()) {
+            BigInteger value = BigInteger.ZERO;
+            for (BigInteger digit : sequence) {
+                value = value.multiply(base.get()).add(digit);
+            }
+            return Optional.of(Rational.ofInteger(value));
+        }
+        BigInteger sum = BigInteger.ZERO;
+        BigInteger previous = null;
+        for (BigInteger sign : sequence) {
+            if (previous != null && sign.compareTo(previous) > 0) {
+                return Optional.empty();
+            }
+            sum = sum.add(sign);
+            previous = sign;
+        }
+        return Optional.of(Rational.ofInteger(sum));
     }
 
     private static boolean hasDecimalDigit(String s) {
@@ -777,9 +866,14 @@ public final class NumeralValueParser {
      *
      * Two boundaries are deliberate. A Roman form without I, V or X is rejected,
      * because "L", "C", "D" and "M" stand for a unit or an abbreviation far more
-     * often than for 50, 100, 500 and 1000. And a Number-Other code point is not
-     * a numeral token, which keeps a superscript exponent, a vulgar fraction and
-     * an enclosed number out of the number comparisons.
+     * often than for 50, 100, 500 and 1000. And a Number-Other code point counts
+     * only when it is a plain numeral or a precomposed vulgar fraction: the
+     * other presentation forms carrying a compatibility decomposition (a
+     * superscript exponent, an enclosed number) and the decoration-number
+     * symbol blocks (dingbat and negative circled digits, which carry no
+     * decomposition) stay out of the number comparisons, while the numeral
+     * systems encoded exclusively in that category (Ethiopic, Aegean, Mayan,
+     * Kaktovik, Meroitic and others) stay in.
      */
     private static boolean isNumeralToken(String text, boolean allowRoman) {
         if (text == null || text.isEmpty()) {
@@ -791,6 +885,13 @@ public final class NumeralValueParser {
             if (type == Character.DECIMAL_DIGIT_NUMBER || type == Character.LETTER_NUMBER) {
                 return true;
             }
+            if (type == Character.OTHER_NUMBER
+                    && (UCharacter.getIntPropertyValue(cp,
+                            UProperty.DECOMPOSITION_TYPE) == UCharacter.DecompositionType.NONE
+                            || VULGAR.containsKey(cp))
+                    && !SYMBOL_NUMBER_BLOCKS.contains(Character.UnicodeBlock.of(cp))) {
+                return true;
+            }
             i += Character.charCount(cp);
         }
         return allowRoman && CANONICAL_ROMAN.matcher(text).matches()
@@ -799,10 +900,266 @@ public final class NumeralValueParser {
     }
 
     /**
+     * Render a non-negative whole value in the numeral system the template
+     * numeral is written in, or empty when that system cannot be written.
+     *
+     * Two writers are tried. The algorithmic systems go through the same ICU
+     * rule sets that read them: whichever rule set consumes the template also
+     * formats the value (Ethiopic, Roman, Greek, Hebrew, Armenian, Tamil,
+     * Georgian, Cyrillic, Han). Sign systems are composed from the template's
+     * own Unicode block: a block whose signs form a contiguous digit run
+     * starting at zero is written positionally in that base (Mayan and
+     * Kaktovik, base twenty), any other block is written greedily as an
+     * additive sequence of its sign values, largest first (Aegean, Meroitic,
+     * cuneiform), and only an exact composition of reasonable length is
+     * returned.
+     */
+    public static Optional<String> renderInSystemOf(BigInteger value, String template) {
+        if (value == null || value.signum() < 0 || template == null || template.isEmpty()) {
+            return Optional.empty();
+        }
+        String trimmed = template.trim();
+        Optional<String> algorithmic = renderAlgorithmic(value, trimmed);
+        if (algorithmic.isPresent()) {
+            return algorithmic;
+        }
+        if (Character.UnicodeBlock.NUMBER_FORMS
+                .equals(Character.UnicodeBlock.of(trimmed.codePointAt(0)))) {
+            return renderRomanForms(value, trimmed);
+        }
+        return composeFromBlockOf(value, trimmed.codePointAt(0));
+    }
+
+    /** Write the value with the ICU rule set that owns the template's system, or empty. */
+    private static Optional<String> renderAlgorithmic(BigInteger value, String trimmed) {
+        for (RuleBasedNumberFormat parser : PARSERS.get()) {
+            ParsePosition pp = new ParsePosition(0);
+            Number read;
+            try {
+                read = parser.parse(trimmed, pp);
+            } catch (RuntimeException ex) {
+                continue;
+            }
+            if (read == null || pp.getIndex() != trimmed.length() || Double.isNaN(read.doubleValue())) {
+                continue;
+            }
+            // A NUMBERING_SYSTEM instance parses with every rule set it
+            // knows, not only its default: only the instance that writes
+            // the template back verbatim owns the template's system.
+            try {
+                if (!trimmed.equals(parser.format(read.longValue()))) {
+                    continue;
+                }
+            } catch (RuntimeException ex) {
+                continue;
+            }
+            try {
+                String written = parser.format(value.longValueExact());
+                // Out-of-range values make RBNF fall back to grouped decimal
+                // digits; that is not the template's system.
+                return hasDecimalDigit(written) ? Optional.empty() : Optional.of(written);
+            } catch (RuntimeException ex) {
+                // The owning system cannot write this value at all.
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** The single-letter Roman forms at U+2160/U+2170, index-aligned with {@link #ROMAN_DIGITS}. */
+    private static final String ROMAN_FORMS = "ⅠⅤⅩⅬⅭⅮⅯ"
+            + "ⅰⅴⅹⅼⅽⅾⅿ";
+
+    /**
+     * Write the value with the Number Forms Roman code points. Their greedy
+     * additive composition would be invalid notation (forty is not four
+     * twelves), so the block's letter numerals go through NFKC to ASCII
+     * Roman, the Roman rule sets write the value subtractively in the
+     * template's case, and the letters map back to the single-letter forms.
+     * The rest of the block (Claudian signs, turned digits) stays unwritable.
+     */
+    private static Optional<String> renderRomanForms(BigInteger value, String trimmed) {
+        String ascii = NFKC.normalize(trimmed);
+        Optional<String> written = ascii.equals(trimmed) ? Optional.empty()
+                : renderAlgorithmic(value, ascii);
+        if (written.isEmpty()) {
+            return Optional.empty();
+        }
+        String letters = written.get();
+        boolean lower = Character.isLowerCase(letters.charAt(0));
+        // One through twelve have precomposed forms; prefer those.
+        if (value.signum() > 0 && value.compareTo(BigInteger.valueOf(12)) <= 0) {
+            return Optional.of(String.valueOf((char) ((lower ? 'ⅰ' : 'Ⅰ') + value.intValueExact() - 1)));
+        }
+        StringBuilder mapped = new StringBuilder();
+        for (char letter : letters.toCharArray()) {
+            int index = ROMAN_DIGITS.indexOf(letter);
+            if (index < 0) {
+                return Optional.empty();
+            }
+            mapped.append(ROMAN_FORMS.charAt(index));
+        }
+        return Optional.of(mapped.toString());
+    }
+
+    /**
+     * Render an exact fraction as a precomposed vulgar-fraction glyph, when
+     * the template numeral is such a glyph itself and a glyph carrying
+     * exactly the value exists; empty otherwise. The counterpart of
+     * {@link #renderInSystemOf} for the non-integer values.
+     */
+    public static Optional<String> renderVulgarFractionOf(Rational value, String template) {
+        if (value == null || template == null || template.isEmpty()) {
+            return Optional.empty();
+        }
+        String trimmed = template.trim();
+        if (trimmed.codePointCount(0, trimmed.length()) != 1
+                || !VULGAR.containsKey(trimmed.codePointAt(0))) {
+            return Optional.empty();
+        }
+        return VULGAR.entrySet().stream().filter(e -> e.getValue().equals(value))
+                .map(e -> new String(Character.toChars(e.getKey()))).findFirst();
+    }
+
+    /** Longest sign sequence a block composition may produce or read. */
+    private static final int MAX_COMPOSED_SIGNS = 24;
+
+    /** Largest base a digit block may declare; Mayan and Kaktovik use twenty. */
+    private static final int MAX_POSITIONAL_BASE = 20;
+
+    /**
+     * The Unicode blocks whose signs compose to numbers, both when reading a
+     * sign sequence and when writing a value. An allowlist, because a block
+     * that merely happens to contain number-valued symbols (the dingbat
+     * circled digits, say) must never be read or written as a numeral system.
+     * Blocks a JDK does not know are skipped: their numerals simply stay
+     * single-sign.
+     */
+    private static final Set<Character.UnicodeBlock> SIGN_BLOCKS = namedBlocks("AEGEAN NUMBERS",
+            "CUNEIFORM NUMBERS AND PUNCTUATION", "MAYAN NUMERALS", "KAKTOVIK NUMERALS",
+            "MEROITIC CURSIVE", "COUNTING ROD NUMERALS", "ANCIENT GREEK NUMBERS",
+            "OTTOMAN SIYAQ NUMBERS", "INDIC SIYAQ NUMBERS", "MEDEFAIDRIN", "KHAROSHTHI", "PHOENICIAN",
+            "NUMBER FORMS");
+
+    /**
+     * Symbol blocks whose number-valued code points are decorations rather
+     * than numerals (list bullets, dingbats); they carry no compatibility
+     * decomposition, so they need naming.
+     */
+    private static final Set<Character.UnicodeBlock> SYMBOL_NUMBER_BLOCKS = namedBlocks(
+            "DINGBATS", "ENCLOSED ALPHANUMERICS", "ENCLOSED ALPHANUMERIC SUPPLEMENT",
+            "ENCLOSED CJK LETTERS AND MONTHS", "ENCLOSED IDEOGRAPHIC SUPPLEMENT");
+
+    private static Set<Character.UnicodeBlock> namedBlocks(String... names) {
+        Set<Character.UnicodeBlock> blocks = new HashSet<>();
+        for (String name : names) {
+            try {
+                blocks.add(Character.UnicodeBlock.forName(name));
+            } catch (IllegalArgumentException unknownInThisJdk) {
+                continue;
+            }
+        }
+        return Set.copyOf(blocks);
+    }
+
+    /** The numeral signs of the given code point's block, by integer value. */
+    private static TreeMap<BigInteger, Integer> blockSigns(int templateCp) {
+        TreeMap<BigInteger, Integer> signs = new TreeMap<>();
+        Character.UnicodeBlock block = Character.UnicodeBlock.of(templateCp);
+        if (block == null || !SIGN_BLOCKS.contains(block)) {
+            return signs;
+        }
+        for (int cp = Math.max(0, templateCp - 0x100); cp <= templateCp + 0x100; cp++) {
+            if (!block.equals(Character.UnicodeBlock.of(cp))) {
+                continue;
+            }
+            int type = Character.getType(cp);
+            if (type != Character.OTHER_NUMBER && type != Character.LETTER_NUMBER) {
+                continue;
+            }
+            // Presentation forms are filtered by their decomposition; letter
+            // numerals keep theirs (a Roman code point decomposes to letters
+            // and is a numeral all the same).
+            if (type == Character.OTHER_NUMBER && UCharacter.getIntPropertyValue(cp,
+                    UProperty.DECOMPOSITION_TYPE) != UCharacter.DecompositionType.NONE) {
+                continue;
+            }
+            double numeric = UCharacter.getUnicodeNumericValue(cp);
+            if (numeric == UCharacter.NO_NUMERIC_VALUE || numeric < 0 || numeric != Math.floor(numeric)) {
+                continue;
+            }
+            signs.putIfAbsent(BigDecimal.valueOf(numeric).toBigIntegerExact(), cp);
+        }
+        return signs;
+    }
+
+    /** The base of a contiguous zero-based digit block, or empty. */
+    private static Optional<BigInteger> positionalBase(TreeMap<BigInteger, Integer> signs) {
+        int base = signs.size();
+        if (base > 1 && base <= MAX_POSITIONAL_BASE && signs.firstKey().signum() == 0
+                && signs.lastKey().equals(BigInteger.valueOf(base - 1L))) {
+            return Optional.of(BigInteger.valueOf(base));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Blocks that are read but never composed: counting rods are positional
+     * above the tens and the Number Forms are subtractive Roman, so a greedy
+     * additive spelling of either would be invalid notation. (Roman gets its
+     * own writer; rod values fall back to plain digits.)
+     */
+    private static final Set<Character.UnicodeBlock> READ_ONLY_BLOCKS = Set
+            .of(Character.UnicodeBlock.NUMBER_FORMS, Character.UnicodeBlock.COUNTING_ROD_NUMERALS);
+
+    /** Write the value with the numeral signs of the given code point's block. */
+    private static Optional<String> composeFromBlockOf(BigInteger value, int templateCp) {
+        if (READ_ONLY_BLOCKS.contains(Character.UnicodeBlock.of(templateCp))) {
+            return Optional.empty();
+        }
+        TreeMap<BigInteger, Integer> signs = blockSigns(templateCp);
+        if (signs.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<BigInteger> base = positionalBase(signs);
+        if (base.isPresent()) {
+            StringBuilder digits = new StringBuilder();
+            BigInteger rest = value;
+            int count = 0;
+            do {
+                BigInteger[] div = rest.divideAndRemainder(base.get());
+                digits.insert(0, Character.toChars(signs.get(div[1])));
+                rest = div[0];
+                count++;
+            } while (rest.signum() > 0 && count < MAX_COMPOSED_SIGNS);
+            return rest.signum() == 0 ? Optional.of(digits.toString()) : Optional.empty();
+        }
+        // Otherwise compose additively, largest sign first.
+        if (value.signum() == 0) {
+            return Optional.empty();
+        }
+        StringBuilder out = new StringBuilder();
+        BigInteger rest = value;
+        int count = 0;
+        for (BigInteger sign : signs.descendingKeySet()) {
+            if (sign.signum() == 0) {
+                continue;
+            }
+            while (rest.compareTo(sign) >= 0 && count < MAX_COMPOSED_SIGNS) {
+                out.append(Character.toChars(signs.get(sign)));
+                rest = rest.subtract(sign);
+                count++;
+            }
+        }
+        return rest.signum() == 0 ? Optional.of(out.toString()) : Optional.empty();
+    }
+
+    /**
      * The integer value of a token that may be read as a number, or empty when
-     * the token is not one. The gated form of {@link #parseWhole}: safe to apply
-     * to every token of a segment, because ordinary words are rejected before
-     * they reach the numeral parsers.
+     * the token is not one. The gated form of {@link #parseWhole} plus the
+     * whole-valued sign numerals: safe to apply to every token of a segment,
+     * because ordinary words are rejected before they reach the numeral
+     * parsers.
      *
      * Every caller decides for itself whether Roman numerals written with Latin
      * letters count, because there is no telling "I", "V", "X", "MIX" or "DIV"
@@ -815,7 +1172,22 @@ public final class NumeralValueParser {
      *            whether a Latin-letter Roman numeral is a number here
      */
     public static Optional<BigInteger> parseTokenWhole(String token, boolean allowRoman) {
-        return isNumeralToken(token, allowRoman) ? parseWhole(token) : Optional.empty();
+        if (!isNumeralToken(token, allowRoman)) {
+            return Optional.empty();
+        }
+        Optional<BigInteger> whole = parseWhole(token);
+        if (whole.isPresent()) {
+            return whole;
+        }
+        // The sign numerals join the whole-number comparison through the same
+        // last resort parseValue uses, whole values only, so the match scorer
+        // pairs every numeral the insertion step can read.
+        String trimmed = token.trim();
+        if (hasDecimalDigit(trimmed)) {
+            return Optional.empty();
+        }
+        return singleCodePointNumericValue(trimmed).or(() -> signSequenceValue(trimmed))
+                .filter(value -> BigInteger.ONE.equals(value.denominator())).map(Rational::numerator);
     }
 
     /**

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -1204,6 +1204,69 @@ public final class NumeralValueParser {
         return isNumeralToken(token, allowRoman) ? parseValue(token) : Optional.empty();
     }
 
+    /** The separator characters a digit token may be written with. */
+    private static final String DIGIT_SEPARATORS = ".,\u00A0\u202F\u2007 ";
+
+    /**
+     * The values a separator-written digit token can mean. A token grouped
+     * by one repeated separator into blocks of three digits reads as the
+     * grouped integer; a token with a single dot or comma also reads as a
+     * decimal fraction, since either character marks decimals somewhere. A
+     * spelling that allows both returns both, a token without separators
+     * falls back to {@link #parseTokenValue}, and an unreadable token
+     * returns no values at all.
+     */
+    public static List<Rational> parseSeparatedValues(String token, boolean allowRoman) {
+        List<String> groups = new ArrayList<>();
+        List<Character> separators = new ArrayList<>();
+        int groupStart = 0;
+        for (int i = 0; i < token.length(); i++) {
+            if (DIGIT_SEPARATORS.indexOf(token.charAt(i)) >= 0) {
+                groups.add(token.substring(groupStart, i));
+                separators.add(token.charAt(i));
+                groupStart = i + 1;
+            }
+        }
+        if (separators.isEmpty()) {
+            return parseTokenValue(token, allowRoman).map(List::of).orElse(List.of());
+        }
+        groups.add(token.substring(groupStart));
+        if (groups.stream().anyMatch(group -> digitsValue(group).isEmpty())) {
+            return List.of();
+        }
+        List<Rational> values = new ArrayList<>();
+        if (separators.stream().distinct().count() == 1 && groups.get(0).length() <= 3
+                && groups.stream().skip(1).allMatch(group -> group.length() == 3)) {
+            digitsValue(String.join("", groups)).map(Rational::ofInteger).ifPresent(values::add);
+        }
+        char separator = separators.get(0);
+        if (separators.size() == 1 && (separator == '.' || separator == ',')) {
+            BigInteger numerator = digitsValue(groups.get(0) + groups.get(1)).orElseThrow();
+            Rational decimal = Rational.of(numerator, BigInteger.TEN.pow(groups.get(1).length()));
+            if (!values.contains(decimal)) {
+                values.add(decimal);
+            }
+        }
+        return values;
+    }
+
+    /** The value of a run of decimal digits of any script, empty when it is none. */
+    private static Optional<BigInteger> digitsValue(String digits) {
+        if (digits.isEmpty()) {
+            return Optional.empty();
+        }
+        BigInteger value = BigInteger.ZERO;
+        for (int cp, i = 0; i < digits.length(); i += Character.charCount(cp)) {
+            cp = digits.codePointAt(i);
+            int digit = Character.digit(cp, 10);
+            if (digit < 0 || !Character.isDigit(cp)) {
+                return Optional.empty();
+            }
+            value = value.multiply(BigInteger.TEN).add(BigInteger.valueOf(digit));
+        }
+        return Optional.of(value);
+    }
+
     /**
      * Token boundaries for the real-value scanner. Sign, decimal point and the
      * fraction slashes stay inside a token so a signed/decimal/fraction number is

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.Normalizer2;
@@ -749,6 +750,86 @@ public final class NumeralValueParser {
             i += Character.charCount(cp);
         }
         return -1;
+    }
+
+    // ------------------------------------------------------------------------
+    // Number tokens of a segment
+    // ------------------------------------------------------------------------
+
+    /**
+     * Matches a canonical uppercase Roman numeral; lowercase or non-canonical
+     * letter runs (like "mix" or "civil") stay ordinary words.
+     */
+    private static final Pattern CANONICAL_ROMAN = Pattern
+            .compile("M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})");
+    private static final Pattern ANY_ROMAN_DIGIT = Pattern.compile(".*[IVX].*");
+    /** Han numeral ideographs, the unambiguous CJK number tokens. */
+    private static final Pattern HAN_NUMERALS = Pattern.compile(
+            "[〇零一二三四五六七八九"
+                    + "十百千万萬億兆两兩]+");
+
+    /**
+     * Whether a token taken from running text may be read as a number at all.
+     * Tokens containing a decimal digit or a letter numeral of any script always
+     * count; letter-only tokens count only in unambiguous forms (canonical
+     * uppercase Roman where the caller allows them, Han numerals), so ordinary
+     * words are never misread as numerals.
+     *
+     * Two boundaries are deliberate. A Roman form without I, V or X is rejected,
+     * because "L", "C", "D" and "M" stand for a unit or an abbreviation far more
+     * often than for 50, 100, 500 and 1000. And a Number-Other code point is not
+     * a numeral token, which keeps a superscript exponent, a vulgar fraction and
+     * an enclosed number out of the number comparisons.
+     */
+    private static boolean isNumeralToken(String text, boolean allowRoman) {
+        if (text == null || text.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < text.length();) {
+            int cp = text.codePointAt(i);
+            int type = Character.getType(cp);
+            if (type == Character.DECIMAL_DIGIT_NUMBER || type == Character.LETTER_NUMBER) {
+                return true;
+            }
+            i += Character.charCount(cp);
+        }
+        return allowRoman && CANONICAL_ROMAN.matcher(text).matches()
+                && ANY_ROMAN_DIGIT.matcher(text).matches()
+                || HAN_NUMERALS.matcher(text).matches();
+    }
+
+    /**
+     * The integer value of a token that may be read as a number, or empty when
+     * the token is not one. The gated form of {@link #parseWhole}: safe to apply
+     * to every token of a segment, because ordinary words are rejected before
+     * they reach the numeral parsers.
+     *
+     * Every caller decides for itself whether Roman numerals written with Latin
+     * letters count, because there is no telling "I", "V", "X", "MIX" or "DIV"
+     * apart from ordinary uppercase words. Where a false positive only shifts a
+     * similarity score it is worth reading them; where it rewrites text a
+     * translator is handed, it is not. Roman numerals written with the dedicated
+     * code points are letter numerals and count either way.
+     *
+     * @param allowRoman
+     *            whether a Latin-letter Roman numeral is a number here
+     */
+    public static Optional<BigInteger> parseTokenWhole(String token, boolean allowRoman) {
+        return isNumeralToken(token, allowRoman) ? parseWhole(token) : Optional.empty();
+    }
+
+    /**
+     * The exact value of a token that may be read as a number, or empty when the
+     * token is not one. The gated form of {@link #parseValue}, so decimals,
+     * fractions and the integer numeral systems are all recognized while
+     * ordinary words are not.
+     *
+     * @param allowRoman
+     *            whether a Latin-letter Roman numeral is a number here; see
+     *            {@link #parseTokenWhole(String, boolean)} for what that costs
+     */
+    public static Optional<Rational> parseTokenValue(String token, boolean allowRoman) {
+        return isNumeralToken(token, allowRoman) ? parseValue(token) : Optional.empty();
     }
 
     /**

--- a/src/main/java/org/omegat/util/PatternConsts.java
+++ b/src/main/java/org/omegat/util/PatternConsts.java
@@ -54,6 +54,37 @@ public final class PatternConsts {
     /** Tag Validation Option: check user defined tags according to regexp.*/
     public static final String CHECK_CUSTOM_PATTERN_DEFAULT = "\\d+";
 
+    private static final String RE_NUMERALS = "\\p{Nd}+|[\\p{Nl}\\p{No}&&["
+            + "^\\u00B9\\u00B2\\u00B3"
+            + "\\p{InSUPERSCRIPTS_AND_SUBSCRIPTS}"
+            + "\\p{InENCLOSED_ALPHANUMERICS}"
+            + "\\p{InENCLOSED_ALPHANUMERIC_SUPPLEMENT}"
+            + "\\p{InENCLOSED_CJK_LETTERS_AND_MONTHS}"
+            + "\\p{InENCLOSED_IDEOGRAPHIC_SUPPLEMENT}"
+            + "\\p{InDINGBATS}]]+";
+
+    /**
+     * A whole numeral in any writing system, matched as one run: decimal
+     * digits of every script, and the letter and other numerals, which cover
+     * the sign-written systems (Roman code points, Ethiopic, cuneiform, Mayan
+     * and others) and the precomposed vulgar fractions. The decoration
+     * numbers are subtracted - superscripts and the enclosed and dingbat
+     * forms number list items and footnotes rather than quantities.
+     */
+    public static final Pattern NUMERALS = Pattern.compile(RE_NUMERALS);
+
+    /**
+     * {@link #NUMERALS}, preceded by the separator-written digit forms: a
+     * decimal fraction with one dot or comma, or a number grouped by dots,
+     * commas or the space characters into blocks of three digits. The
+     * separated alternatives come first, so a decimal or grouped number
+     * matches as one token rather than as its digit runs.
+     */
+    public static final Pattern NUMERALS_WITH_SEPARATORS = Pattern.compile(
+            "\\p{Nd}{1,3}(?:([.,\\u00A0\\u202F\\u2007 ])\\p{Nd}{3}(?:\\1\\p{Nd}{3})*)(?![\\p{Nd}.,])"
+                    + "|\\p{Nd}+[.,]\\p{Nd}+(?![\\p{Nd}.,])"
+                    + "|" + RE_NUMERALS);
+
     /**
      * Compiled pattern to extract the encoding from XML file, if any. Found
      * encoding is stored in group #1.

--- a/src/main/java/org/omegat/util/gui/Styles.java
+++ b/src/main/java/org/omegat/util/gui/Styles.java
@@ -203,6 +203,11 @@ public final class Styles {
          */
         COLOR_NBSP("OmegaT.nbsp", "#888888"),
         /**
+         * Numeral underline color. Ships without a color, so the numeral
+         * marks stay unpainted until the user picks a color of their own.
+         */
+        COLOR_NUMERALS("OmegaT.numerals", (Color) null),
+        /**
          * White space marker background color.
          */
         COLOR_WHITESPACE("OmegaT.whiteSpace", "#808080"),

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -2318,6 +2318,18 @@ TEAM_HTTP_UNAUTHORIZED=Authentication error when trying to access {0}.
 TEAM_HTTP_NOT_FOUND=No content found at {0}.
 TEAM_HTTP_OTHER_ERRORS=HTTP connection {1} responded with code: {2}.
 
+TEAM_SETTING_DIVERGED_TITLE=Team Project Setting
+TEAM_SETTING_DIVERGED_MESSAGE=The project setting "{0}" is {1} on this computer but {2} in the team project. The team version is now active.\nWhat do you want to do with the local version?
+TEAM_SETTING_SHARE=Share with the team
+TEAM_SETTING_TAKE_TEAM=Use the team version
+TEAM_SETTING_KEEP_THIS_TIME=Use the local version this time
+TEAM_SETTING_CHANGED_MESSAGE=You changed the project setting "{0}" to {1}. Share the change with the team? Without sharing it stays local, and the next open of the project asks again.
+TEAM_SETTING_KEEP_FOR_NOW=Keep it local for now
+TEAM_SETTING_VALUE_ON=enabled
+TEAM_SETTING_VALUE_OFF=disabled
+TEAM_SETTING_SHARE_ERROR=The setting could not be committed to the team project.
+TEAM_SETTING_APPLY_ERROR=The local setting could not be applied.
+
 # Save options
 SAVE_DIALOG_TITLE=Saving and Output Options
 PREFS_TITLE_SAVING_AND_OUTPUT=Saving and Output

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -785,7 +785,9 @@ PP_LOC_TOK=Target language tokenizer:
 PP_ALLOW_DEFAULTS=&Auto-propagation of translations
 
 PP_REMOVE_TAGS=Remove ta&gs
-PP_MATCH_NUMBERS=Consider &numbers in fuzzy matching
+PP_MATCH_NUMBERS=Consider &numbers in matches
+PP_CHECK_NUMBERS=Check numerals by &value
+
 
 PP_EXTERNAL_COMMAND=Local post-processing commands
 
@@ -2493,6 +2495,7 @@ COLOR_MOD_INFO_FG=Modification info text
 COLOR_PLACEHOLDER=Tags
 COLOR_REMOVETEXT_TARGET=Flagged text
 COLOR_NBSP=Non-breakable spaces
+COLOR_NUMERALS=Numerals
 COLOR_WHITESPACE=Whitespaces
 COLOR_BIDIMARKERS=Bidirectional control characters
 COLOR_MARK_COMES_FROM_TM_MT=From MT memory

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -2187,6 +2187,18 @@ TEAM_HTTP_UNAUTHORIZED=Authentifizierungsfehler beim Zugriff auf {0}.
 TEAM_HTTP_NOT_FOUND=Kein Inhalt gefunden bei {0}.
 TEAM_HTTP_OTHER_ERRORS=HTTP-Verbindung {1} antwortet mit Code: {2}.
 
+TEAM_SETTING_DIVERGED_TITLE=Team-Projekteinstellung
+TEAM_SETTING_DIVERGED_MESSAGE=Die Projekteinstellung "{0}" ist auf diesem Rechner {1}, im Teamprojekt {2}. Die Team-Fassung ist jetzt aktiv.\nWas soll mit der lokalen Fassung geschehen?
+TEAM_SETTING_SHARE=Ans Team verteilen
+TEAM_SETTING_TAKE_TEAM=Team-Fassung \u00FCbernehmen
+TEAM_SETTING_KEEP_THIS_TIME=Diesmal die lokale Fassung verwenden
+TEAM_SETTING_CHANGED_MESSAGE=Die Projekteinstellung "{0}" wurde auf {1} ge\u00E4ndert. Soll die \u00C4nderung ans Team verteilt werden? Ohne Verteilung bleibt sie lokal, und das n\u00E4chste \u00D6ffnen des Projekts fragt erneut.
+TEAM_SETTING_KEEP_FOR_NOW=Vorerst lokal belassen
+TEAM_SETTING_VALUE_ON=aktiviert
+TEAM_SETTING_VALUE_OFF=deaktiviert
+TEAM_SETTING_SHARE_ERROR=Die Einstellung konnte nicht ins Teamprojekt \u00FCbertragen werden.
+TEAM_SETTING_APPLY_ERROR=Die lokale Einstellung konnte nicht angewendet werden.
+
 # Save options
 SAVE_DIALOG_TITLE=Speichern und Ausgabe
 PREFS_TITLE_SAVING_AND_OUTPUT=Speichern und Ausgabe

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -751,7 +751,9 @@ PP_LOC_TOK=Tokenizer der Zielsprache:
 PP_ALLOW_DEFAULTS=&Auto-Propagation von \u00DCbersetzungen
 
 PP_REMOVE_TAGS=Ta&gs entfernen
-PP_MATCH_NUMBERS=Zahle&n bei unscharfen Treffern ber\u00FCcksichtigen
+PP_MATCH_NUMBERS=Zahle&n in Treffern ber\u00FCcksichtigen
+PP_CHECK_NUMBERS=Zahlen nach &Wert pr\u00FCfen
+
 
 PP_EXTERNAL_COMMAND=Lokale Nachbearbeitungsbefehle
 
@@ -2358,6 +2360,7 @@ COLOR_MOD_INFO_FG=Modifikationsinfo: Text
 COLOR_PLACEHOLDER=Tags
 COLOR_REMOVETEXT_TARGET=Gesch\u00FCtzte Texte
 COLOR_NBSP=Gesch\u00FCtzte Leerzeichen
+COLOR_NUMERALS=Zahlen
 COLOR_WHITESPACE=Leerr\u00E4ume
 COLOR_BIDIMARKERS=Bidirektionale Steuerzeichen
 COLOR_MARK_COMES_FROM_TM_MT=Aus Maschinelle-\u00DCbersetzung-TM

--- a/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
@@ -1,0 +1,274 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.team2.RemoteRepositoryProvider;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that sharing a team project setting commits the sidecar settings
+ * file and leaves omegat.project untouched, so team members on older OmegaT
+ * versions can still open the project.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectSettingsPublishTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "README").toPath(), "team project\n",
+                StandardCharsets.UTF_8);
+        commitAll("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    @Test
+    public void testPublishDeliversTheSettingsFileToTheTeam() throws Exception {
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("the team must receive the value", "true", loadDeliveredValue("member2"));
+        assertFalse("omegat.project must stay untouched for older versions",
+                new File(projectDir, OConsts.FILE_PROJECT).exists());
+    }
+
+    @Test
+    public void testPublishCanAlsoOverwriteAValue() throws Exception {
+        Files.createDirectories(new File(remoteDir, OConsts.DEFAULT_INTERNAL).toPath());
+        Files.writeString(remoteSettingsFile().toPath(), KEY + "=true\n", StandardCharsets.UTF_8);
+        commitAll("team with the option");
+
+        ProjectSettingsStorage.save(config, KEY, "false");
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("the team must receive the new value", "false", loadDeliveredValue("member2"));
+    }
+
+    @Test
+    public void testPublishingAnAlreadySharedValueIsNotAnError() throws Exception {
+        // Another team member shared the same value in the meantime: the git
+        // commit would be a no-op, which reports the same way as a rejected
+        // push - so publishing must recognise the identical file and skip.
+        Files.createDirectories(new File(remoteDir, OConsts.DEFAULT_INTERNAL).toPath());
+        Files.writeString(remoteSettingsFile().toPath(), KEY + "=true\n", StandardCharsets.UTF_8);
+        commitAll("team already carries the value");
+
+        ProjectSettingsStorage.save(config, KEY, "true");
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("true", loadDeliveredValue("member2"));
+    }
+
+    @Test
+    public void testStorageRoundTripAndDefaults() throws Exception {
+        assertNull("unconfigured project reads as null", ProjectSettingsStorage.load(config, KEY));
+        // removing an unset key must not materialise the file
+        ProjectSettingsStorage.save(config, KEY, null);
+        assertFalse("removing from an absent file must stay a no-op",
+                ProjectSettingsStorage.getFile(config).isFile());
+        ProjectSettingsStorage.save(config, KEY, "true");
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+        // deterministic content, so team no-op detection can compare bytes
+        assertEquals(KEY + "=true\n",
+                Files.readString(ProjectSettingsStorage.getFile(config).toPath(), StandardCharsets.UTF_8));
+        ProjectSettingsStorage.save(config, KEY, "false");
+        assertEquals("false", ProjectSettingsStorage.load(config, KEY));
+        // null removes the key but keeps the file and foreign keys
+        Files.writeString(ProjectSettingsStorage.getFile(config).toPath(),
+                "future_setting=x\n" + KEY + "=false\n", StandardCharsets.UTF_8);
+        ProjectSettingsStorage.save(config, KEY, null);
+        assertNull(ProjectSettingsStorage.load(config, KEY));
+        assertTrue(Files.readString(ProjectSettingsStorage.getFile(config).toPath(),
+                StandardCharsets.UTF_8).contains("future_setting=x"));
+    }
+
+    @Test
+    public void testResolveSettingTruthTable() {
+        // non-team / offline: the local file rules, never a question
+        assertResolved(null, null, RealProject.resolveSetting(null, null, false, false));
+        assertResolved("true", null, RealProject.resolveSetting(null, "true", false, false));
+        // team: remote delivered a value over an absent local file - first
+        // arrival activates and asks once
+        assertAsks("true", null, RealProject.resolveSetting(null, "true", true, true));
+        // team: remote delivered a differing value - team wins, asks
+        assertAsks("false", "true", RealProject.resolveSetting("true", "false", true, true));
+        // team: local-only survivor - team default stays active, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", "true", false, true));
+        // team: both agree (shared value) - quiet
+        assertResolved("true", null, RealProject.resolveSetting("true", "true", true, true));
+        // team: nothing anywhere - quiet
+        assertResolved(null, null, RealProject.resolveSetting(null, null, false, true));
+        // team: remote carries only foreign future keys - like absent, quiet
+        assertResolved(null, null, RealProject.resolveSetting(null, null, true, true));
+        // team: the sync deleted the key - team default wins, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", null, true, true));
+        // team: diverged and not identical - local-only, team default, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", "false", false, true));
+    }
+
+    private static void assertResolved(String effective, String superseded,
+            RealProject.SettingResolution state) {
+        assertEquals(effective, state.effective);
+        assertFalse("expected quiet resolution", state.asks);
+        assertEquals(superseded, state.supersededLocal);
+    }
+
+    private static void assertAsks(String effective, String superseded,
+            RealProject.SettingResolution state) {
+        assertEquals(effective, state.effective);
+        assertTrue("expected a question", state.asks);
+        assertEquals(superseded, state.supersededLocal);
+    }
+
+    @Test
+    public void testPersistSessionSettingsSkipsSupersededAndDefaults() throws Exception {
+        AtomicBoolean first = new AtomicBoolean(true);
+        AtomicBoolean second = new AtomicBoolean(true);
+        TeamSettingsRegistry.register(TeamSetting.ofBoolean("first_option",
+                "TEAM_SETTING_DIVERGED_TITLE", false, p -> first.get(), (p, v) -> first.set(v)));
+        TeamSettingsRegistry.register(TeamSetting.ofBoolean("second_option",
+                "TEAM_SETTING_DIVERGED_TITLE", false, p -> second.get(), (p, v) -> second.set(v)));
+        try {
+            // superseded key keeps the file untouched for its setting, the
+            // other one still persists
+            RealProject.persistSessionSettings(config, Collections.singleton("first_option"));
+            assertNull(ProjectSettingsStorage.load(config, "first_option"));
+            assertEquals("true", ProjectSettingsStorage.load(config, "second_option"));
+
+            // default values stay unmaterialised unless the file exists
+            Files.delete(ProjectSettingsStorage.getFile(config).toPath());
+            first.set(false);
+            second.set(false);
+            RealProject.persistSessionSettings(config, Collections.emptySet());
+            assertFalse("defaults must not materialise the file",
+                    ProjectSettingsStorage.getFile(config).isFile());
+        } finally {
+            TeamSettingsRegistry.unregister("first_option");
+            TeamSettingsRegistry.unregister("second_option");
+        }
+    }
+
+    @Test
+    public void testEscapingWriterRoundTripsForeignKeys() throws Exception {
+        Files.createDirectories(ProjectSettingsStorage.getFile(config).getParentFile().toPath());
+        Files.writeString(ProjectSettingsStorage.getFile(config).toPath(),
+                "future\\ key\\=x=va\\\\lue\\=1\n" + KEY + "=false\n", StandardCharsets.UTF_8);
+        Properties before = loadRaw();
+        ProjectSettingsStorage.save(config, KEY, "true");
+        Properties after = loadRaw();
+        assertEquals("foreign key must survive the rewrite unchanged", before.getProperty("future key=x"),
+                after.getProperty("future key=x"));
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    private Properties loadRaw() throws Exception {
+        Properties p = new Properties();
+        try (java.io.Reader in = Files.newBufferedReader(
+                ProjectSettingsStorage.getFile(config).toPath(), StandardCharsets.UTF_8)) {
+            p.load(in);
+        }
+        return p;
+    }
+
+    private File remoteSettingsFile() {
+        return new File(remoteDir,
+                OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+    }
+
+    private void commitAll(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    /** Fetch the settings file the way a second member's open does. */
+    private String loadDeliveredValue(String memberDirName) throws Exception {
+        File memberDir = folder.newFolder(memberDirName);
+        RemoteRepositoryProvider member = newProvider(memberDir, remoteDir);
+        member.switchAllToLatest();
+        member.copyFilesFromReposToProject("");
+        return ProjectSettingsStorage.load(new ProjectProperties(memberDir), KEY);
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}

--- a/src/test/java/org/omegat/core/data/TeamSettingTest.java
+++ b/src/test/java/org/omegat/core/data/TeamSettingTest.java
@@ -1,0 +1,122 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Contract of the boolean team setting descriptor and the registry: absent
+ * key means default, only the non-default value materialises, normalization
+ * folds explicit default values back to null so divergence detection never
+ * confuses "explicitly default" with "not configured".
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class TeamSettingTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @After
+    public final void tearDown() {
+        TeamSettingsRegistry.unregister(KEY);
+    }
+
+    @Test
+    public void testOptInBooleanContract() throws Exception {
+        AtomicBoolean holder = new AtomicBoolean(false);
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false,
+                config -> holder.get(), (config, value) -> holder.set(value));
+        ProjectProperties config = new ProjectProperties(folder.newFolder("p"));
+
+        assertNull("default reads as not configured", setting.read(config));
+        holder.set(true);
+        assertEquals("only the non-default value materialises", "true", setting.read(config));
+
+        setting.apply(config, null);
+        assertEquals("null applies the default", false, holder.get());
+        setting.apply(config, "true");
+        assertTrue(holder.get());
+
+        assertNull("explicit default folds back to null", setting.normalize("false"));
+        assertEquals("true", setting.normalize("true"));
+        assertNull(setting.normalize(null));
+    }
+
+    @Test
+    public void testOptOutBooleanContract() throws Exception {
+        AtomicBoolean holder = new AtomicBoolean(true);
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", true,
+                config -> holder.get(), (config, value) -> holder.set(value));
+        ProjectProperties config = new ProjectProperties(folder.newFolder("p"));
+
+        assertNull("default reads as not configured", setting.read(config));
+        holder.set(false);
+        assertEquals("false", setting.read(config));
+
+        setting.apply(config, null);
+        assertTrue("null applies the default", holder.get());
+        assertNull("explicit default folds back to null", setting.normalize("true"));
+        assertEquals("false", setting.normalize("false"));
+    }
+
+    @Test
+    public void testDisplayNameStripsMnemonicMarker() {
+        // existing label keys carry mnemonic markers; dialogs must not show them
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "PP_REMOVE_TAGS", false,
+                config -> false, (config, value) -> {
+                });
+        assertFalse("marker key must resolve to a non-empty name", setting.getDisplayName().isEmpty());
+        assertEquals("mnemonic marker must be stripped", -1, setting.getDisplayName().indexOf('&'));
+    }
+
+    @Test
+    public void testRegistryRejectsDuplicatesAndUnregisters() {
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false,
+                config -> false, (config, value) -> {
+                });
+        TeamSettingsRegistry.register(setting);
+        assertNotNull(TeamSettingsRegistry.byKey(KEY));
+        assertThrows(IllegalArgumentException.class, () -> TeamSettingsRegistry.register(setting));
+        TeamSettingsRegistry.unregister(KEY);
+        assertNull(TeamSettingsRegistry.byKey(KEY));
+        assertTrue(TeamSettingsRegistry.all().stream().noneMatch(s -> s.getKey().equals(KEY)));
+    }
+}

--- a/src/test/java/org/omegat/core/tagvalidation/CheckNumbersTeamSettingTest.java
+++ b/src/test/java/org/omegat/core/tagvalidation/CheckNumbersTeamSettingTest.java
@@ -1,0 +1,117 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.tagvalidation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectSettingsStorage;
+import org.omegat.core.data.TeamSetting;
+import org.omegat.core.data.TeamSettingsRegistry;
+
+/**
+ * The numeral check rides the generic team settings sidecar as opt-out flag
+ * (SF #465): absent value means enabled, only a disabled check materialises
+ * in the file, and the registration survives repeated bootstraps.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class CheckNumbersTeamSettingTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ProjectProperties props;
+    private TeamSetting setting;
+
+    @Before
+    public void setUp() throws Exception {
+        props = new ProjectProperties(folder.newFolder("project"));
+        TagValidation.registerCheckNumbersTeamSetting();
+        setting = TeamSettingsRegistry.byKey(TagValidation.CHECK_NUMBERS_TEAM_SETTING_KEY);
+    }
+
+    @After
+    public void tearDown() {
+        TeamSettingsRegistry.unregister(TagValidation.CHECK_NUMBERS_TEAM_SETTING_KEY);
+    }
+
+    @Test
+    public void enabledIsDefaultAndReadsAsNull() {
+        assertTrue(props.isCheckNumbersEnabled());
+        assertNull(setting.read(props));
+        assertNull(setting.normalize("true"));
+        assertEquals("false", setting.normalize(" FALSE "));
+    }
+
+    @Test
+    public void applyAndReadRoundTrip() {
+        setting.apply(props, "false");
+        assertFalse(props.isCheckNumbersEnabled());
+        assertEquals("false", setting.read(props));
+        setting.apply(props, null);
+        assertTrue(props.isCheckNumbersEnabled());
+        assertNull(setting.read(props));
+    }
+
+    @Test
+    public void storageRoundTripAndDefaultWritesNoFile() throws Exception {
+        // Mirror of the persist guard in RealProject: save runs only for a
+        // configured value or an already existing file.
+        persistLikeRealProject();
+        assertFalse("default project must stay sidecar-free",
+                ProjectSettingsStorage.getFile(props).isFile());
+
+        setting.apply(props, "false");
+        persistLikeRealProject();
+        assertEquals("false", setting.normalize(
+                ProjectSettingsStorage.load(props, TagValidation.CHECK_NUMBERS_TEAM_SETTING_KEY)));
+    }
+
+    @Test
+    public void registrationIsIdempotent() {
+        TagValidation.registerCheckNumbersTeamSetting();
+        TagValidation.registerCheckNumbersTeamSetting();
+        assertEquals(1, TeamSettingsRegistry.all().stream()
+                .filter(s -> TagValidation.CHECK_NUMBERS_TEAM_SETTING_KEY.equals(s.getKey())).count());
+    }
+
+    private void persistLikeRealProject() throws Exception {
+        String sessionValue = setting.read(props);
+        if (sessionValue != null || ProjectSettingsStorage.getFile(props).isFile()) {
+            ProjectSettingsStorage.save(props, TagValidation.CHECK_NUMBERS_TEAM_SETTING_KEY, sessionValue);
+        }
+    }
+}

--- a/src/test/java/org/omegat/core/tagvalidation/TagValidationTest.java
+++ b/src/test/java/org/omegat/core/tagvalidation/TagValidationTest.java
@@ -25,12 +25,16 @@
 
 package org.omegat.core.tagvalidation;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.ProtectedPart;
+import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.tagvalidation.ErrorReport.TagError;
 import org.omegat.util.Preferences;
 import org.omegat.util.TagUtil.Tag;
@@ -186,6 +190,216 @@ public class TagValidationTest {
         TagValidation.inspectRemovePattern(report);
         assertTrue(report.srcErrors.isEmpty());
         assertTrue(report.transErrors.get(new Tag(0, "foo")) == TagError.EXTRANEOUS);
+    }
+
+    /**
+     * Numerals match by value across notations: a source numeral missing
+     * verbatim from the translation is satisfied by an equal value in any
+     * notation, while a changed value keeps its error and verbatim pairings
+     * stay with the ordinary check. Numeral tags leave the ordered tag check
+     * when satisfied; numerals outside the tag machinery report their
+     * missing values directly.
+     */
+    @Test
+    public void testNumeralsCheckedByValue() throws Exception {
+        String khmer = "១២៣៤៥៦";
+        String khmerSource = "បានកត់ត្រា ១២៣៤៥៦ គ្រួសារ";
+
+        // The same value in plain digits satisfies the Khmer source numeral.
+        ErrorReport report = new ErrorReport(khmerSource, "erfasste 123456 Haushalte");
+        List<Tag> srcTags = tagsAt(khmerSource, khmer);
+        TagValidation.inspectNumerals(srcTags, new ArrayList<>(), report);
+        assertTrue(srcTags.isEmpty());
+        assertTrue(report.isEmpty());
+
+        // A changed value stays with the ordered tag check.
+        report = new ErrorReport(khmerSource, "erfasste 123457 Haushalte");
+        srcTags = tagsAt(khmerSource, khmer);
+        TagValidation.inspectNumerals(srcTags, new ArrayList<>(), report);
+        assertEquals(1, srcTags.size());
+
+        // A verbatim pairing is not consumed by value matching, and a second
+        // source numeral of the same value still finds no counterpart.
+        String twoYears = "ឆ្នាំ 1984 និង ១៩៨៤";
+        String twoYearsTranslation = "nennt 1984 Tonkrüge";
+        report = new ErrorReport(twoYears, twoYearsTranslation);
+        srcTags = tagsAt(twoYears, "1984", "១៩៨៤");
+        TagValidation.inspectNumerals(srcTags, tagsAt(twoYearsTranslation, "1984"), report);
+        assertEquals(2, srcTags.size());
+
+        // Ordinary tags are never value-matched, and their digits do not
+        // join the numeral check.
+        String tagged = "siehe <x1/> hier";
+        report = new ErrorReport(tagged, "ohne Tag");
+        srcTags = tagsAt(tagged, "<x1/>");
+        TagValidation.inspectNumerals(srcTags, new ArrayList<>(), report);
+        assertEquals(1, srcTags.size());
+        assertTrue(report.isEmpty());
+
+        // The compatibility spelling satisfies the numeral as well: a Roman
+        // code point written out with Latin letters, a vulgar fraction
+        // written with a plain slash.
+        String chapter = "Chapter Ⅻ opens";
+        report = new ErrorReport(chapter, "Kapitel XII beginnt");
+        srcTags = tagsAt(chapter, "Ⅻ");
+        TagValidation.inspectNumerals(srcTags, new ArrayList<>(), report);
+        assertTrue(srcTags.isEmpty());
+
+        String recipe = "add ¼ measure";
+        report = new ErrorReport(recipe, "1/4 Tasse Honig");
+        srcTags = tagsAt(recipe, "¼");
+        TagValidation.inspectNumerals(srcTags, new ArrayList<>(), report);
+        assertTrue(srcTags.isEmpty());
+
+        // A compatibility spelling embedded in a different number does not
+        // satisfy the numeral: twelve is not part of thirteen, a quarter is
+        // not part of eleven forty-seconds.
+        report = new ErrorReport(chapter, "Kapitel XIII beginnt");
+        srcTags = tagsAt(chapter, "Ⅻ");
+        TagValidation.inspectNumerals(srcTags, new ArrayList<>(), report);
+        assertEquals(1, srcTags.size());
+
+        report = new ErrorReport(recipe, "genau 11/42 Anteile");
+        srcTags = tagsAt(recipe, "¼");
+        TagValidation.inspectNumerals(srcTags, new ArrayList<>(), report);
+        assertEquals(1, srcTags.size());
+    }
+
+    /**
+     * The numeral check does not depend on the tag machinery: a source
+     * numeral outside every tag list reports its missing value itself, so a
+     * mistranslated number surfaces whatever the script and whatever the
+     * custom-tag pattern.
+     */
+    @Test
+    public void testNumeralsOutsideTagsAreCheckedAllTheSame() throws Exception {
+        String khmerSource = "បានកត់ត្រា ១២៣៤៥៦ គ្រួសារ";
+
+        // An equal value in any notation satisfies the check.
+        ErrorReport report = new ErrorReport(khmerSource, "erfasste 123456 Haushalte");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertTrue(report.isEmpty());
+
+        // A changed value reports the source numeral as missing.
+        report = new ErrorReport(khmerSource, "erfasste 123457 Haushalte");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertEquals(TagError.MISSING,
+                report.srcErrors.get(new Tag(khmerSource.indexOf("១២៣៤៥៦"), "១២៣៤៥៦")));
+
+        // Plain digit runs are checked without any tag list too: both
+        // dropped values of this translation are reported.
+        report = new ErrorReport("5 Kisten und 3 Säcke", "einige Kisten und Säcke");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertEquals(2, report.srcErrors.size());
+
+        // The compatibility spelling satisfies the plain-text numeral.
+        report = new ErrorReport("Chapter Ⅻ opens", "Kapitel XII beginnt");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertTrue(report.isEmpty());
+    }
+
+    private static List<Tag> tagsAt(String text, String... tokens) {
+        List<Tag> list = new ArrayList<>();
+        for (String token : tokens) {
+            list.add(new Tag(text.indexOf(token), token));
+        }
+        return list;
+    }
+
+    /**
+     * A decimal or grouped spelling means the same value: a vulgar fraction
+     * may become 0,5 or 0.25, a plain thousand may come back grouped, while
+     * a decimal of a different value keeps the error. An enumeration is not
+     * a decimal: its numbers keep their individual checks.
+     */
+    @Test
+    public void testSeparatorSpellingsCountByValue() throws Exception {
+        ErrorReport report = new ErrorReport("add ¼ measure", "füge 0,25 Maß hinzu");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertTrue(report.isEmpty());
+
+        report = new ErrorReport("misst 1000 Meter", "misst 1.000 Meter");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertTrue(report.isEmpty());
+
+        report = new ErrorReport("misst 0,5 Liter", "misst ½ Liter");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertTrue(report.isEmpty());
+
+        report = new ErrorReport("add ¼ measure", "füge 0,3 Maß hinzu");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertEquals(1, report.srcErrors.size());
+
+        // 5, 6 and 8 are three numbers, not a decimal: the unmatched 7
+        // reports alone.
+        report = new ErrorReport("Seiten 5, 6, 7", "Seiten 5, 6, 8");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertEquals(TagError.MISSING, report.srcErrors.get(new Tag(13, "7")));
+        assertEquals(1, report.srcErrors.size());
+    }
+
+    /**
+     * A compatibility spelling inside an ordinary word is not a numeral:
+     * the Roman twelve hides in taxiing, but the plane does not satisfy the
+     * chapter number.
+     */
+    @Test
+    public void testCompatibilitySpellingNeedsWordBoundaries() throws Exception {
+        ErrorReport report = new ErrorReport("chapter ⅻ opens", "the taxiing plane");
+        TagValidation.inspectNumerals(new ArrayList<>(), new ArrayList<>(), report);
+        assertEquals(TagError.MISSING, report.srcErrors.get(new Tag("chapter ".length(), "ⅻ")));
+    }
+
+    /**
+     * The full pipeline through {@link TagValidation#inspectOmegaTTags}:
+     * custom-tag numerals pair verbatim first and by value beyond that
+     * budget, digits inside an OmegaT tag stay out of the numeral check,
+     * and the digit runs of a decimal number do not demand verbatim
+     * pairings of their own.
+     */
+    @Test
+    public void testInspectOmegaTTagsChecksNumeralsEndToEnd() throws Exception {
+        TestPreferencesInitializer.init();
+
+        // A protected numeral rewritten in another notation raises no
+        // issue; the digits inside the OmegaT tag are no numerals.
+        SourceTextEntry ste = entry("Im Jahr 1984 <x12/>", "1984", "<x12/>");
+        ErrorReport report = new ErrorReport(ste.getSrcText(), "ⅯⅭⅯⅬⅩⅩⅩⅣ年 <x12/>");
+        TagValidation.inspectOmegaTTags(ste, report);
+        assertTrue(report.isEmpty());
+
+        // A changed value keeps its error.
+        ste = entry("Im Jahr 1984", "1984");
+        report = new ErrorReport(ste.getSrcText(), "ⅯⅭⅯⅬⅩⅩⅩⅤ年");
+        TagValidation.inspectOmegaTTags(ste, report);
+        assertEquals(TagError.MISSING, report.srcErrors.get(new Tag("Im Jahr ".length(), "1984")));
+
+        // One verbatim pairing consumes one source tag; the second tag of
+        // the same spelling is satisfied by an equal value in another
+        // notation.
+        ste = entry("12 Kisten und 12 Säcke", "12");
+        report = new ErrorReport(ste.getSrcText(), "12 Äpfel und ١٢ Birnen");
+        TagValidation.inspectOmegaTTags(ste, report);
+        assertTrue(report.isEmpty());
+
+        // The digit runs of a decimal number leave the verbatim tag check
+        // to the value comparison of the number as a whole.
+        ste = entry("misst 0,5 Liter", "0", "5");
+        report = new ErrorReport(ste.getSrcText(), "misst ½ Liter");
+        TagValidation.inspectOmegaTTags(ste, report);
+        assertTrue(report.isEmpty());
+    }
+
+    private static SourceTextEntry entry(String source, String... protectedTexts) {
+        List<ProtectedPart> protectedParts = new ArrayList<>();
+        for (String text : protectedTexts) {
+            ProtectedPart part = new ProtectedPart();
+            part.setTextInSourceSegment(text);
+            part.setDetailsFromSourceFile(text);
+            protectedParts.add(part);
+        }
+        return new SourceTextEntry(new EntryKey("file.txt", source, null, null, null, null), 1, null,
+                null, protectedParts);
     }
 
     protected static List<Tag> getList(String[] array) {

--- a/src/test/java/org/omegat/core/team2/ProjectSettingsTeamRoundTripTest.java
+++ b/src/test/java/org/omegat/core/team2/ProjectSettingsTeamRoundTripTest.java
@@ -1,0 +1,168 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectSettingsStorage;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that a per-project team setting survives the team project round
+ * trip in its sidecar file omegat/project_settings.properties: the routine
+ * full sync distributes and supersedes it like any other configuration file,
+ * a purely local file survives the sync and is recognisable as local-only
+ * divergence through the repository comparison.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectSettingsTeamRoundTripTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "readme.txt").toPath(), "team project",
+                StandardCharsets.UTF_8);
+        // the provider detects the repository type at construction time, so
+        // the remote must be a git repository before newProvider runs
+        commitRemote("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    @Test
+    public void testTeamOpenDeliversTheRemoteSettingsFile() throws Exception {
+        writeRemoteSettings(KEY + "=true\n");
+        commitRemote("team with the option");
+
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("the full sync must deliver the settings file", "true",
+                ProjectSettingsStorage.load(config, KEY));
+        assertTrue("a delivered file is identical to the repository copy",
+                provider.isIdenticalInRepositories(settingsPathUnderRoot()));
+    }
+
+    @Test
+    public void testRemoteFileSupersedesADivergingLocalFile() throws Exception {
+        writeRemoteSettings(KEY + "=false\n");
+        commitRemote("team without the option");
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        // the pre-sync snapshot is what the open uses to notice and report
+        // the superseded local value
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("on open, the team's file wins", "false", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    @Test
+    public void testLocalOnlyFileSurvivesTheSyncAndReadsAsDivergence() throws Exception {
+        commitRemote("team without a settings file");
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("a file the team never had survives the full sync", "true",
+                ProjectSettingsStorage.load(config, KEY));
+        assertFalse("the survivor is recognisable as local-only, so the open "
+                + "keeps the team default active and asks",
+                provider.isIdenticalInRepositories(settingsPathUnderRoot()));
+    }
+
+    private String settingsPathUnderRoot() {
+        return OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
+    }
+
+    private void writeRemoteSettings(String content) throws Exception {
+        File f = new File(remoteDir,
+                OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+        Files.createDirectories(f.getParentFile().toPath());
+        Files.writeString(f.toPath(), content, StandardCharsets.UTF_8);
+    }
+
+    private void commitRemote(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}

--- a/src/test/java/org/omegat/gui/editor/mark/NumeralMarkerTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/NumeralMarkerTest.java
@@ -29,12 +29,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.awt.Color;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.ProtectedPart;
+import org.omegat.core.data.SourceTextEntry;
 import org.omegat.util.TestPreferencesInitializer;
 import org.omegat.util.gui.Styles;
 
@@ -126,5 +130,59 @@ public class NumeralMarkerTest {
     public void testPlainTextYieldsNoMarks() throws Exception {
         assertEquals(0, new NumeralMarker().getMarksForEntry(null, "ohne Zahlen", "without numbers", true)
                 .size());
+    }
+
+    /**
+     * A number the custom tag pattern turned into a protected part is still
+     * a numeral to this marker - the numeral check compares it by value -
+     * while the digits inside a real OmegaT tag stay with the tag checks.
+     */
+    @Test
+    public void testCustomPatternNumbersAreMarkedRealTagsAreNot() throws Exception {
+        String source = "Im Jahr 1984 <x12/>";
+        SourceTextEntry ste = entry(source, "1984", "<x12/>");
+        List<Mark> marks = new NumeralMarker().getMarksForEntry(ste, source, null, true);
+
+        assertEquals(1, marks.size());
+        assertEquals(source.indexOf("1984"), marks.get(0).startOffset);
+        assertEquals(source.indexOf("1984") + "1984".length(), marks.get(0).endOffset);
+    }
+
+    /**
+     * The digit runs of a decimal number, protected one by one under the
+     * default custom tag pattern, do not break the number's single mark.
+     */
+    @Test
+    public void testProtectedDigitRunsKeepTheDecimalAsOneMark() throws Exception {
+        String source = "misst 0,5 Liter";
+        SourceTextEntry ste = entry(source, "0", "5");
+        List<Mark> marks = new NumeralMarker().getMarksForEntry(ste, source, null, true);
+
+        assertEquals(1, marks.size());
+        assertEquals(source.indexOf("0,5"), marks.get(0).startOffset);
+        assertEquals(source.indexOf("0,5") + "0,5".length(), marks.get(0).endOffset);
+    }
+
+    /** A numeral inside a protected part that is no numeral stays unmarked. */
+    @Test
+    public void testNumbersInsideNonNumeralProtectedPartsAreNotMarked() throws Exception {
+        String source = "siehe %1$s hier: 7";
+        SourceTextEntry ste = entry(source, "%1$s");
+        List<Mark> marks = new NumeralMarker().getMarksForEntry(ste, source, null, true);
+
+        assertEquals(1, marks.size());
+        assertEquals(source.indexOf(": 7") + 2, marks.get(0).startOffset);
+    }
+
+    private static SourceTextEntry entry(String source, String... protectedTexts) {
+        List<ProtectedPart> protectedParts = new ArrayList<>();
+        for (String text : protectedTexts) {
+            ProtectedPart part = new ProtectedPart();
+            part.setTextInSourceSegment(text);
+            part.setDetailsFromSourceFile(text);
+            protectedParts.add(part);
+        }
+        return new SourceTextEntry(new EntryKey("file.txt", source, null, null, null, null), 1, null,
+                null, protectedParts);
     }
 }

--- a/src/test/java/org/omegat/gui/editor/mark/NumeralMarkerTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/NumeralMarkerTest.java
@@ -1,0 +1,130 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.mark;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.awt.Color;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.util.TestPreferencesInitializer;
+import org.omegat.util.gui.Styles;
+
+/**
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class NumeralMarkerTest {
+
+    @Before
+    public final void setUp() throws Exception {
+        TestPreferencesInitializer.init();
+        Styles.EditorColor.COLOR_NUMERALS.setColor(new Color(0x0000ff));
+    }
+
+    @After
+    public final void tearDown() {
+        Styles.EditorColor.COLOR_NUMERALS.setColor(null);
+    }
+
+    /** Without a color of its own, the marker paints nothing at all. */
+    @Test
+    public void testWithoutAColorNothingIsPainted() throws Exception {
+        Styles.EditorColor.COLOR_NUMERALS.setColor(null);
+        assertNull(new NumeralMarker().getMarksForEntry(null, "misst 1984 Meter", null, true));
+    }
+
+    /**
+     * Every numeral of the entry is underlined, in the source and in the
+     * translation, whatever the writing system.
+     */
+    @Test
+    public void testNumeralsOfBothSidesAreMarked() throws Exception {
+        String source = "បានកត់ត្រា ១២៣៤៥៦ គ្រួសារ";
+        String translation = "erfasste 123456 Haushalte";
+        List<Mark> marks = new NumeralMarker().getMarksForEntry(null, source, translation, true);
+
+        assertEquals(2, marks.size());
+        Mark sourceMark = marks.get(0);
+        assertEquals(Mark.ENTRY_PART.SOURCE, sourceMark.entryPart);
+        assertEquals(source.indexOf("១២៣៤៥៦"), sourceMark.startOffset);
+        assertEquals(source.indexOf("១២៣៤៥៦") + "១២៣៤៥៦".length(), sourceMark.endOffset);
+        Mark translationMark = marks.get(1);
+        assertEquals(Mark.ENTRY_PART.TRANSLATION, translationMark.entryPart);
+        assertEquals(translation.indexOf("123456"), translationMark.startOffset);
+    }
+
+    /** A numeral inside a tag belongs to the tag checks, not to this marker. */
+    @Test
+    public void testNumeralsInsideTagsAreNotMarked() throws Exception {
+        List<Mark> marks = new NumeralMarker().getMarksForEntry(null, "siehe <x12/> hier: 7",
+                "voir <x12/> ici : 7", true);
+
+        assertEquals(2, marks.size());
+        assertEquals("siehe <x12/> hier: ".length(), marks.get(0).startOffset);
+    }
+
+    /** A separator-written number is one mark, not one mark per digit run. */
+    @Test
+    public void testSeparatedNumbersMarkAsOneToken() throws Exception {
+        String source = "misst 1.000 Meter";
+        List<Mark> marks = new NumeralMarker().getMarksForEntry(null, source, null, true);
+
+        assertEquals(1, marks.size());
+        assertEquals(source.indexOf("1.000"), marks.get(0).startOffset);
+        assertEquals(source.indexOf("1.000") + "1.000".length(), marks.get(0).endOffset);
+        assertNull("Both readings of 1.000 are possible, so no tooltip takes sides",
+                marks.get(0).toolTipText);
+    }
+
+    /**
+     * A numeral whose spelling reads differently from plain digits carries
+     * its value as the tooltip; a plain digit run needs none.
+     */
+    @Test
+    public void testTooltipCarriesTheValueWhenItReadsDifferently() throws Exception {
+        List<Mark> marks = new NumeralMarker().getMarksForEntry(null, "ជំពូក ១២", "Kapitel 12", true);
+
+        assertEquals(2, marks.size());
+        assertEquals("= 12", marks.get(0).toolTipText);
+        assertNull(marks.get(1).toolTipText);
+
+        marks = new NumeralMarker().getMarksForEntry(null, "misst 0,5 Liter", null, true);
+        assertEquals(1, marks.size());
+        assertEquals("= 1/2", marks.get(0).toolTipText);
+    }
+
+    /** Text without numerals yields no marks. */
+    @Test
+    public void testPlainTextYieldsNoMarks() throws Exception {
+        assertEquals(0, new NumeralMarker().getMarksForEntry(null, "ohne Zahlen", "without numbers", true)
+                .size());
+    }
+}

--- a/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -173,24 +173,348 @@ public class MatchesTextAreaTest {
         assertEquals("p 9 q ８",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
 
-        // Documented limit: full-width DECIMALS are not recognized as numbers
-        // (Double.parseDouble is ASCII-only), so no substitution happens. This
-        // pins the current scope; extending to full-width decimals is a
-        // possible follow-up.
+        // Documented limit: a full-width DECIMAL is not a single number, because
+        // the full-width full stop is not read as a decimal separator, so no
+        // substitution happens. This pins the current scope; extending to
+        // full-width decimals is a possible follow-up.
         source = "x ５．５";
         srcMatch = "x １．１";
         trgMatch = "foo 1.1";
         assertEquals("foo 1.1", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
 
-        // Documented scope boundary: Arabic-Indic digits (U+0660-U+0669) and
-        // Extended Arabic-Indic digits (U+06F0-U+06F9) are recognized as
-        // numbers but are NOT width-normalized by #1193, so such a source
-        // number is inserted verbatim rather than converted. Cross
-        // numeral-system handling is intentionally out of scope here.
+        // Arabic-Indic digits (U+0660-U+0669) carry the same values as their
+        // ASCII counterparts, and the inserted number follows the digit script
+        // of the target token it replaces, so a Latin target receives ASCII
+        // digits.
         source = "x ٩";
         srcMatch = "x 8";
         trgMatch = "foo 8";
+        assertEquals("foo 9",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // ... and the other way round: an Arabic-Indic target keeps its script.
+        source = "x 9";
+        srcMatch = "x 8";
+        trgMatch = "foo ٨";
         assertEquals("foo ٩",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Numbers are compared and paired by value, so the same number written in a
+     * different numeral system counts as the same number. Roman numerals are the
+     * exception, and only where they are written with Latin letters: see
+     * {@link #testUppercaseRomanWordsAreNotNumbers()}.
+     */
+    @Test
+    public void testReplaceNumbersAcrossNumeralSystems() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // A Roman numeral written with the dedicated code points is unambiguous
+        // and counts, so the numbers pair up and the source number is inserted.
+        String source = "Kapitel 7";
+        String srcMatch = "Kapitel 4";
+        String trgMatch = "Chapter Ⅳ";
+        assertEquals("Chapter 7",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Written with Latin letters the same numeral is not a number here, so
+        // the counts disagree and the match is left alone.
+        trgMatch = "Chapter IV";
+        assertEquals("Chapter IV",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Han numerals are numbers as well, including multi-character ones.
+        source = "chapter 五";
+        srcMatch = "chapter 十二";
+        trgMatch = "Kapitel 12";
+        assertEquals("Kapitel 5",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Where a number begins and ends is the tokenizer's decision, not ours:
+        // the default tokenizer keeps a run of ideographs together, so the
+        // numeral inside the Han word below never becomes a token of its own and
+        // the segment holds no number at all.
+        source = "第五章";
+        srcMatch = "第八章";
+        trgMatch = "Chapter 8";
+        assertEquals("Chapter 8",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Ordinary words that look like numerals must not be touched: "mix" is
+        // not a lowercase Roman 1009, and "civil" is not 106. The segment
+        // carries a real number as well, so the assertion tells the two cases
+        // apart: were "mix" counted, the number counts would disagree and no
+        // substitution would happen at all.
+        source = "the mix of 3 civil laws";
+        srcMatch = "the mix of 5 civil laws";
+        trgMatch = "die Mischung aus 5 Zivilgesetzen";
+        assertEquals("die Mischung aus 3 Zivilgesetzen",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Values are exact and unbounded: numbers far beyond the range and the
+     * precision of a double are substituted digit for digit, and two numbers
+     * that differ only beyond that precision are recognized as different.
+     */
+    @Test
+    public void testReplaceNumbersArbitraryPrecision() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // A 40-digit integer is inserted verbatim, with no rounding and no
+        // exponent notation.
+        String big = "1234567890123456789012345678901234567890";
+        String source = "id " + big;
+        String srcMatch = "id 7";
+        String trgMatch = "Kennung 7";
+        assertEquals("Kennung " + big,
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Two 20-digit numbers that a double would round to the same value are
+        // different numbers, so the guard refuses the substitution.
+        source = "id 99999999999999999999";
+        srcMatch = "id 99999999999999999998";
+        trgMatch = "Kennung 99999999999999999997";
+        assertEquals("Kennung 99999999999999999997",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // The same for decimals: a difference in the twentieth decimal place is
+        // a real difference, and it is not lost.
+        source = "value 1.00000000000000000001";
+        srcMatch = "value 1.00000000000000000002";
+        trgMatch = "Wert 1.00000000000000000003";
+        assertEquals("Wert 1.00000000000000000003",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A long decimal that does match is carried over exactly.
+        source = "value 2.71828182845904523536028747135266249776";
+        srcMatch = "value 3.14159265358979323846264338327950288420";
+        trgMatch = "Wert 3.14159265358979323846264338327950288420";
+        assertEquals("Wert 2.71828182845904523536028747135266249776",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * The numbers of a match may appear in any order in its target, and they may
+     * repeat. Every target number must receive the source number that belongs to
+     * it, whatever the permutation.
+     */
+    @Test
+    public void testReplaceNumbersPermutations() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // A cyclic permutation: the target order 2, 3, 1 must pick up the source
+        // numbers that stand where those numbers stand in the match's source.
+        String source = "a 7 b 8 c 9";
+        String srcMatch = "a 1 b 2 c 3";
+        String trgMatch = "x 2 y 3 z 1";
+        assertEquals("x 8 y 9 z 7",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // The same numbers in different multiplicities are not the same set of
+        // numbers; refusing here also keeps every target number mapped.
+        source = "a 7 b 8 c 9";
+        srcMatch = "a 1 b 1 c 2";
+        trgMatch = "x 1 y 2 z 2";
+        assertEquals("x 1 y 2 z 2",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A repeated number is substituted in every place it occurs.
+        source = "a 7 b 7 c 9";
+        srcMatch = "a 1 b 1 c 2";
+        trgMatch = "x 2 y 1 z 1";
+        assertEquals("x 9 y 7 z 7",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A permutation that is not its own inverse. Reversing a pair or a
+        // triple hides a mapping that runs in the wrong direction, because
+        // those permutations equal their inverse; a four-element cycle does
+        // not, so this is the case that pins the direction of the mapping.
+        source = "a 10 b 20 c 30 d 40";
+        srcMatch = "a 1 b 2 c 3 d 4";
+        trgMatch = "w 2 x 3 y 4 z 1";
+        assertEquals("w 20 x 30 y 40 z 10",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * What counts as a number here is decided token by token, so a number glued
+     * to a symbol is only reached when the tokenizer happens to separate the
+     * two. The cases below pin today's reach. The ones marked as gaps are not
+     * intended behaviour: a percentage, a currency amount, a dotted date and an
+     * ordinal are all values the number conversion window already reads and
+     * writes locale by locale, and match insertion should end up using the same
+     * notion of a number rather than the bare token parser.
+     */
+    @Test
+    public void testReplaceNumbersReachOfTheTokenNotion() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Separated by a space, the amount is an ordinary number token and is
+        // substituted; the unit travels along untouched.
+        String source = "Preis 30 EUR für 4 Stück";
+        String srcMatch = "Preis 50 EUR für 6 Stück";
+        String trgMatch = "Price 50 EUR for 6 items";
+        assertEquals("Price 30 EUR for 4 items",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // GAP: glued to a percent or a currency sign it is one token with no
+        // value, so the match's own figure survives although the source
+        // disagrees - the translator is handed 50% where the segment says 30%.
+        source = "Rabatt 30% auf 4 Artikel";
+        srcMatch = "Rabatt 50% auf 6 Artikel";
+        trgMatch = "50% discount on 6 items";
+        assertEquals("50% discount on 4 items",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        source = "Preis $30 für 4";
+        srcMatch = "Preis $50 für 6";
+        trgMatch = "Price $50 for 4";
+        assertEquals("Price $50 for 4",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A date whose parts are separated becomes three numbers and is carried
+        // over part by part - including across a different date order in the
+        // target, which is exactly the case a mapping in the wrong direction
+        // would scramble.
+        source = "am 2024-03-07";
+        srcMatch = "am 2024-01-06";
+        trgMatch = "on 01/06/2024";
+        assertEquals("on 03/07/2024",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // GAP: a dotted date is a single token with no value, so the stale date
+        // of the match is left standing.
+        source = "am 07.03.2024";
+        srcMatch = "am 06.01.2024";
+        trgMatch = "on 06.01.2024";
+        assertEquals("on 06.01.2024",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A time separated by a colon is two numbers and is carried over.
+        source = "um 12:30 kamen 4";
+        srcMatch = "um 14:45 kamen 6";
+        trgMatch = "at 14:45 there were 6";
+        assertEquals("at 12:30 there were 4",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // GAP: an ordinal indicator makes the token unreadable as a number on
+        // the English side, so the counts disagree and nothing is substituted -
+        // although "3." and "3rd" are the same ordinal, and the conversion
+        // window already knows how to read and write both.
+        source = "der 4. Absatz";
+        srcMatch = "der 3. Absatz";
+        trgMatch = "the 3rd paragraph";
+        assertEquals("the 3rd paragraph",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Numbers keep their surroundings intact: inline tags, punctuation directly
+     * against a number, and a target that holds no number at all.
+     */
+    @Test
+    public void testReplaceNumbersLeavesSurroundingsAlone() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // OmegaT inline tags are ordinary text here and must come through byte
+        // for byte, including the digits inside the tag names.
+        String source = "<f1>Chapter 3</f1>";
+        String srcMatch = "<f1>Chapter 5</f1>";
+        String trgMatch = "<f1>Kapitel 5</f1>";
+        assertEquals("<f1>Kapitel 3</f1>",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        source = "Text <x0/> 3 items";
+        srcMatch = "Text <x0/> 5 items";
+        trgMatch = "Text <x0/> 5 Stück";
+        assertEquals("Text <x0/> 3 Stück",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A number pressed against punctuation and a percent sign.
+        source = "50% of 3, no more.";
+        srcMatch = "50% of 5, no more.";
+        trgMatch = "50% von 5, nicht mehr.";
+        assertEquals("50% von 3, nicht mehr.",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Empty input is not a special case, it simply holds no number.
+        assertEquals("", MatchesTextArea.substituteNumbers("", "", "", tok, tok));
+    }
+
+    /**
+     * The digit script of the target token is followed for every decimal script,
+     * including one outside the basic multilingual plane. A target token written
+     * in an algorithmic system that this code cannot write back (Han) falls back
+     * to plain digits rather than to the wrong number.
+     */
+    @Test
+    public void testReplaceNumbersDigitScripts() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Osmanya digits (U+104A0..) are surrogate pairs; the substituted number
+        // is written in that script, not in ASCII.
+        String source = "n 7";
+        String srcMatch = "n 5";
+        String trgMatch = "n 𐒥";
+        assertEquals("n 𐒧",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Documented limit: there is no writer for the Han system here, so a Han
+        // target receives the value spelled out in digits. The number is right,
+        // the notation is not preserved.
+        source = "chapter 7";
+        srcMatch = "chapter 12";
+        trgMatch = "第 十二 章";
+        assertEquals("第 7 章",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Regression guard for the substitution side: a token made only of Roman
+     * letters is a numeral only in the fuzzy-matching score, where a false
+     * positive costs a little similarity. Here it rewrites text the translator
+     * gets handed, so an ordinary uppercase word must never be read as a number.
+     *
+     * These cases fail as long as the substitution side uses the same
+     * unrestricted Roman gate as the match scorer. Fix the production code, not
+     * the expectations.
+     */
+    @Test
+    public void testUppercaseRomanWordsAreNotNumbers() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // The English pronoun "I" is a canonical Roman 1. Were it counted, it
+        // would take part in the pairing and be rewritten as a numeral: the
+        // target would read "II saw 8 birds 2 hours later."
+        String source = "2 Stunden später sah ich 8 Vögel.";
+        String srcMatch = "1 Stunde später sah ich 3 Vögel.";
+        String trgMatch = "I saw 3 birds 1 hour later.";
+        assertEquals("I saw 8 birds 2 hour later.",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // "X" as a size or a multiplier, and "MIX" as a word, are not 10 and 1009.
+        source = "Größe 3";
+        srcMatch = "Größe 10";
+        trgMatch = "Size X";
+        assertEquals("Size X", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // The same rule the other way round: a Roman-looking word in the source
+        // or in the match must not silently switch the whole feature off by
+        // making the number counts disagree.
+        source = "I have 3 apples";
+        srcMatch = "I have 5 apples";
+        trgMatch = "Ich habe 5 Äpfel";
+        assertEquals("Ich habe 3 Äpfel",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // "IV" reads as intravenous far more often than as 4, and "V" prefixes a
+        // version far more often than it counts five.
+        source = "Gabe von 3 ml";
+        srcMatch = "Gabe von 4 ml";
+        trgMatch = "IV administration of 4 ml";
+        assertEquals("IV administration of 3 ml",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
     }
 

--- a/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -211,11 +211,12 @@ public class MatchesTextAreaTest {
         ITokenizer tok = new DefaultTokenizer();
 
         // A Roman numeral written with the dedicated code points is unambiguous
-        // and counts, so the numbers pair up and the source number is inserted.
+        // and counts, so the numbers pair up and the source value is written
+        // back in the target's own notation.
         String source = "Kapitel 7";
         String srcMatch = "Kapitel 4";
         String trgMatch = "Chapter Ⅳ";
-        assertEquals("Chapter 7",
+        assertEquals("Chapter Ⅶ",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
 
         // Written with Latin letters the same numeral is not a number here, so
@@ -461,13 +462,12 @@ public class MatchesTextAreaTest {
         assertEquals("n 𐒧",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
 
-        // Documented limit: there is no writer for the Han system here, so a Han
-        // target receives the value spelled out in digits. The number is right,
-        // the notation is not preserved.
+        // A Han target keeps its notation: the source value is written through
+        // the same ICU rule set that read the target number.
         source = "chapter 7";
         srcMatch = "chapter 12";
         trgMatch = "第 十二 章";
-        assertEquals("第 7 章",
+        assertEquals("第 七 章",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
     }
 
@@ -534,5 +534,153 @@ public class MatchesTextAreaTest {
         String trgMatch = "This is a sample sentence 8";
         assertEquals("This is a sample sentence 9",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, jaTok, enTok));
+    }
+
+    /**
+     * Sign numerals of the Number-Other category (Mayan and Kaktovik digits,
+     * Ethiopic composites, cuneiform and others) pair by value and are
+     * spelled out as digits in a digit-writing target.
+     */
+    @Test
+    public void testSubstituteSignNumerals() {
+        ITokenizer tok = new DefaultTokenizer();
+        String mayanNineteen = new String(Character.toChars(0x1D2F3));
+        String mayanEleven = new String(Character.toChars(0x1D2EB));
+        assertEquals("day 19 dawns",
+                MatchesTextArea.substituteNumbers("day " + mayanNineteen + " dawns",
+                        "day " + mayanEleven + " dawns", "day 11 dawns", tok, tok));
+
+        String ethiopic1976 = "፲፱፻፸፮";
+        String ethiopic1974 = "፲፱፻፸፬";
+        assertEquals("year 1976 begins",
+                MatchesTextArea.substituteNumbers("year " + ethiopic1976 + " begins",
+                        "year " + ethiopic1974 + " begins", "year 1974 begins", tok, tok));
+
+        String cuneiformLarge = new String(Character.toChars(0x12433));
+        String cuneiformHalf = new String(Character.toChars(0x12432));
+        assertEquals("tally 432000 sila",
+                MatchesTextArea.substituteNumbers("tally " + cuneiformLarge + " sila",
+                        "tally " + cuneiformHalf + " sila", "tally 216000 sila", tok, tok));
+    }
+
+    /**
+     * When the target match writes its number in a numeral system rather than
+     * digits, the source value is written in that same system: composed
+     * additively for sign systems, positionally for the base-twenty digit
+     * blocks, and through the ICU rule sets for the algorithmic systems.
+     */
+    @Test
+    public void testSubstituteAcrossNumeralSystems() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Ethiopic source value 840, Aegean target: composed as 800 plus 40
+        String aegean600 = new String(Character.toChars(0x1011E));
+        String aegean840 = new String(Character.toChars(0x10120)) + new String(Character.toChars(0x10113));
+        assertEquals("toll " + aegean840 + " due",
+                MatchesTextArea.substituteNumbers("toll ፰፻፵ due", "toll ፮፻ due",
+                        "toll " + aegean600 + " due", tok, tok));
+
+        // Ethiopic source value 40, Mayan digit target: positional base twenty
+        String mayanNine = new String(Character.toChars(0x1D2E9));
+        String mayanForty = new String(Character.toChars(0x1D2E2)) + new String(Character.toChars(0x1D2E0));
+        assertEquals("count " + mayanForty + " tuns",
+                MatchesTextArea.substituteNumbers("count ፵ tuns", "count ፱ tuns",
+                        "count " + mayanNine + " tuns", tok, tok));
+
+        // Meroitic source value 900000, Ethiopic target: the rule set that
+        // writes the template back verbatim also writes the value - and no
+        // other, so a Roman or grouped-digit rendition would fail here.
+        String meroiticLarge = new String(Character.toChars(0x109F5));
+        String meroiticThousand = new String(Character.toChars(0x109DB));
+        assertEquals("stock ፺፼ kept",
+                MatchesTextArea.substituteNumbers("stock " + meroiticLarge + " kept",
+                        "stock " + meroiticThousand + " kept", "stock ፲፻ kept", tok, tok));
+    }
+
+    /**
+     * A sequence of numeral signs from one block reads as one number: additive
+     * sums for the historic systems, positional base twenty for the Mayan
+     * digit block - so those numbers pair and substitute like any other.
+     */
+    @Test
+    public void testSignSequencesReadAsOneNumber() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Aegean 1984 written additively (1000, 900, 80, 4) in the source
+        String aegean1984 = new String(Character.toChars(0x10122)) + new String(Character.toChars(0x10121))
+                + new String(Character.toChars(0x10117)) + new String(Character.toChars(0x1010A));
+        assertEquals("anno 1984 scripta",
+                MatchesTextArea.substituteNumbers("year " + aegean1984 + " written", "year 1291 written",
+                        "anno 1291 scripta", tok, tok));
+
+        // Mayan two-digit positional source value: 1;0 in base twenty is 20
+        String mayanTwenty = new String(Character.toChars(0x1D2E1)) + new String(Character.toChars(0x1D2E0));
+        assertEquals("cycle 20 closes",
+                MatchesTextArea.substituteNumbers("cycle " + mayanTwenty + " closes", "cycle 13 closes",
+                        "cycle 13 closes", tok, tok));
+    }
+
+    /**
+     * A composition is only inserted when it is valid notation in the target's
+     * system: Roman forty is written subtractively rather than as a pile of
+     * twelves, counting rods are positional and cannot be composed (the value
+     * arrives in plain digits), and a fractional sign value has no digit
+     * spelling at all, so the target keeps its own number.
+     */
+    @Test
+    public void testInvalidCompositionsNeverReachTheTarget() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        assertEquals("Chapter ⅩⅬ", MatchesTextArea.substituteNumbers("Kapitel 40", "Kapitel 4",
+                "Chapter Ⅳ", tok, tok));
+
+        String rods32 = new String(Character.toChars(0x1D36B)) + new String(Character.toChars(0x1D361));
+        assertEquals("silk 432 bolts", MatchesTextArea.substituteNumbers("bolt 432", "bolt 32",
+                "silk " + rods32 + " bolts", tok, tok));
+
+        // A fractional sign value is spelled out as a digit fraction.
+        assertEquals("mische 1/4 Tassen", MatchesTextArea.substituteNumbers("mix ꠰ cup", "mix 2 cup",
+                "mische 2 Tassen", tok, tok));
+    }
+
+    /**
+     * A genuine number in a segment substitutes even when a protected
+     * presentation form sits next to it, and the decoration numbers of the
+     * dingbat blocks are never treated as numbers at all.
+     */
+    @Test
+    public void testProtectedFormsDoNotBlockRealNumbers() {
+        ITokenizer tok = new DefaultTokenizer();
+        assertEquals("room 7 measures 3² units",
+                MatchesTextArea.substituteNumbers("room 7 measures 5² units", "room 4 measures 3² units",
+                        "room 4 measures 3² units", tok, tok));
+        assertEquals("❷ item 9", MatchesTextArea.substituteNumbers("❶ item 9", "❷ item 4",
+                "❷ item 4", tok, tok));
+    }
+
+    /**
+     * Presentation forms with a compatibility decomposition stay out of the
+     * substitution - a superscript exponent and an enclosed number must never
+     * be rewritten, so those target matches stay untouched even though the
+     * values differ. The precomposed vulgar fractions are real numbers and
+     * substitute like any other, glyph for glyph.
+     */
+    @Test
+    public void testPresentationFormsStayUntouched() {
+        ITokenizer tok = new DefaultTokenizer();
+        assertEquals("area 3² units", MatchesTextArea.substituteNumbers("area 5² units",
+                "area 3² units", "area 3² units", tok, tok));
+        assertEquals("floor ⑫ opens", MatchesTextArea.substituteNumbers("floor ⑪ opens",
+                "floor ⑫ opens", "floor ⑫ opens", tok, tok));
+        assertEquals("add ¼ measure", MatchesTextArea.substituteNumbers("add ¼ measure",
+                "add ½ measure", "add ½ measure", tok, tok));
+        assertEquals("knead ¾ portion", MatchesTextArea.substituteNumbers("knead ¾ portion",
+                "knead ⅔ portion", "knead ⅔ portion", tok, tok));
+        // A value no glyph carries (a Meroitic twelfth) is spelled out as a
+        // digit fraction: the right value in a foreign notation beats the
+        // target's own, wrong one.
+        String meroiticTwelfth = new String(Character.toChars(0x109F6));
+        assertEquals("pour 1/12 barrel", MatchesTextArea.substituteNumbers("pour " + meroiticTwelfth + " barrel",
+                "pour ⅚ barrel", "pour ⅚ barrel", tok, tok));
     }
 }

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -494,11 +494,11 @@ public class NumeralValueParserTest {
         assertEquals(Optional.of("3/4"), NumeralValueParser.parseTokenValue("3/4", true).map(Object::toString));
         assertFalse(NumeralValueParser.parseTokenValue("mix", true).isPresent());
 
-        // Deliberate boundary: Number-Other code points are not numeral tokens,
-        // so an exponent, a vulgar fraction and an enclosed number stay out of
-        // the number comparisons even though they carry a numeric value.
+        // Deliberate boundary: an exponent and an enclosed number stay out of
+        // the number comparisons even though they carry a numeric value; the
+        // precomposed vulgar fractions are real numbers and count.
         assertFalse(NumeralValueParser.parseTokenValue("²", true).isPresent());
-        assertFalse(NumeralValueParser.parseTokenValue("¾", true).isPresent());
+        assertEquals(Optional.of("3/4"), NumeralValueParser.parseTokenValue("¾", true).map(Object::toString));
         assertFalse(NumeralValueParser.parseTokenValue("⑩", true).isPresent());
 
         // Deliberate boundary: a Roman form without I, V or X is a unit or an
@@ -534,5 +534,67 @@ public class NumeralValueParserTest {
                 NumeralValueParser.parseTokenValue("99999999999999999998", true));
     }
 
+    /**
+     * The Number Forms block is never composed additively - forty is not four
+     * twelves. The Roman rule sets write the value subtractively instead, in
+     * the template's case, preferring the precomposed forms one to twelve.
+     */
+    @Test
+    public void renderRomanFormsSubtractively() {
+        assertEquals(Optional.of("ⅩⅬ"), NumeralValueParser.renderInSystemOf(BigInteger.valueOf(40), "Ⅳ"));
+        assertEquals(Optional.of("ⅹⅼ"), NumeralValueParser.renderInSystemOf(BigInteger.valueOf(40), "ⅳ"));
+        assertEquals(Optional.of("ⅯⅭⅯⅬⅩⅩⅩⅠⅤ"),
+                NumeralValueParser.renderInSystemOf(BigInteger.valueOf(1984), "Ⅻ"));
+        assertEquals(Optional.of("Ⅶ"), NumeralValueParser.renderInSystemOf(BigInteger.valueOf(7), "Ⅻ"));
+        assertEquals(Optional.of("ⅶ"), NumeralValueParser.renderInSystemOf(BigInteger.valueOf(7), "ⅻ"));
+    }
 
+    /**
+     * Counting rods are positional above the tens, so a greedy additive
+     * spelling would be invalid notation: the block is read, never written.
+     */
+    @Test
+    public void countingRodsAreReadButNotWritten() {
+        String rods32 = new String(Character.toChars(0x1D36B)) + new String(Character.toChars(0x1D361));
+        assertEquals(Optional.of(BigInteger.valueOf(32)),
+                NumeralValueParser.parseTokenWhole(rods32, false));
+        assertEquals(Optional.empty(),
+                NumeralValueParser.renderInSystemOf(BigInteger.valueOf(432), rods32));
+    }
+
+    /**
+     * A fraction value renders as the precomposed vulgar-fraction glyph when
+     * the template is such a glyph and a glyph with exactly that value
+     * exists; anything else stays unwritable.
+     */
+    @Test
+    public void renderVulgarFractionsExactly() {
+        NumeralValueParser.Rational quarter = NumeralValueParser.parseValue("1/4").orElseThrow();
+        NumeralValueParser.Rational twoFifths = NumeralValueParser.parseValue("2/5").orElseThrow();
+        NumeralValueParser.Rational fiveSevenths = NumeralValueParser.parseValue("5/7").orElseThrow();
+
+        assertEquals(Optional.of("¼"), NumeralValueParser.renderVulgarFractionOf(quarter, "½"));
+        assertEquals(Optional.of("⅖"), NumeralValueParser.renderVulgarFractionOf(twoFifths, "⅓"));
+        // No precomposed glyph carries five sevenths.
+        assertEquals(Optional.empty(), NumeralValueParser.renderVulgarFractionOf(fiveSevenths, "½"));
+        // A non-fraction template is not written.
+        assertEquals(Optional.empty(), NumeralValueParser.renderVulgarFractionOf(quarter, "12"));
+    }
+
+    /**
+     * The sign numerals join the whole-token reading, so the match scorer
+     * pairs them just like the insertion step does.
+     */
+    @Test
+    public void wholeTokenFormReadsSignNumerals() {
+        String mayanTwenty = new String(Character.toChars(0x1D2E1))
+                + new String(Character.toChars(0x1D2E0));
+        assertEquals(Optional.of(BigInteger.valueOf(20)),
+                NumeralValueParser.parseTokenWhole(mayanTwenty, false));
+        String aegeanLarge = new String(Character.toChars(0x10133));
+        assertEquals(Optional.of(BigInteger.valueOf(90000)),
+                NumeralValueParser.parseTokenWhole(aegeanLarge, false));
+        // A fractional sign is a value, not a whole number.
+        assertFalse(NumeralValueParser.parseTokenWhole("꠰", false).isPresent());
+    }
 }

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -27,6 +27,7 @@ package org.omegat.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
@@ -467,5 +468,71 @@ public class NumeralValueParserTest {
         assertFalse(NumeralValueParser.parseWhole(",").isPresent());
         assertFalse(NumeralValueParser.parseWhole("don't").isPresent());
     }
+
+    /**
+     * The token forms gate letter-only input: a word must not become a numeral
+     * just because its letters happen to be Roman digits, while an unambiguous
+     * numeral of any system is read.
+     */
+    @Test
+    public void tokenFormsGateLetterOnlyInput() {
+        // Words made of Roman letters stay words, whatever ICU would read.
+        assertFalse(NumeralValueParser.parseTokenWhole("mix", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("civil", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("DID", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole(null, true).isPresent());
+
+        // Unambiguous numerals are read, by value.
+        assertEquals(Optional.of(BigInteger.valueOf(12)), NumeralValueParser.parseTokenWhole("XII", true));
+        assertEquals(Optional.of(BigInteger.valueOf(12)), NumeralValueParser.parseTokenWhole("十二", true));
+        assertEquals(Optional.of(BigInteger.valueOf(9)), NumeralValueParser.parseTokenWhole("٩", true));
+        assertEquals(Optional.of(BigInteger.valueOf(5)), NumeralValueParser.parseTokenWhole("５", true));
+
+        // The value form adds the non-integer numbers on top of the same gate.
+        assertEquals(Optional.of("3/2"), NumeralValueParser.parseTokenValue("1.5", true).map(Object::toString));
+        assertEquals(Optional.of("3/4"), NumeralValueParser.parseTokenValue("3/4", true).map(Object::toString));
+        assertFalse(NumeralValueParser.parseTokenValue("mix", true).isPresent());
+
+        // Deliberate boundary: Number-Other code points are not numeral tokens,
+        // so an exponent, a vulgar fraction and an enclosed number stay out of
+        // the number comparisons even though they carry a numeric value.
+        assertFalse(NumeralValueParser.parseTokenValue("²", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenValue("¾", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenValue("⑩", true).isPresent());
+
+        // Deliberate boundary: a Roman form without I, V or X is a unit or an
+        // abbreviation more often than a number.
+        assertFalse(NumeralValueParser.parseTokenWhole("L", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("M", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("CD", true).isPresent());
+
+        // Latin-letter Roman numerals are the caller's decision, because there is
+        // no telling them apart from ordinary uppercase words: the English
+        // pronoun, a size, a version prefix and a handful of words read as
+        // numbers where they are allowed and as prose where they are not.
+        for (String roman : new String[] { "I", "V", "X", "XL", "MIX", "DIV" }) {
+            assertTrue(roman, NumeralValueParser.parseTokenWhole(roman, true).isPresent());
+            assertFalse(roman, NumeralValueParser.parseTokenWhole(roman, false).isPresent());
+        }
+        assertEquals(Optional.of(BigInteger.ONE), NumeralValueParser.parseTokenWhole("I", true));
+        assertEquals(Optional.of(BigInteger.valueOf(1009)),
+                NumeralValueParser.parseTokenWhole("MIX", true));
+
+        // The switch is about Latin letters only: numerals of every other system,
+        // the dedicated Roman code points included, read the same either way.
+        for (String numeral : new String[] { "Ⅻ", "十二", "٩", "５", "12" }) {
+            assertEquals(numeral, NumeralValueParser.parseTokenWhole(numeral, true),
+                    NumeralValueParser.parseTokenWhole(numeral, false));
+            assertTrue(numeral, NumeralValueParser.parseTokenWhole(numeral, false).isPresent());
+        }
+
+        // Arbitrary length: the value is exact, not a double.
+        String big = "1234567890123456789012345678901234567890";
+        assertEquals(Optional.of(new BigInteger(big)), NumeralValueParser.parseTokenWhole(big, true));
+        assertNotEquals(NumeralValueParser.parseTokenValue("99999999999999999999", true),
+                NumeralValueParser.parseTokenValue("99999999999999999998", true));
+    }
+
 
 }

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -597,4 +597,29 @@ public class NumeralValueParserTest {
         // A fractional sign is a value, not a whole number.
         assertFalse(NumeralValueParser.parseTokenWhole("꠰", false).isPresent());
     }
+
+    /**
+     * A separator-written digit token means every value its spelling
+     * allows: a grouped integer, a decimal fraction, or both, while an
+     * enumeration-like spelling means none.
+     */
+    @Test
+    public void separatedSpellingsListTheirReadings() {
+        assertEquals(java.util.List.of(Rational.ofInteger(BigInteger.valueOf(35000000))),
+                NumeralValueParser.parseSeparatedValues("35\u00A0000\u00A0000", false));
+        // Mixed separators do not group.
+        assertTrue(NumeralValueParser.parseSeparatedValues("35\u00A0000\u0020000", false)
+                .isEmpty());
+        assertEquals(java.util.List.of(Rational.of(BigInteger.ONE, BigInteger.TWO)),
+                NumeralValueParser.parseSeparatedValues("0,5", false));
+        // 1.000 reads as a grouped thousand and as a decimal one.
+        assertEquals(java.util.List.of(Rational.ofInteger(BigInteger.valueOf(1000)),
+                Rational.ofInteger(BigInteger.ONE)),
+                NumeralValueParser.parseSeparatedValues("1.000", false));
+        assertTrue(NumeralValueParser.parseSeparatedValues("5,6,7", false).isEmpty());
+        // Without separators the plain token parse answers.
+        assertEquals(java.util.List.of(Rational.ofInteger(BigInteger.valueOf(12))),
+                NumeralValueParser.parseSeparatedValues("\u2169\u2160\u2160", false));
+    }
 }
+

--- a/src/test/java/org/omegat/util/PatternConstsTest.java
+++ b/src/test/java/org/omegat/util/PatternConstsTest.java
@@ -26,11 +26,13 @@
 package org.omegat.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -75,4 +77,28 @@ public class PatternConstsTest {
         assertEquals("Wrong country extracted", "abc", m.group(2));
     }
 
+    /**
+     * The numeral pattern covers numbers of every notation, not only ASCII
+     * digit runs: decimal digits of any script and the numerals of the
+     * sign-written systems, each matched as one run.
+     */
+    @Test
+    public void testNumeralsPatternCoversEveryNotation() {
+        Pattern p = PatternConsts.NUMERALS;
+        for (String numeral : new String[] { "1984", "١٩٨٤", "១២៣", "Ⅻ", "፲፱፻፸፮",
+                new String(Character.toChars(0x12433)),
+                new String(Character.toChars(0x1D2E1)) + new String(Character.toChars(0x1D2E0)) }) {
+            assertTrue("Numeral pattern should match " + numeral, p.matcher(numeral).matches());
+        }
+        assertTrue("Vulgar fractions are quantities and count",
+                p.matcher("¼").matches());
+        assertFalse("Words must stay unmatched", p.matcher("word").find());
+        assertFalse("Roman letters must stay unmatched", p.matcher("MIX").find());
+        // Decoration numbers - list bullets, footnote superscripts, enclosed
+        // and dingbat forms - number things rather than count them.
+        for (String decoration : new String[] { "⑫", "❶", "²", "¹²³", "⁴", "㋀" }) {
+            assertFalse("Decoration number should stay unmatched: " + decoration,
+                    p.matcher(decoration).find());
+        }
+    }
 }

--- a/src/testAcceptance/java/org/omegat/gui/matches/NumeralMatchesSubstitutionTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/matches/NumeralMatchesSubstitutionTest.java
@@ -1,0 +1,122 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.matches;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.beans.PropertyChangeListener;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.swing.SwingUtilities;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.gui.main.MainWindow;
+import org.omegat.gui.main.TestCoreGUI;
+import org.omegat.util.Preferences;
+
+/**
+ * End-to-end check of value-based fuzzy match number substitution (SF #465):
+ * loads project_numerals fixture like user project, {@code match_numbers} in
+ * omegat.project enables number matching, recycling match writes source
+ * segment's number into match target - read from and rendered into numeral
+ * systems beyond ASCII digits. Per-system rules: unit tests. Here: wiring
+ * only, on representative segments.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class NumeralMatchesSubstitutionTest extends TestCoreGUI {
+
+    private static final Path PROJECT_PATH = Paths.get("src/testAcceptance/resources/data/project_numerals/");
+
+    /**
+     * Demo segments live in source/exotic-numerals.txt;
+     * source/beyond-coverage.txt sorts first with two segments, so README
+     * segment numbers are offset by two.
+     */
+    private static final int FIRST_DEMO_ENTRY = 3;
+
+    @Test
+    public void testMatchInsertionSubstitutesNumbersByValue() throws Exception {
+        Preferences.setPreference(Preferences.CONVERT_NUMBERS, true);
+        openSampleProject(PROJECT_PATH);
+        assertTrue("Fixture's match_numbers setting must reach the loaded project.",
+                Core.getProject().getProjectProperties().isMatchNumbersEnabled());
+
+        // Demo segment 1, Western digits: source 1984 replaces match's 1750.
+        assertEquals("Das Lagerverzeichnis nennt 1984 Tonkrüge.",
+                recycledTranslationOfEntry(FIRST_DEMO_ENTRY));
+        // Demo segment 2, Khmer digits: source value rendered in match
+        // target's digit script.
+        assertEquals("Die Volkszählung von Angkor erfasste 123456 Haushalte.",
+                recycledTranslationOfEntry(FIRST_DEMO_ENTRY + 1));
+        // Demo segment 3, Ethiopic sign numerals: read by value, written as
+        // target's digits.
+        assertEquals("Die Chronik datiert die Synode auf das Jahr 1976.",
+                recycledTranslationOfEntry(FIRST_DEMO_ENTRY + 2));
+        // Demo segment 23, counting-rod target: rods never composed, value
+        // arrives as plain digits.
+        assertEquals("Das Rechenbrett zählt 432 Münzen.",
+                recycledTranslationOfEntry(FIRST_DEMO_ENTRY + 22));
+
+        closeProject();
+    }
+
+    /**
+     * Activates entry, waits for match, returns editor translation after
+     * recycling that match.
+     */
+    private String recycledTranslationOfEntry(int entryNum) throws Exception {
+        MatchesTextArea matcher = (MatchesTextArea) Core.getMatcher();
+        CountDownLatch matchArrived = new CountDownLatch(1);
+        // Entry check keeps stray events of previously activated entries from
+        // releasing latch early.
+        PropertyChangeListener waiter = evt -> SwingUtilities.invokeLater(() -> {
+            if (matcher.getActiveMatch() != null
+                    && Core.getEditor().getCurrentEntryNumber() == entryNum) {
+                matchArrived.countDown();
+            }
+        });
+        matcher.addPropertyChangeListener("matches", waiter);
+        try {
+            GuiActionRunner.execute(() -> Core.getEditor().gotoEntry(entryNum));
+            assertTrue("No match arrived for entry " + entryNum + ".",
+                    matchArrived.await(timeout, TimeUnit.SECONDS));
+        } finally {
+            matcher.removePropertyChangeListener("matches", waiter);
+        }
+        return GuiActionRunner.execute(() -> {
+            MainWindow.doRecycleTrans();
+            return Core.getEditor().getCurrentTranslation();
+        });
+    }
+}

--- a/src/testAcceptance/resources/data/project_numerals/README.md
+++ b/src/testAcceptance/resources/data/project_numerals/README.md
@@ -1,0 +1,114 @@
+# Exotic numerals demo project
+
+A minimal OmegaT project (English to German, `match_numbers` enabled in `omegat.project`)
+illustrating how far the value-based fuzzy match number handling of SF-465
+reaches across the numeral systems encoded in Unicode. Every example was
+verified against `NumeralValueParser` before it went into this project.
+
+Open the project folder in OmegaT and step through the segments of
+`source/exotic-numerals.txt`: each segment has a translation-memory twin in
+`tm/exotic-numerals-demo.tmx` that differs only in the number value, so the
+Matches pane demonstrates the value comparison and substitution on scripts
+far beyond ASCII digits.
+
+Project doubles as fixture of acceptance test
+`NumeralMatchesSubstitutionTest`, verifying substitution on several segments
+below. Note: `source/beyond-coverage.txt` sorts before
+`source/exotic-numerals.txt`, so editor entry numbers run two ahead of
+segment numbers in this file.
+
+## Covered systems (one segment each)
+
+| Segment | System | Base | Codepoints used | Value in source / TM |
+|---|---|---|---|---|
+| 1 | Western digits | 10 | ASCII | 1984 / 1750 |
+| 2 | Khmer digits | 10 | U+17E0 block | 123456 / 98765 |
+| 3 | Ethiopic (multiplicative-additive) | 10, no zero | U+1369 block | 1976 / 1974 |
+| 4 | Cuneiform (Sumero-Akkadian) | 60 | U+12433, U+12432 | 432000 / 216000 |
+| 5 | Aegean (Linear A/B) | 10 | U+10133, U+10132 | 90000 / 80000 |
+| 6 | Mayan digit | 20 | U+1D2F3, U+1D2EB | 19 / 11 |
+| 7 | Kaktovik digit (Inupiaq, 1990s) | 20 | U+1D2D3, U+1D2C4 | 19 / 4 |
+| 8 | Roman (subtractive-additive) | mixed | ASCII letters | 1984 / 2026 |
+| 9 | CJK ideographic (multiplicative) | 10 | myriad grouping | 35000 / 1984 |
+| 10 | Meroitic (Kingdom of Kush) | 10 | U+109C0 block | 900000 / 1000 |
+| 11 | Pahawh Hmong | 10 | U+16B5B block | 10^12 / 10000 |
+| 12 | Greek acrophonic (Attic) | 5/10 | U+10147, U+10146 | 50000 / 5000 |
+| 13 | Ottoman Siyaq | 10 | U+1ED01 block | 90000 / 10000 |
+| 14 | Vulgar fractions | - | U+00BC, U+00BD | 1/4 / 1/2 |
+| 15 | Adlam digits (1980s, Guinea) | 10 | U+1E950 block | 1984 / 2026 |
+| 16 | Medefaidrin digit (Nigeria) | 20 | U+16E80 block | 19 / 7 |
+
+## Parsing versus substitution
+
+All sixteen numbers above parse to the right value and enter the
+value-based match comparison. The insertion step substitutes them as well
+(verified with both the default and the Lucene tokenizers): digit systems
+render in the target's digit script, sign numerals - Ethiopic
+composites, cuneiform, Mayan and Kaktovik digits - are spelled out as
+digits when the target writes digits, and a vulgar fraction (segment 14)
+becomes the precomposed glyph of its exact value, so a quarter replaces a
+half glyph for glyph.
+
+Two exclusions are deliberate and stay: Roman numerals written with Latin
+letters (segment 8) are never rewritten because "I", "MIX" or "DIV" cannot
+be told apart from words, and the remaining presentation forms carrying a
+compatibility decomposition - superscript exponents and enclosed numbers -
+must never be touched by a substitution.
+
+A related boundary holds for the protected-parts marking: Han numerals
+(segment 9) are read by value but stay out of the default custom-tag
+pattern, because their characters double as ordinary words in CJK prose
+and the untokenized pattern would flood such projects with false tags.
+A project that cannot meet Han characters outside numbers can add the
+class to the pattern under tag processing preferences.
+
+## Cross-system conversion (segments 17 to 19)
+
+When the match target writes its number in a numeral system rather than in
+digits, the source value is written in that system, whatever system the
+source itself uses. Three segments demonstrate the three writers:
+
+| Segment | Source system and value | Target system | Written as |
+|---|---|---|---|
+| 17 | Ethiopic 840 | Aegean | additive composition, 800 sign plus 40 sign |
+| 18 | Ethiopic 40 | Mayan digits | positional base twenty, two signs |
+| 19 | Meroitic 900000 | Ethiopic | ICU rule set writes the composite |
+
+Only an exact composition is inserted; otherwise the value falls back to
+plain digits.
+
+## Sign sequences read as one number (segments 20 and 21)
+
+The reading side composes sign sequences from the named numeral blocks as
+well: a Mayan two-digit column reads positionally in base twenty (segment
+20, value 20), and a largest-first cuneiform sign pair reads as an
+additive sum (segment 21, value 11). Single fraction signs - the
+cuneiform two-thirds at U+1245B, the North Indic quarter at U+A830, the
+Kharoshthi half at U+10A48 - resolve to their exact rational as well.
+
+## Valid notation only (segments 22 and 23)
+
+A composition is only inserted when it is valid notation in the target's
+system. The Roman code points of the Number Forms block are written
+subtractively through the ICU rule sets in the template's case (year 40
+becomes ⅩⅬ, never a pile of twelves), and the counting rods - positional
+above the tens - are read but never composed, so a rod-written target
+receives the value in plain digits instead.
+
+## Beyond coverage: debugging candidates
+
+`source/beyond-coverage.txt` keeps the remaining verified misses:
+
+1. Tamil multiplicative-additive numerals: ICU's rule set writes them but
+   cannot read them back, and the additive reader deliberately rejects
+   their ascending unit-multiplier order rather than misread it as a sum.
+2. Suzhou/Hangzhou numerals (U+3021 block) are positional decimal, but
+   their block mixes in the ten/twenty/thirty signs, so a digit run is
+   not composed.
+
+## Not representable in Unicode
+
+The Inca quipu records numbers as knot positions on cords; there is no
+Unicode encoding for it, so it cannot appear in a text-based demo. The
+Egyptian hieroglyph numerals are encoded but carry no Unicode numeric
+properties, which keeps them outside the parser's code-point path as well.

--- a/src/testAcceptance/resources/data/project_numerals/omegat.project
+++ b/src/testAcceptance/resources/data/project_numerals/omegat.project
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<omegat>
+  <project version="1.0">
+    <source_dir>__DEFAULT__</source_dir>
+    <source_dir_excludes>
+      <mask>**/.svn/**</mask>
+      <mask>**/CVS/**</mask>
+      <mask>**/.cvs/**</mask>
+      <mask>**/.git/**</mask>
+      <mask>**/.hg/**</mask>
+      <mask>**/.repositories/**</mask>
+      <mask>**/desktop.ini</mask>
+      <mask>**/Thumbs.db</mask>
+      <mask>**/.DS_Store</mask>
+      <mask>**/~$*</mask>
+    </source_dir_excludes>
+    <target_dir>__DEFAULT__</target_dir>
+    <tm_dir>__DEFAULT__</tm_dir>
+    <glossary_dir>__DEFAULT__</glossary_dir>
+    <glossary_file>__DEFAULT__</glossary_file>
+    <dictionary_dir>__DEFAULT__</dictionary_dir>
+    <export_tm_dir>__DEFAULT__</export_tm_dir>
+    <export_tm_levels>omegat level1 level2</export_tm_levels>
+    <source_lang>en</source_lang>
+    <target_lang>de</target_lang>
+    <source_tok>org.omegat.tokenizer.LuceneEnglishTokenizer</source_tok>
+    <target_tok>org.omegat.tokenizer.LuceneGermanTokenizer</target_tok>
+    <sentence_seg>true</sentence_seg>
+    <support_default_translations>true</support_default_translations>
+    <remove_tags>false</remove_tags>
+    <match_numbers>true</match_numbers>
+    <external_command></external_command>
+  </project>
+</omegat>

--- a/src/testAcceptance/resources/data/project_numerals/source/beyond-coverage.txt
+++ b/src/testAcceptance/resources/data/project_numerals/source/beyond-coverage.txt
@@ -1,0 +1,3 @@
+The Tamil deed states the sum ௲௯௱௨௰௪.
+
+The Suzhou invoice notes 〡〢〣 bolts of silk.

--- a/src/testAcceptance/resources/data/project_numerals/source/exotic-numerals.txt
+++ b/src/testAcceptance/resources/data/project_numerals/source/exotic-numerals.txt
@@ -1,0 +1,45 @@
+The warehouse inventory lists 1984 clay jars.
+
+The Angkor census recorded ១២៣៤៥៦ households.
+
+The chronicle dates the synod to the year ፲፱፻፸፮.
+
+The temple archive tallies 𒐳 measures of barley.
+
+The Knossos tablet counts 𐄳 sheep.
+
+The stela marks day 𝋳 of the winal.
+
+The Inupiaq worksheet shows 𝋓 seals.
+
+The cornerstone bears the year MCMLXXXIV.
+
+The ledger totals 三万五千 copper coins.
+
+The offering table lists 𐧵 measures of incense.
+
+The Pahawh primer spells the number 𖭡.
+
+The Attic inscription pledges 𐅇 drachmas.
+
+The Ottoman ledger registers 𞴭 akce.
+
+Add ¼ measure of honey to the mixture.
+
+The Adlam textbook prints the year 𞥑𞥙𞥘𞥔.
+
+The Medefaidrin hymnal numbers verse 𖺓.
+
+The customs house restates the toll of ፰፻፵ in the island ledger.
+
+The calendar priest transcribes ፵ tuns into the Long Count.
+
+The Kushite granary restates 𐧵 measures in the highland script.
+
+The Long Count tablet records 𝋡𝋠 tuns.
+
+The Uruk tally joins 𒐇𒐀 baskets.
+
+The chronicle dates the council to year 40.
+
+The abacus ledger counts 432 coins.

--- a/src/testAcceptance/resources/data/project_numerals/tm/exotic-numerals-demo.tmx
+++ b/src/testAcceptance/resources/data/project_numerals/tm/exotic-numerals-demo.tmx
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+  <header creationtool="OmegaT" creationtoolversion="6.2.0" o-tmf="OmegaT TMX" adminlang="EN-US" datatype="plaintext" segtype="sentence" srclang="en"/>
+  <body>
+    <tu>
+      <tuv xml:lang="en"><seg>The warehouse inventory lists 1750 clay jars.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Lagerverzeichnis nennt 1750 Tonkrüge.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Angkor census recorded ៩៨៧៦៥ households.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Volkszählung von Angkor erfasste 98765 Haushalte.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The chronicle dates the synod to the year ፲፱፻፸፬.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Chronik datiert die Synode auf das Jahr 1974.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The temple archive tallies 𒐲 measures of barley.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Tempelarchiv verzeichnet 216000 Maß Gerste.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Knossos tablet counts 𐄲 sheep.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Tafel aus Knossos zählt 80000 Schafe.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The stela marks day 𝋫 of the winal.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Stele markiert Tag 11 des Winal.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Inupiaq worksheet shows 𝋄 seals.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Inupiaq-Arbeitsblatt zeigt 4 Robben.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The cornerstone bears the year MMXXVI.</seg></tuv>
+      <tuv xml:lang="de"><seg>Der Grundstein trägt die Jahreszahl 2026.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The ledger totals 千九百八十四 copper coins.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Kontobuch summiert 1984 Kupfermünzen.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The offering table lists 𐧛 measures of incense.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Opfertafel führt 1000 Maß Weihrauch auf.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Pahawh primer spells the number 𖭝.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Pahawh-Fibel schreibt die Zahl 10000.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Attic inscription pledges 𐅆 drachmas.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die attische Inschrift gelobt 5000 Drachmen.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Ottoman ledger registers 𞴥 akce.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das osmanische Rechnungsbuch verzeichnet 10000 Akçe.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>Add ½ measure of honey to the mixture.</seg></tuv>
+      <tuv xml:lang="de"><seg>Der Mischung ½ Maß Honig hinzufügen.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Adlam textbook prints the year 𞥒𞥐𞥒𞥖.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Adlam-Schulbuch druckt die Jahreszahl 2026.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Medefaidrin hymnal numbers verse 𖺇.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Medefaidrin-Gesangbuch nummeriert Vers 7.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The customs house restates the toll of ፮፻ in the island ledger.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Zollhaus weist die Abgabe von 𐄞 im Insel-Hauptbuch aus.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The calendar priest transcribes ፱ tuns into the Long Count.</seg></tuv>
+      <tuv xml:lang="de"><seg>Der Kalenderpriester überträgt 𝋩 Tun in die Lange Zählung.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Kushite granary restates 𐧛 measures in the highland script.</seg></tuv>
+      <tuv xml:lang="de"><seg>Der kuschitische Speicher weist ፲፻ Maß in der Hochlandschrift aus.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Long Count tablet records 33 tuns.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Tafel der Langen Zählung verzeichnet 33 Tun.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Uruk tally joins 𒐆 baskets.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Zählung aus Uruk fasst 8 Körbe zusammen.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The chronicle dates the council to year 4.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Chronik datiert das Konzil auf das Jahr Ⅳ.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The abacus ledger counts 32 coins.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Rechenbrett zählt 𝍫𝍡 Münzen.</seg></tuv>
+    </tu>
+  </body>
+</tmx>


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Accept alternatives to Arabic Numbers
  * https://sourceforge.net/p/omegat/feature-requests/465/

## What does this PR change?

- Stacked on #2228 — only the two newest commits belong to this PR.
- The tag check compares numbers of source and translation by numeric value, whatever the writing system and whatever the custom-tag pattern; a changed or missing value is reported in the Issues window, while another script's digits, sign-written systems, vulgar fractions and decimal or grouped spellings count as the same number.
- A per-project option (on by default, written to omegat.project only when disabled) turns the check off for language pairs that rewrite numbers beyond recognition, such as Japanese ten-thousands grouping.
- A new editor marker underlines the checked numerals; it ships without a colour and paints nothing until one is assigned under Options > Preferences > Colours > Numbers (project setting).
- Manual and tip of the day describe the behaviour.

## Other information

see screenshots and discussion in #2228