### PR TITLE
[6.1] chore(ci): fix dest URL and hardening connection

### DIFF
--- a/ci/azure-pipelines/publish_release.yml
+++ b/ci/azure-pipelines/publish_release.yml
@@ -33,28 +33,27 @@ steps:
         [[ -n "$LFTP_PASSWORD" ]] && echo "✅ LFTP_PASSWORD is set" || { echo "❌ LFTP_PASSWORD is empty — check SOURCEFORGE_CI_PASSPHRASE variable"; exit 1; }
         # Verify key file exists and passphrase is correct in one shot
         ssh-keygen -y -f ~/.ssh/id_rsa -P "$LFTP_PASSWORD" > /dev/null && echo "✅ Key + passphrase OK" || { echo "❌ Key or passphrase wrong"; exit 1; }
+        dest=sftp://$(SOURCEFORGE_CI_USER)@$SF_HOST
         # Upload distributions
         echo "Push OmegaT files to SourceForge file manager"
-        dest=$(SOURCEFORGE_CI_USER)@$SF_HOST
         srcdir=$(Pipeline.Workspace)/build/distributions/
         ls -l $srcdir/*
         destdir="/home/frs/project/omegat/OmegaT - Standard/OmegaT ${OMEGAT_VERSION}/"
-        cmd="set net:max-retries 10; mkdir -p '$destdir'; lcd $srcdir; cd '$destdir'; mirror -R --verbose=3; bye"
+        cmd="set net:timeout 20; set net:max-retries 3; set net:reconnect-interval-base 5; set net:reconnect-interval-max 30; open $dest; mkdir -p '$destdir'; lcd $srcdir; cd '$destdir'; mirror -R --verbose=3; bye"
         lftp --env-password -e "$cmd" $dest
-        dest=sftp://$(SOURCEFORGE_CI_USER)@$SF_HOST
         # Upload manuals
         echo "Push manuals to sourceforge project web"
         srcdir=$(Pipeline.Workspace)/build/docs/manual/
         destdir=/home/project-web/omegat/htdocs/manual/${OMEGAT_VERSION}/
         target=/home/project-web/omegat/htdocs/manual-standard
-        cmd="set net:max-retries 10; mkdir -p $destdir ; lcd $srcdir ; cd $destdir ; mirror -Re --parallel=4 --verbose=3 ; rm $target ; ln -s $destdir $target ; bye"
+        cmd="set net:timeout 20; set net:max-retries 3; set net:reconnect-interval-base 5; set net:reconnect-interval-max 30; open $dest; mkdir -p $destdir ; lcd $srcdir ; cd $destdir ; mirror -Re --parallel=4 --verbose=3 ; rm $target ; ln -s $destdir $target ; bye"
         lftp --env-password -e "$cmd" $dest
         # Upload javadoc
         echo "Push javadoc to sourceforge project web"
         srcdir=$(Pipeline.Workspace)/build/docs/javadoc/
         destdir=/home/project-web/omegat/htdocs/javadoc/${OMEGAT_VERSION}/
         target=/home/project-web/omegat/htdocs/javadoc-standard
-        cmd="set net:max-retries 10; mkdir -p $destdir ; lcd $srcdir ; cd $destdir ; mirror -Re --parallel=4 --verbose=3 ; rm $target ; ln -s $destdir $target ; bye"
+        cmd="set net:timeout 20; set net:max-retries 3; set net:reconnect-interval-base 5; set net:reconnect-interval-max 30; open $dest; mkdir -p $destdir ; lcd $srcdir ; cd $destdir ; mirror -Re --parallel=4 --verbose=3 ; rm $target ; ln -s $destdir $target ; bye"
         lftp --env-password -e "$cmd" $dest
     env:
       OMEGAT_VERSION: ${{ parameters.omegatVersion }}


### PR DESCRIPTION
Release upload failed in previous 6.1.0 and 6.1.1. It is because the $dest has missed the "sftp://"

## Pull request type

- Build and release changes -> [build/release]

## What does this PR change?

- Fix the error that missing "sftp://" in the $dest
- Hardening timeout/retry/reconnect to failed early in several minutes when somethings become wrong

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
