### PR TITLE
feat(editor): show spelling suggestions in tooltip of misspelled words

### DIFF
--- a/src/main/java/org/omegat/core/spellchecker/AbstractSpellChecker.java
+++ b/src/main/java/org/omegat/core/spellchecker/AbstractSpellChecker.java
@@ -7,6 +7,7 @@
  *                2009 Didier Briel
  *                2015 Aaron Madlon-Kay
  *                2020 Briac Pilpre
+ *                2026 Stephan Pakebusch
  *                Home page: https://www.omegat.org/
  *                Support center: https://omegat.org/support
  *
@@ -36,7 +37,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -82,6 +85,21 @@ public abstract class AbstractSpellChecker implements ISpellChecker {
      * Cache of incorrect words.
      */
     private final Set<String> incorrectWordsCache = new HashSet<>();
+    /**
+     * Cache of suggestions per misspelled word: a suggestion lookup is far
+     * more expensive than a spell check, and the editor tooltips ask on
+     * every hover. Bounded, access ordered; guarded by the same monitor as
+     * the word caches, which also serializes the provider access with the
+     * background checks (the providers are not thread safe).
+     */
+    private static final int SUGGESTIONS_CACHE_SIZE = 500;
+    private final Map<String, List<String>> suggestionsCache = new LinkedHashMap<String, List<String>>(
+            16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, List<String>> eldest) {
+            return size() > SUGGESTIONS_CACHE_SIZE;
+        }
+    };
 
     public AbstractSpellChecker() {
         CoreEvents.registerProjectChangeListener(eventType -> {
@@ -209,12 +227,16 @@ public abstract class AbstractSpellChecker implements ISpellChecker {
             checker.destroy();
             checker = null;
         }
+        // The settings dialog destroys and reinitializes without a project
+        // event: cached suggestions of the old dictionary must go with it.
+        resetCache();
     }
 
     protected void resetCache() {
         synchronized (this) {
             incorrectWordsCache.clear();
             correctWordsCache.clear();
+            suggestionsCache.clear();
         }
     }
 
@@ -274,10 +296,12 @@ public abstract class AbstractSpellChecker implements ISpellChecker {
         // if it is valid (learned), it is ok
         if (learnedList.contains(word) || ignoreList.contains(word)) {
             isCorrect = true;
-        } else if (checker != null) {
-            isCorrect = checker.isCorrect(word);
         } else {
-            isCorrect = false;
+            // The providers are not thread safe: the check runs under the
+            // same monitor as the suggestion lookup of the tooltips.
+            synchronized (this) {
+                isCorrect = checker != null && checker.isCorrect(word);
+            }
         }
 
         // remember in cache
@@ -300,10 +324,22 @@ public abstract class AbstractSpellChecker implements ISpellChecker {
         }
         // Check if a spellchecker is already initialized.
         // If not, skip checking to prevent nullPointerErrors.
-        if (checker != null) {
-            return checker.suggest(normalize(word));
+        if (checker == null) {
+            return Collections.emptyList();
         }
-        return Collections.emptyList();
+        String normalized = normalize(word);
+        synchronized (this) {
+            List<String> cached = suggestionsCache.get(normalized);
+            if (cached != null) {
+                return cached;
+            }
+            if (checker == null) {
+                return Collections.emptyList();
+            }
+            List<String> suggestions = List.copyOf(checker.suggest(normalized));
+            suggestionsCache.put(normalized, suggestions);
+            return suggestions;
+        }
     }
 
     /**
@@ -316,6 +352,8 @@ public abstract class AbstractSpellChecker implements ISpellChecker {
             synchronized (this) {
                 incorrectWordsCache.remove(word);
                 correctWordsCache.add(word);
+                // A changed word list changes what suggestions make sense.
+                suggestionsCache.clear();
             }
         }
     }
@@ -333,6 +371,9 @@ public abstract class AbstractSpellChecker implements ISpellChecker {
             synchronized (this) {
                 incorrectWordsCache.remove(word);
                 correctWordsCache.add(word);
+                // A learned word may now appear among the suggestions of
+                // its neighbours.
+                suggestionsCache.clear();
             }
         }
     }

--- a/src/main/java/org/omegat/core/spellchecker/SpellCheckerMarker.java
+++ b/src/main/java/org/omegat/core/spellchecker/SpellCheckerMarker.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2010 Alex Buloichik
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -36,6 +37,8 @@ import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.editor.UnderlineFactory;
 import org.omegat.gui.editor.mark.IMarker;
 import org.omegat.gui.editor.mark.Mark;
+import org.omegat.util.OStrings;
+import org.omegat.util.StringUtil;
 import org.omegat.util.gui.Styles;
 
 /**
@@ -45,6 +48,9 @@ import org.omegat.util.gui.Styles;
  * @author Alex Buloichik (alex73mail@gmail.com)
  */
 public class SpellCheckerMarker implements IMarker {
+
+    /** At most this many suggestions fit a readable tooltip. */
+    static final int MAX_TOOLTIP_SUGGESTIONS = 5;
 
     @Override
     public @Nullable List<Mark> getMarksForEntry(SourceTextEntry ste, String sourceText,
@@ -66,7 +72,40 @@ public class SpellCheckerMarker implements IMarker {
             int en = st + tok.getLength();
             Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, st, en);
             m.painter = highlightPainter;
+            // Resolved when the mouse rests on the word: a suggestion
+            // lookup is too expensive to run per mark, especially for the
+            // active segment, whose marks recompute on every keystroke.
+            String word = tok.getTextFromString(translationText);
+            m.toolTipSupplier = () -> suggestionToolTip(word);
             return m;
         }).collect(Collectors.toList());
+    }
+
+    /**
+     * The tooltip of a misspelled word: its suggestions, cached per word by
+     * the spell checker, so only the first hover of a word runs a lookup.
+     */
+    static String suggestionToolTip(String word) {
+        return formatSuggestions(Core.getSpellChecker().suggest(word));
+    }
+
+    /**
+     * The suggestions as tooltip text, or the "no suggestions" notice. The
+     * suggestion tags render bold, like in the language checker tooltips
+     * (MarkerController.getToolTips maps them); a trailing ellipsis points
+     * to the context menu when the list was cut.
+     */
+    static String formatSuggestions(List<String> suggestions) {
+        if (suggestions.isEmpty()) {
+            return OStrings.getString("SC_NO_SUGGESTIONS");
+        }
+        String shown = suggestions.stream().limit(MAX_TOOLTIP_SUGGESTIONS)
+                .map(StringUtil::makeValidXML)
+                .map(s -> "<suggestion>" + s + "</suggestion>")
+                .collect(Collectors.joining(", "));
+        if (suggestions.size() > MAX_TOOLTIP_SUGGESTIONS) {
+            shown += ", ...";
+        }
+        return StringUtil.format(OStrings.getString("SC_TOOLTIP_SUGGESTIONS"), shown);
     }
 }

--- a/src/main/java/org/omegat/gui/editor/MarkerController.java
+++ b/src/main/java/org/omegat/gui/editor/MarkerController.java
@@ -6,6 +6,7 @@
  Copyright (C) 2010-2013 Alex Buloichik
                2014 Aaron Madlon-Kay
                2024 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
@@ -252,10 +254,24 @@ public class MarkerController {
             for (MarkInfo t : markInfos) {
                 if (t != null && t.tooltip != null) {
                     if (t.tooltip.p0.getOffset() <= pos && t.tooltip.p1.getOffset() >= pos) {
+                        // A supplier resolves on hover, so expensive lookups
+                        // like spelling suggestions run only here. A broken
+                        // supplier must not break the whole tooltip.
+                        String text;
+                        try {
+                            text = t.tooltip.supplier != null ? t.tooltip.supplier.get()
+                                    : t.tooltip.text;
+                        } catch (Exception ex) {
+                            Log.log(ex);
+                            continue;
+                        }
+                        if (text == null || text.isEmpty()) {
+                            continue;
+                        }
                         if (res.length() > 0) {
                             res.append("<br>");
                         }
-                        res.append(t.tooltip.text);
+                        res.append(text);
                     }
                 }
             }
@@ -264,6 +280,8 @@ public class MarkerController {
             return null;
         }
         String r = res.toString();
+        // The suggestion tags of the language checker messages and of the
+        // spelling suggestions (SpellCheckerMarker) render bold.
         r = r.replace("<suggestion>", "<b>");
         r = r.replace("</suggestion>", "</b>");
         return "<html>" + r + "</html>";
@@ -359,9 +377,9 @@ public class MarkerController {
                 highlight = (Highlighter.Highlight) highlighter.addHighlight(startOffset + m.startOffset,
                         startOffset + m.endOffset, m.painter);
             }
-            if (m.toolTipText != null) {
+            if (m.toolTipText != null || m.toolTipSupplier != null) {
                 tooltip = new Tooltip(doc, startOffset + m.startOffset, startOffset + m.endOffset,
-                        m.toolTipText);
+                        m.toolTipText, m.toolTipSupplier);
             }
             if (m.attributes != null) {
                 doc.setCharacterAttributes(startOffset + m.startOffset, m.endOffset - m.startOffset,
@@ -374,11 +392,19 @@ public class MarkerController {
         Position p0;
         Position p1;
         String text;
+        /** Resolved on hover when set; wins over the static text. */
+        Supplier<String> supplier;
 
         public Tooltip(Document3 doc, int start, int end, String text) throws BadLocationException {
+            this(doc, start, end, text, null);
+        }
+
+        public Tooltip(Document3 doc, int start, int end, String text, Supplier<String> supplier)
+                throws BadLocationException {
             p0 = doc.createPosition(start);
             p1 = doc.createPosition(end);
             this.text = text;
+            this.supplier = supplier;
         }
     }
 }

--- a/src/main/java/org/omegat/gui/editor/mark/Mark.java
+++ b/src/main/java/org/omegat/gui/editor/mark/Mark.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2010-2013 Alex Buloichik
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -24,6 +25,8 @@
  **************************************************************************/
 
 package org.omegat.gui.editor.mark;
+
+import java.util.function.Supplier;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -55,6 +58,13 @@ public class Mark {
      * over Mark.
      */
     public @Nullable String toolTipText;
+    /**
+     * Lazy variant of toolTipText, resolved when the mouse rests on the
+     * Mark. An expensive lookup, e.g. for spelling suggestions, then runs
+     * once per hover instead of on every marker pass. When set, it wins
+     * over toolTipText; a null or empty result shows no tooltip.
+     */
+    public @Nullable Supplier<String> toolTipSupplier;
     /**
      * Text attributes for specific Mark. Will be added to text by
      * Document.setCharacterAttributes() without replacement.

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -1967,6 +1967,8 @@ LOG_ERROR_DELETE_FILE=Could not delete {0}
 
 SC_NO_SUGGESTIONS=No Suggestions
 
+SC_TOOLTIP_SUGGESTIONS=Spelling suggestions: {0}
+
 SC_IGNORE_ALL=Ignore All
 
 SC_ADD_TO_DICTIONARY=Add to Dictionary

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -1858,6 +1858,8 @@ LOG_ERROR_DELETE_FILE=Konnte {0} nicht l\u00F6schen
 
 SC_NO_SUGGESTIONS=Keine Vorschl\u00E4ge
 
+SC_TOOLTIP_SUGGESTIONS=Rechtschreibvorschl\u00E4ge: {0}
+
 SC_IGNORE_ALL=Alle ignorieren
 
 SC_ADD_TO_DICTIONARY=Zum W\u00F6rterbuch hinzuf\u00FCgen

--- a/src/test/java/org/omegat/core/spellchecker/AbstractSpellCheckerSuggestionsTest.java
+++ b/src/test/java/org/omegat/core/spellchecker/AbstractSpellCheckerSuggestionsTest.java
@@ -1,0 +1,185 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.spellchecker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.util.Language;
+import org.omegat.util.TestPreferencesInitializer;
+
+/**
+ * The suggestions cache of the spell checker: a suggestion lookup runs once
+ * per word (the editor tooltips ask on every hover), and every event that
+ * can change the suggestions empties the cache.
+ *
+ * @author Stephan Pakebusch stephan.pakebusch at zollsoft.de
+ */
+public class AbstractSpellCheckerSuggestionsTest {
+
+    private File projectDir;
+
+    /** Counts the lookups, so the tests see cache hits and misses. */
+    static final class CountingProvider implements ISpellCheckerProvider {
+        private int suggestCalls;
+
+        @Override
+        public boolean isCorrect(String word) {
+            return false;
+        }
+
+        @Override
+        public List<String> suggest(String word) {
+            suggestCalls++;
+            return Arrays.asList(word + "-first", word + "-second");
+        }
+
+        @Override
+        public void learnWord(String word) {
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+
+    /** Checkers created by the running test, made inert afterwards. */
+    private static final List<TestSpellChecker> CREATED = new ArrayList<>();
+
+    static final class TestSpellChecker extends AbstractSpellChecker {
+        private final CountingProvider provider = new CountingProvider();
+        private volatile boolean inert;
+
+        TestSpellChecker() {
+            CREATED.add(this);
+        }
+
+        @Override
+        protected Optional<ISpellCheckerProvider> initializeWithLanguage(String language) {
+            return Optional.of(provider);
+        }
+
+        @Override
+        public boolean initialize() {
+            // The constructor registers project listeners that cannot be
+            // unregistered: a leaked instance must stay inert, or it acts
+            // on the projects of the following tests and breaks them.
+            if (inert) {
+                return false;
+            }
+            return super.initialize();
+        }
+    }
+
+    @Before
+    public final void setUp() throws IOException {
+        TestPreferencesInitializer.init();
+        projectDir = Files.createTempDirectory("omegat-suggesttest").toFile();
+        ProjectProperties props = new ProjectProperties() {
+            @Override
+            public Language getTargetLanguage() {
+                return new Language("de");
+            }
+
+            @Override
+            public String getProjectInternal() {
+                return projectDir.getAbsolutePath();
+            }
+        };
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public ProjectProperties getProjectProperties() {
+                return props;
+            }
+        });
+    }
+
+    @After
+    public final void tearDown() {
+        for (TestSpellChecker checker : CREATED) {
+            checker.inert = true;
+        }
+        FileUtils.deleteQuietly(projectDir);
+    }
+
+    @Test
+    public void suggestionsAreCachedPerWord() {
+        TestSpellChecker checker = new TestSpellChecker();
+        assertTrue(checker.initialize());
+
+        List<String> first = checker.suggest("wrod");
+        assertEquals(Arrays.asList("wrod-first", "wrod-second"), first);
+        assertEquals(first, checker.suggest("wrod"));
+        assertEquals("the second lookup of the same word hits the cache", 1,
+                checker.provider.suggestCalls);
+
+        checker.suggest("teh");
+        assertEquals("a new word runs a new lookup", 2, checker.provider.suggestCalls);
+    }
+
+    @Test
+    public void wordListChangesEmptyTheCache() {
+        TestSpellChecker checker = new TestSpellChecker();
+        assertTrue(checker.initialize());
+
+        checker.suggest("wrod");
+        checker.learnWord("wordly");
+        checker.suggest("wrod");
+        assertEquals("a learned word may change the suggestions of its neighbours", 2,
+                checker.provider.suggestCalls);
+
+        checker.ignoreWord("wroddy");
+        checker.suggest("wrod");
+        assertEquals("an ignored word empties the cache too", 3, checker.provider.suggestCalls);
+    }
+
+    @Test
+    public void destroyEmptiesTheCacheAndStopsSuggesting() {
+        TestSpellChecker checker = new TestSpellChecker();
+        assertTrue(checker.initialize());
+
+        checker.suggest("wrod");
+        checker.destroy();
+        assertEquals("without a provider there is nothing to suggest", new ArrayList<String>(),
+                checker.suggest("wrod"));
+    }
+}

--- a/src/test/java/org/omegat/core/spellchecker/SpellCheckerMarkerTest.java
+++ b/src/test/java/org/omegat/core/spellchecker/SpellCheckerMarkerTest.java
@@ -1,0 +1,77 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.spellchecker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.omegat.util.OStrings;
+
+/**
+ * The tooltip of a misspelled word: formatting of the spelling suggestions
+ * shown on hover.
+ *
+ * @author Stephan Pakebusch stephan.pakebusch at zollsoft.de
+ */
+public class SpellCheckerMarkerTest {
+
+    @Test
+    public void noSuggestions() {
+        assertEquals(OStrings.getString("SC_NO_SUGGESTIONS"),
+                SpellCheckerMarker.formatSuggestions(Collections.emptyList()));
+    }
+
+    @Test
+    public void suggestionsAreTaggedAndJoined() {
+        String tooltip = SpellCheckerMarker.formatSuggestions(Arrays.asList("word", "ward"));
+        assertTrue(tooltip.contains("<suggestion>word</suggestion>, <suggestion>ward</suggestion>"));
+    }
+
+    @Test
+    public void suggestionCountIsLimited() {
+        List<String> many = Arrays.asList("one", "two", "three", "four", "five", "six", "seven");
+        String tooltip = SpellCheckerMarker.formatSuggestions(many);
+        assertTrue(tooltip.contains("five"));
+        assertFalse("only the first five suggestions fit the tooltip", tooltip.contains("six"));
+    }
+
+    @Test
+    public void suggestionsAreEscaped() {
+        // Words never contain markup, but the tooltip pipeline renders
+        // HTML, so the formatting must stay safe whatever the checker
+        // returns.
+        String tooltip = SpellCheckerMarker.formatSuggestions(Arrays.asList("a<b&c"));
+        assertTrue(tooltip.contains("a&lt;b&amp;c"));
+        assertFalse(tooltip.contains("a<b&c"));
+    }
+}


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- (no ticket)

## What does this PR change?

- Hovering a misspelled word in the editor shows its spelling suggestions in the tooltip (bold, at most five). Until now suggestions were only reachable through the context menu, and only in the active segment.
- The lookup runs lazily on hover and once per word: the spell checker caches the suggestions and serializes the provider access, because the providers are not thread safe.

## Other information
