### PR TITLE
feat(stat): add match-category filter buttons in Match Statistics window

### DIFF
--- a/src/docs/manual/en/Menus_Tools.xml
+++ b/src/docs/manual/en/Menus_Tools.xml
@@ -182,6 +182,11 @@
             <para>Displays the match statistics for the project, which consist of 
                the number of repetitions, exact matches, fuzzy matches and no-matches 
                for segments, words and characters.</para>
+            <para>Every category row has a
+               <guibutton>Filter</guibutton> button that restricts the editor to
+               the segments of that category. The window is not modal, and the
+               last result is kept for the session, with its date and time,
+               until you use <guibutton>Recalculate</guibutton>.</para>
             <para>The data is saved in the 
                <link linkend="project.folder.omegat.project.stats.match" endterm="project.folder.omegat.project.stats.match.title"></link> file located in the 
                <link linkend="project.folder.omegat.folder" endterm="project.folder.omegat.folder.title"></link> folder of the

--- a/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -8,6 +8,7 @@
                2013 Alex Buloichik
                2015 Aaron Madlon-Kay
                2024 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -41,10 +42,14 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 import java.util.logging.Logger;
@@ -95,6 +100,11 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
             OStrings.getString("CT_STATS_Words"), OStrings.getString("CT_STATS_Characters_NOSP"),
             OStrings.getString("CT_STATS_Characters") };
 
+    /**
+     * Row labels of the total table. Its final shape (all rows except index 1,
+     * plus the total row) is mirrored by the filter buttons of
+     * org.omegat.gui.stat.MatchStatisticsPanel.
+     */
     protected final String[] rowsTotal = new String[] { OStrings.getString("CT_STATSMATCH_RowRepetitions"),
             OStrings.getString("CT_STATSMATCH_RowExactMatch"), OStrings.getString("CT_STATSMATCH_RowMatch95"),
             OStrings.getString("CT_STATSMATCH_RowMatch85"), OStrings.getString("CT_STATSMATCH_RowMatch75"),
@@ -115,6 +125,17 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
 
     /** Already processed segments. Used for repetitions detect. */
     private final Set<String> alreadyProcessedInProject = new HashSet<>();
+
+    /**
+     * Category row index per entry number, following the row semantics of
+     * {@link MatchStatCounts}. Concurrent because the similarity pass may run
+     * on a parallel stream. Only recorded for total calculations that output
+     * data; the per-file mode reuses calcSimilarity but never delivers the map.
+     */
+    private final Map<Integer, Integer> entryRowIndexes = new ConcurrentHashMap<>();
+
+    /** Volatile because calcSimilarity may record from parallel stream workers. */
+    private volatile boolean recordEntryRows;
 
     private final ThreadLocal<ISimilarityCalculator> distanceCalculator = ThreadLocal
             .withInitial(LevenshteinDistance::new);
@@ -210,6 +231,8 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
     MatchStatCounts calcTotal(boolean outData) {
         MatchStatCounts result = new MatchStatCounts();
         alreadyProcessedInProject.clear();
+        entryRowIndexes.clear();
+        recordEntryRows = outData;
 
         final List<SourceTextEntry> untranslatedEntries = new ArrayList<>();
 
@@ -222,10 +245,17 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
                 // segment has translation - should be calculated as "Exact
                 // matched"
                 result.addExact(count);
+                if (recordEntryRows) {
+                    entryRowIndexes.put(ste.entryNum(),
+                            MatchStatCounts.getRowByPercent(Statistics.PERCENT_EXACT_MATCH));
+                }
                 entryProcessed();
             } else if (!isFirst) {
                 // already processed - repetition
                 result.addRepetition(count);
+                if (recordEntryRows) {
+                    entryRowIndexes.put(ste.entryNum(), MatchStatCounts.ROW_REPETITIONS);
+                }
                 entryProcessed();
             } else {
                 // first time
@@ -241,11 +271,16 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
         }
 
         calcSimilarity(untranslatedEntries).ifPresent(result::addCounts);
+        // calcSimilarity swallows cancellation to deliver partial results to
+        // the closing window, but a cancelled run must not be published as a
+        // complete result (entryRowIndexes would have gaps).
+        cancellationToken.throwIfCancelled();
 
         if (outData) {
             String[][] table = result.calcTable(rowsTotal, i -> i != 1);
             String outText = TextUtil.showTextTable(header, table, align);
             showText(outText);
+            callback.setEntryRowIndexes(Collections.unmodifiableMap(new HashMap<>(entryRowIndexes)));
             callback.setTable(header, table);
             String fn = project.getProjectProperties().getProjectInternal() + OConsts.STATS_MATCH_FILENAME;
             writeStat(fn, outText);
@@ -288,7 +323,11 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
         try {
             result = stream.collect(MatchStatCounts::new, (counts, ste) -> {
                 cancellationToken.throwIfCancelled();
-                counts.addForPercents(calcMaxSimilarity(ste), new StatCount(ste));
+                int maxSimilarity = calcMaxSimilarity(ste);
+                counts.addForPercents(maxSimilarity, new StatCount(ste));
+                if (recordEntryRows) {
+                    entryRowIndexes.put(ste.entryNum(), MatchStatCounts.getRowByPercent(maxSimilarity));
+                }
                 entryProcessed();
             }, MatchStatCounts::addCounts);
         } catch (StoppedException | LongProcessInterruptedException ignored) {

--- a/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -264,7 +264,9 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
         }
 
         if (outData) {
-            String[][] table = result.calcTableWithoutPercentage(rowsTotal);
+            // Same rows as the final table below: the similarity buckets are
+            // still empty, but every count already sits in its final row.
+            String[][] table = result.calcTable(rowsTotal, i -> i != 1);
             String outText = TextUtil.showTextTable(header, table, align);
             showText(outText);
             callback.setTable(header, table);

--- a/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -103,7 +103,8 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
     /**
      * Row labels of the total table. Its final shape (all rows except index 1,
      * plus the total row) is mirrored by the filter buttons of
-     * org.omegat.gui.stat.MatchStatisticsPanel.
+     * org.omegat.gui.stat.MatchStatisticsPanel; the row count is pinned as
+     * {@link MatchStatCounts#FINAL_TABLE_ROWS}.
      */
     protected final String[] rowsTotal = new String[] { OStrings.getString("CT_STATSMATCH_RowRepetitions"),
             OStrings.getString("CT_STATSMATCH_RowExactMatch"), OStrings.getString("CT_STATSMATCH_RowMatch95"),

--- a/src/main/java/org/omegat/core/statistics/IStatsConsumer.java
+++ b/src/main/java/org/omegat/core/statistics/IStatsConsumer.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2016 Aaron Madlon-Kay
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -25,6 +26,8 @@
 
 package org.omegat.core.statistics;
 
+import java.util.Map;
+
 import org.omegat.core.threads.Completion;
 
 /**
@@ -42,6 +45,20 @@ public interface IStatsConsumer {
     void setTable(String[] headers, String[][] data);
 
     void setDataFile(String path);
+
+    /**
+     * Receive the mapping from segment entry number to the row index of the
+     * match statistics category the segment was counted in (see
+     * {@link org.omegat.core.statistics.dso.MatchStatCounts}). Delivered by
+     * total match statistics calculations only, once per run, before the final
+     * table is delivered via {@link #setTable(String[], String[][])}. The
+     * default implementation ignores the data.
+     *
+     * @param entryRowIndexes
+     *            unmodifiable map of entry number to category row index
+     */
+    default void setEntryRowIndexes(Map<Integer, Integer> entryRowIndexes) {
+    }
 
     /**
      * Legacy completion signal (no status / no error detail).

--- a/src/main/java/org/omegat/core/statistics/dso/MatchStatCounts.java
+++ b/src/main/java/org/omegat/core/statistics/dso/MatchStatCounts.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2013 Alex Buloichik
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -39,6 +40,13 @@ import java.util.stream.Stream;
  */
 public class MatchStatCounts {
     private static final int BASE_FOR_PERCENTS = 2;
+
+    /**
+     * Row index of the repetitions bucket (in per-file mode: repetitions within
+     * this file).
+     */
+    public static final int ROW_REPETITIONS = 0;
+
     private final StatCount[] counts;
 
     public MatchStatCounts() {
@@ -90,7 +98,7 @@ public class MatchStatCounts {
      *            match percent
      * @return row index
      */
-    private int getRowByPercent(int percent) {
+    public static int getRowByPercent(int percent) {
         if (percent == Statistics.PERCENT_EXACT_MATCH) {
             // exact match
             return BASE_FOR_PERCENTS;

--- a/src/main/java/org/omegat/core/statistics/dso/MatchStatCounts.java
+++ b/src/main/java/org/omegat/core/statistics/dso/MatchStatCounts.java
@@ -47,6 +47,17 @@ public class MatchStatCounts {
      */
     public static final int ROW_REPETITIONS = 0;
 
+    /**
+     * Number of rows in the total match statistics table, including the total
+     * row. Must be kept in sync with the row labels of
+     * {@link org.omegat.core.statistics.CalcMatchStatistics} (all categories
+     * plus the total row; the slot unused in total mode is skipped). Used by
+     * org.omegat.gui.stat.MatchStatisticsPanel to recognize the shape of the
+     * total table (the per-file table has one row more); whether a scan
+     * completed is decided by the entry mapping, not by this count.
+     */
+    public static final int FINAL_TABLE_ROWS = 8;
+
     private final StatCount[] counts;
 
     public MatchStatCounts() {

--- a/src/main/java/org/omegat/gui/editor/filter/FilterBarMatchRange.java
+++ b/src/main/java/org/omegat/gui/editor/filter/FilterBarMatchRange.java
@@ -1,0 +1,66 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.filter;
+
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+
+import org.omegat.util.OStrings;
+import org.omegat.util.StringUtil;
+
+/**
+ * Editor filter bar shown while the editor is filtered to the segments of one
+ * match statistics category.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+@SuppressWarnings("serial")
+public class FilterBarMatchRange extends JPanel {
+
+    final JButton btnRemoveFilter;
+
+    public FilterBarMatchRange(String categoryLabel, int segmentCount) {
+        setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
+        add(Box.createHorizontalGlue());
+        add(new JLabel(StringUtil.format(OStrings.getString("STATSMATCH_FILTER_BAR_LABEL"), categoryLabel,
+                segmentCount)));
+        add(Box.createHorizontalStrut(10));
+        btnRemoveFilter = new JButton();
+        org.openide.awt.Mnemonics.setLocalizedText(btnRemoveFilter,
+                OStrings.getString("BUTTON_FILTER_REMOVE_FILTER"));
+        add(btnRemoveFilter);
+        add(Box.createHorizontalGlue());
+        Border border = UIManager.getBorder("OmegaTEditorFilter.border");
+        if (border != null) {
+            setBorder(border);
+        }
+    }
+}

--- a/src/main/java/org/omegat/gui/editor/filter/MatchRangeFilter.java
+++ b/src/main/java/org/omegat/gui/editor/filter/MatchRangeFilter.java
@@ -1,0 +1,79 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.filter;
+
+import java.awt.Component;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.omegat.core.Core;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.editor.IEditorFilter;
+
+/**
+ * Editor filter that limits the editor to the segments counted in one match
+ * statistics category (repetitions, exact match, a fuzzy match band, or no
+ * match).
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+@NullMarked
+public class MatchRangeFilter implements IEditorFilter {
+    private final Set<Integer> entriesList;
+    private final FilterBarMatchRange controlComponent;
+
+    public MatchRangeFilter(String categoryLabel, Collection<Integer> entries) {
+        entriesList = new HashSet<>(entries);
+        controlComponent = new FilterBarMatchRange(categoryLabel, entriesList.size());
+        controlComponent.btnRemoveFilter.addActionListener(e -> {
+            // Make sure that any change done in the current segment is not
+            // lost
+            Core.getEditor().commitAndDeactivate();
+            Core.getEditor().removeFilter();
+        });
+    }
+
+    @Override
+    public boolean isSourceAsEmptyTranslation() {
+        return false;
+    }
+
+    @Override
+    public boolean allowed(@Nullable SourceTextEntry ste) {
+        if (ste == null) {
+            return false;
+        }
+        return entriesList.contains(ste.entryNum());
+    }
+
+    @Override
+    public Component getControlComponent() {
+        return controlComponent;
+    }
+}

--- a/src/main/java/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -807,18 +807,18 @@ public final class MainWindowMenuHandler extends BaseMainWindowMenuHandler {
     }
 
     public void toolsShowStatisticsStandardMenuItemActionPerformed() {
-        new StatisticsWindow(Core.getMainWindow().getApplicationFrame(), StatisticsWindow.STAT_TYPE.STANDARD)
-                .setVisible(true);
+        StatisticsWindow.showWindow(Core.getMainWindow().getApplicationFrame(),
+                StatisticsWindow.STAT_TYPE.STANDARD);
     }
 
     public void toolsShowStatisticsMatchesMenuItemActionPerformed() {
-        new StatisticsWindow(Core.getMainWindow().getApplicationFrame(), StatisticsWindow.STAT_TYPE.MATCHES)
-                .setVisible(true);
+        StatisticsWindow.showWindow(Core.getMainWindow().getApplicationFrame(),
+                StatisticsWindow.STAT_TYPE.MATCHES);
     }
 
     public void toolsShowStatisticsMatchesPerFileMenuItemActionPerformed() {
-        new StatisticsWindow(Core.getMainWindow().getApplicationFrame(),
-                StatisticsWindow.STAT_TYPE.MATCHES_PER_FILE).setVisible(true);
+        StatisticsWindow.showWindow(Core.getMainWindow().getApplicationFrame(),
+                StatisticsWindow.STAT_TYPE.MATCHES_PER_FILE);
     }
 
     public void optionsAutoCompleteShowAutomaticallyItemActionPerformed(ActionEvent evt) {

--- a/src/main/java/org/omegat/gui/stat/BaseStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/BaseStatisticsPanel.java
@@ -33,6 +33,7 @@ import javax.swing.JPanel;
 import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumn;
+import javax.swing.table.TableModel;
 
 import org.omegat.core.Core;
 import org.omegat.core.statistics.IStatsConsumer;
@@ -104,6 +105,10 @@ public abstract class BaseStatisticsPanel extends JPanel implements IStatsConsum
     }
 
     protected TitledTablePanel generateTableDisplay(String title, String[] headers, String[][] data) {
+        return generateTableDisplay(title, headers, new StringArrayTableModel(data));
+    }
+
+    protected TitledTablePanel generateTableDisplay(String title, String[] headers, TableModel model) {
         TitledTablePanel panel = new TitledTablePanel();
 
         DataTableStyling.applyColors(panel.table);
@@ -115,7 +120,7 @@ public abstract class BaseStatisticsPanel extends JPanel implements IStatsConsum
         DataTableStyling.applyFont(panel.table, font);
 
         panel.title.setText(title);
-        panel.table.setModel(new StringArrayTableModel(data));
+        panel.table.setModel(model);
         setTableHeaders(panel.table, headers);
         panel.table.getColumnModel().getColumn(0)
                 .setCellRenderer(DataTableStyling.getHeaderTextCellRenderer());

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsCache.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsCache.java
@@ -1,0 +1,127 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.stat;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.events.IProjectEventListener;
+
+/**
+ * Session-scoped cache of the last total match statistics scan. Keeps the
+ * result available while the program runs, even after the statistics window has
+ * been closed. Cleared whenever the project changes, because entry numbers are
+ * only stable within one loaded project.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class MatchStatisticsCache {
+
+    /** Immutable result of one finished match statistics scan. */
+    public static final class Snapshot {
+        private final String[] headers;
+        private final String[][] data;
+        private final Map<Integer, Integer> entryRowIndexes;
+        private final @Nullable String textData;
+        private final String projectRoot;
+        private final Instant lastScan;
+
+        Snapshot(String[] headers, String[][] data, Map<Integer, Integer> entryRowIndexes,
+                @Nullable String textData, String projectRoot, Instant lastScan) {
+            this.headers = headers.clone();
+            this.data = new String[data.length][];
+            for (int i = 0; i < data.length; i++) {
+                this.data[i] = data[i].clone();
+            }
+            this.entryRowIndexes = entryRowIndexes;
+            this.textData = textData;
+            this.projectRoot = projectRoot;
+            this.lastScan = lastScan;
+        }
+
+        public String[] getHeaders() {
+            return headers;
+        }
+
+        public String[][] getData() {
+            return data;
+        }
+
+        /** Root folder of the project the scan belongs to. */
+        public String getProjectRoot() {
+            return projectRoot;
+        }
+
+        /**
+         * Map of entry number to category row index, see
+         * {@link org.omegat.core.statistics.dso.MatchStatCounts}.
+         */
+        public Map<Integer, Integer> getEntryRowIndexes() {
+            return entryRowIndexes;
+        }
+
+        public @Nullable String getTextData() {
+            return textData;
+        }
+
+        public Instant getLastScan() {
+            return lastScan;
+        }
+    }
+
+    private static volatile @Nullable Snapshot snapshot;
+
+    static {
+        CoreEvents.registerProjectChangeListener(MatchStatisticsCache::onProjectChanged);
+    }
+
+    private MatchStatisticsCache() {
+    }
+
+    static void onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE eventType) {
+        switch (eventType) {
+        case CLOSE, LOAD, CREATE -> clear();
+        default -> {
+        }
+        }
+    }
+
+    public static void store(String[] headers, String[][] data, Map<Integer, Integer> entryRowIndexes,
+            @Nullable String textData, String projectRoot) {
+        snapshot = new Snapshot(headers, data, entryRowIndexes, textData, projectRoot, Instant.now());
+    }
+
+    public static Optional<Snapshot> get() {
+        return Optional.ofNullable(snapshot);
+    }
+
+    public static void clear() {
+        snapshot = null;
+    }
+}

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsCache.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsCache.java
@@ -26,7 +26,6 @@
 package org.omegat.gui.stat;
 
 import java.time.Instant;
-import java.util.Map;
 import java.util.Optional;
 
 import org.jspecify.annotations.Nullable;
@@ -43,59 +42,16 @@ import org.omegat.core.events.IProjectEventListener;
  */
 public final class MatchStatisticsCache {
 
-    /** Immutable result of one finished match statistics scan. */
-    public static final class Snapshot {
-        private final String[] headers;
-        private final String[][] data;
-        private final Map<Integer, Integer> entryRowIndexes;
-        private final @Nullable String textData;
-        private final String projectRoot;
-        private final Instant lastScan;
-
-        Snapshot(String[] headers, String[][] data, Map<Integer, Integer> entryRowIndexes,
-                @Nullable String textData, String projectRoot, Instant lastScan) {
-            this.headers = headers.clone();
-            this.data = new String[data.length][];
-            for (int i = 0; i < data.length; i++) {
-                this.data[i] = data[i].clone();
-            }
-            this.entryRowIndexes = entryRowIndexes;
-            this.textData = textData;
-            this.projectRoot = projectRoot;
-            this.lastScan = lastScan;
-        }
-
-        public String[] getHeaders() {
-            return headers;
-        }
-
-        public String[][] getData() {
-            return data;
-        }
-
-        /** Root folder of the project the scan belongs to. */
-        public String getProjectRoot() {
-            return projectRoot;
-        }
-
-        /**
-         * Map of entry number to category row index, see
-         * {@link org.omegat.core.statistics.dso.MatchStatCounts}.
-         */
-        public Map<Integer, Integer> getEntryRowIndexes() {
-            return entryRowIndexes;
-        }
-
-        public @Nullable String getTextData() {
-            return textData;
-        }
-
-        public Instant getLastScan() {
-            return lastScan;
-        }
+    /**
+     * One finished scan, wrapped with the cache-specific metadata to judge
+     * its validity: the root folder of the project the scan belongs to and
+     * the scan time. The statistics data itself is the already-copied
+     * {@link MatchStatisticsResult}.
+     */
+    public record Entry(MatchStatisticsResult result, String projectRoot, Instant lastScan) {
     }
 
-    private static volatile @Nullable Snapshot snapshot;
+    private static volatile @Nullable Entry entry;
 
     static {
         CoreEvents.registerProjectChangeListener(MatchStatisticsCache::onProjectChanged);
@@ -112,16 +68,15 @@ public final class MatchStatisticsCache {
         }
     }
 
-    public static void store(String[] headers, String[][] data, Map<Integer, Integer> entryRowIndexes,
-            @Nullable String textData, String projectRoot) {
-        snapshot = new Snapshot(headers, data, entryRowIndexes, textData, projectRoot, Instant.now());
+    public static void store(MatchStatisticsResult result, String projectRoot) {
+        entry = new Entry(result, projectRoot, Instant.now());
     }
 
-    public static Optional<Snapshot> get() {
-        return Optional.ofNullable(snapshot);
+    public static Optional<Entry> get() {
+        return Optional.ofNullable(entry);
     }
 
     public static void clear() {
-        snapshot = null;
+        entry = null;
     }
 }

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2015 Aaron Madlon-Kay
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -25,22 +26,120 @@
 
 package org.omegat.gui.stat;
 
-import org.omegat.core.statistics.IStatsConsumer;
-
 import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import javax.swing.AbstractCellEditor;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JTable;
 import javax.swing.SwingUtilities;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+
+import org.jspecify.annotations.Nullable;
+import org.omegat.core.Core;
+import org.omegat.core.data.IProject;
+import org.omegat.core.statistics.IStatsConsumer;
+import org.omegat.core.statistics.dso.MatchStatCounts;
+import org.omegat.core.threads.Completion;
+import org.omegat.gui.editor.IEditor;
+import org.omegat.gui.editor.filter.MatchRangeFilter;
+import org.omegat.util.OStrings;
 
 /**
  *
  * @author Aaron Madlon-Kay
+ * @author stephan.pakebusch at zollsoft.de
  */
 @SuppressWarnings("serial")
 public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IStatsConsumer {
 
+    /**
+     * Number of rows in the final total match statistics table, including the
+     * total row. Intermediate tables are smaller and get no filter buttons.
+     */
+    static final int FINAL_TABLE_ROWS = 8;
+
+    /** Index of the filter button column, inserted before the segment counts. */
+    static final int FILTER_COLUMN = 1;
+
+    private volatile @Nullable Map<Integer, Integer> entryRowIndexes;
+    private volatile String @Nullable [] lastHeaders;
+    private volatile String @Nullable [][] lastData;
+    private volatile @Nullable String lastTextData;
+
     public MatchStatisticsPanel(StatisticsWindow window) {
         super(window);
         setLayout(new BorderLayout());
+    }
+
+    /**
+     * Restore the last scan of this session from the cache, if any.
+     *
+     * @return true if a cached result was restored
+     */
+    public boolean restoreFromCache() {
+        Optional<MatchStatisticsCache.Snapshot> cached = MatchStatisticsCache.get();
+        if (!cached.isPresent()) {
+            return false;
+        }
+        MatchStatisticsCache.Snapshot snapshot = cached.get();
+        if (!snapshot.getProjectRoot().equals(currentProjectRoot())) {
+            // A scan of another project must never leak through; entry
+            // numbers are only meaningful within the project they came from.
+            return false;
+        }
+        entryRowIndexes = snapshot.getEntryRowIndexes();
+        String textData = snapshot.getTextData();
+        if (textData != null) {
+            setTextData(textData);
+        }
+        setTable(snapshot.getHeaders(), snapshot.getData());
+        return true;
+    }
+
+    @Override
+    public void setEntryRowIndexes(Map<Integer, Integer> entryRowIndexes) {
+        this.entryRowIndexes = entryRowIndexes;
+    }
+
+    @Override
+    public void setTextData(String data) {
+        lastTextData = data;
+        super.setTextData(data);
+    }
+
+    @Override
+    public void onComplete(Completion completion) {
+        Map<Integer, Integer> rows = entryRowIndexes;
+        String[] headers = lastHeaders;
+        String[][] data = lastData;
+        String projectRoot = currentProjectRoot();
+        if (completion.isSuccess() && rows != null && headers != null && data != null
+                && data.length == FINAL_TABLE_ROWS && projectRoot != null) {
+            MatchStatisticsCache.store(headers, data, rows, lastTextData, projectRoot);
+        } else if (!completion.isSuccess()) {
+            // A failed or cancelled recalculation leaves the intermediate
+            // table behind; fall back to the last complete result.
+            restoreFromCache();
+        }
+        super.onComplete(completion);
+    }
+
+    private static @Nullable String currentProjectRoot() {
+        IProject project = Core.getProject();
+        if (!project.isProjectLoaded()) {
+            return null;
+        }
+        return project.getProjectProperties().getProjectRoot();
     }
 
     @Override
@@ -56,11 +155,179 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
         if (data == null || data.length == 0) {
             return;
         }
+        lastHeaders = headers;
+        lastData = data;
         SwingUtilities.invokeLater(() -> {
             // A simpler table is first shown, then replaced with a fancier one,
             // so have to remove first.
             removeAll();
-            add(generateTableDisplay(null, headers, data));
+            add(createTablePanel(headers, data));
+            revalidate();
+            repaint();
         });
+    }
+
+    private Component createTablePanel(String[] headers, String[][] data) {
+        Map<Integer, Integer> rows = entryRowIndexes;
+        if (rows == null || data.length != FINAL_TABLE_ROWS) {
+            return generateTableDisplay(null, headers, data);
+        }
+        String[] headersWithFilter = new String[headers.length + 1];
+        headersWithFilter[0] = headers[0];
+        headersWithFilter[FILTER_COLUMN] = "";
+        System.arraycopy(headers, 1, headersWithFilter, FILTER_COLUMN + 1, headers.length - 1);
+        FilterableTableModel model = new FilterableTableModel(data, rows);
+        TitledTablePanel panel = generateTableDisplay(null, headersWithFilter, model);
+        ButtonColumn buttonColumn = new ButtonColumn(model);
+        TableColumn column = panel.table.getColumnModel().getColumn(FILTER_COLUMN);
+        column.setCellRenderer(buttonColumn);
+        column.setCellEditor(buttonColumn);
+        int width = buttonColumn.getPreferredButtonWidth();
+        column.setMinWidth(width);
+        column.setMaxWidth(width);
+        return panel;
+    }
+
+    /**
+     * Map a displayed table row to the category row index of
+     * {@link MatchStatCounts}. The displayed total table skips the
+     * repetitions-from-other-files category (index 1) and appends a total row
+     * that has no category.
+     *
+     * @param displayRow
+     *            0-based displayed row, excluding the total row
+     * @return category row index
+     */
+    static int categoryRowForDisplayRow(int displayRow) {
+        if (displayRow == MatchStatCounts.ROW_REPETITIONS) {
+            return MatchStatCounts.ROW_REPETITIONS;
+        }
+        return displayRow + 1;
+    }
+
+    private void applyFilter(int displayRow, String categoryLabel) {
+        Map<Integer, Integer> rows = entryRowIndexes;
+        if (rows == null) {
+            return;
+        }
+        int categoryRow = categoryRowForDisplayRow(displayRow);
+        Set<Integer> entries = rows.entrySet().stream().filter(e -> e.getValue() == categoryRow)
+                .map(Map.Entry::getKey).collect(Collectors.toSet());
+        if (entries.isEmpty()) {
+            return;
+        }
+        IEditor editor = Core.getEditor();
+        if (editor.getFilter() != null) {
+            int answer = JOptionPane.showConfirmDialog(this,
+                    OStrings.getString("STATSMATCH_FILTER_REPLACE_MESSAGE"),
+                    OStrings.getString("STATSMATCH_FILTER_REPLACE_TITLE"), JOptionPane.YES_NO_OPTION);
+            if (answer != JOptionPane.YES_OPTION) {
+                return;
+            }
+        }
+        String label = categoryLabel.endsWith(":")
+                ? categoryLabel.substring(0, categoryLabel.length() - 1).trim()
+                : categoryLabel;
+        editor.commitAndLeave(); // Otherwise, the current segment
+                                 // being edited is lost
+        editor.setFilter(new MatchRangeFilter(label, entries));
+    }
+
+    /**
+     * Table model for the final table: the plain string data plus a virtual
+     * filter button column inserted before the segment counts. Button cells
+     * are editable so the button can be clicked; rows of empty categories and
+     * the total row get no button.
+     */
+    private static class FilterableTableModel extends AbstractTableModel {
+
+        private final String[][] data;
+        private final boolean[] hasButton;
+
+        FilterableTableModel(String[][] data, Map<Integer, Integer> entryRowIndexes) {
+            this.data = data;
+            hasButton = new boolean[data.length];
+            for (int row = 0; row < data.length - 1; row++) {
+                int categoryRow = categoryRowForDisplayRow(row);
+                hasButton[row] = entryRowIndexes.containsValue(categoryRow);
+            }
+        }
+
+        boolean hasButton(int row) {
+            return hasButton[row];
+        }
+
+        String getCategoryLabel(int row) {
+            return data[row][0];
+        }
+
+        @Override
+        public int getRowCount() {
+            return data.length;
+        }
+
+        @Override
+        public int getColumnCount() {
+            return data.length == 0 ? 0 : data[0].length + 1;
+        }
+
+        @Override
+        public Object getValueAt(int rowIndex, int columnIndex) {
+            if (columnIndex == FILTER_COLUMN) {
+                return "";
+            }
+            return data[rowIndex][columnIndex < FILTER_COLUMN ? columnIndex : columnIndex - 1];
+        }
+
+        @Override
+        public boolean isCellEditable(int rowIndex, int columnIndex) {
+            return columnIndex == FILTER_COLUMN && hasButton(rowIndex);
+        }
+    }
+
+    /**
+     * Renderer and editor showing a filter button per category row.
+     */
+    private class ButtonColumn extends AbstractCellEditor implements TableCellRenderer, TableCellEditor {
+
+        private final FilterableTableModel model;
+        private final JButton rendererButton;
+        private final JButton editorButton;
+        private final JLabel emptyCell = new JLabel();
+        private int editingRow;
+
+        ButtonColumn(FilterableTableModel model) {
+            this.model = model;
+            String label = OStrings.getString("STATSMATCH_FILTER_BUTTON");
+            rendererButton = new JButton(label);
+            editorButton = new JButton(label);
+            editorButton.addActionListener(e -> {
+                int row = editingRow;
+                fireEditingStopped();
+                applyFilter(row, model.getCategoryLabel(row));
+            });
+        }
+
+        int getPreferredButtonWidth() {
+            return rendererButton.getPreferredSize().width + 4;
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+                boolean hasFocus, int row, int column) {
+            return model.hasButton(row) ? rendererButton : emptyCell;
+        }
+
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row,
+                int column) {
+            editingRow = row;
+            return editorButton;
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            return "";
+        }
     }
 }

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
@@ -65,10 +65,13 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
     /** Index of the filter button column, inserted before the segment counts. */
     static final int FILTER_COLUMN = 1;
 
-    private volatile @Nullable Map<Integer, Integer> entryRowIndexes;
-    private volatile String @Nullable [] lastHeaders;
-    private volatile String @Nullable [][] lastData;
-    private volatile @Nullable String lastTextData;
+    /**
+     * Parts of the current scan, accumulated across the IStatsConsumer
+     * callbacks. Replaced wholesale when a calculation starts, so filter
+     * buttons never act on the mapping of a previous scan and the cache can
+     * never receive parts of two different scans.
+     */
+    private volatile MatchStatisticsResult.Builder scanResult = new MatchStatisticsResult.Builder();
 
     public MatchStatisticsPanel(StatisticsWindow window) {
         super(window);
@@ -76,15 +79,14 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
     }
 
     /**
-     * Forget the entry mapping of the previous scan before a recalculation
-     * starts. The intermediate table of the new scan has the final shape but
-     * fresh numbers; wiring filter buttons against the previous mapping would
-     * filter on stale categories. The mapping of the running scan arrives
-     * before its final table; on failure or cancellation
-     * {@link #onComplete(Completion)} restores the cached one.
+     * Start accumulating a fresh scan before a recalculation begins. The
+     * intermediate table of the new scan has the final shape but fresh
+     * numbers; the mapping of the running scan arrives before its final
+     * table; on failure or cancellation {@link #onComplete(Completion)}
+     * restores the cached result.
      */
     void onCalculationStart() {
-        entryRowIndexes = null;
+        scanResult = new MatchStatisticsResult.Builder();
     }
 
     /**
@@ -93,45 +95,45 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
      * @return true if a cached result was restored
      */
     public boolean restoreFromCache() {
-        Optional<MatchStatisticsCache.Snapshot> cached = MatchStatisticsCache.get();
+        Optional<MatchStatisticsCache.Entry> cached = MatchStatisticsCache.get();
         if (!cached.isPresent()) {
             return false;
         }
-        MatchStatisticsCache.Snapshot snapshot = cached.get();
-        if (!snapshot.getProjectRoot().equals(currentProjectRoot())) {
+        MatchStatisticsCache.Entry entry = cached.get();
+        if (!entry.projectRoot().equals(currentProjectRoot())) {
             // A scan of another project must never leak through; entry
             // numbers are only meaningful within the project they came from.
             return false;
         }
-        entryRowIndexes = snapshot.getEntryRowIndexes();
-        String textData = snapshot.getTextData();
+        MatchStatisticsResult result = entry.result();
+        scanResult = new MatchStatisticsResult.Builder();
+        setEntryRowIndexes(result.entryRowIndexes());
+        String textData = result.textData();
         if (textData != null) {
             setTextData(textData);
         }
-        setTable(snapshot.getHeaders(), snapshot.getData());
+        setTable(result.headers(), result.data());
         return true;
     }
 
     @Override
     public void setEntryRowIndexes(Map<Integer, Integer> entryRowIndexes) {
-        this.entryRowIndexes = entryRowIndexes;
+        scanResult.setEntryRowIndexes(entryRowIndexes);
     }
 
     @Override
     public void setTextData(String data) {
-        lastTextData = data;
+        scanResult.setTextData(data);
         super.setTextData(data);
     }
 
     @Override
     public void onComplete(Completion completion) {
-        Map<Integer, Integer> rows = entryRowIndexes;
-        String[] headers = lastHeaders;
-        String[][] data = lastData;
+        MatchStatisticsResult result = scanResult.build();
         String projectRoot = currentProjectRoot();
-        if (completion.isSuccess() && rows != null && headers != null && data != null
-                && data.length == MatchStatCounts.FINAL_TABLE_ROWS && projectRoot != null) {
-            MatchStatisticsCache.store(headers, data, rows, lastTextData, projectRoot);
+        if (completion.isSuccess() && result != null
+                && result.data().length == MatchStatCounts.FINAL_TABLE_ROWS && projectRoot != null) {
+            MatchStatisticsCache.store(result, projectRoot);
         } else if (!completion.isSuccess()) {
             // A failed or cancelled recalculation leaves the intermediate
             // table behind; fall back to the last complete result.
@@ -161,8 +163,7 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
         if (data == null || data.length == 0) {
             return;
         }
-        lastHeaders = headers;
-        lastData = data;
+        scanResult.setTable(headers, data);
         SwingUtilities.invokeLater(() -> {
             // A simpler table is first shown, then replaced with a fancier one,
             // so have to remove first.
@@ -174,7 +175,7 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
     }
 
     private Component createTablePanel(String[] headers, String[][] data) {
-        Map<Integer, Integer> rows = entryRowIndexes;
+        Map<Integer, Integer> rows = scanResult.entryRowIndexes();
         if (rows == null || data.length != MatchStatCounts.FINAL_TABLE_ROWS) {
             return generateTableDisplay(null, headers, data);
         }
@@ -212,7 +213,7 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
     }
 
     private void applyFilter(int displayRow, String categoryLabel) {
-        Map<Integer, Integer> rows = entryRowIndexes;
+        Map<Integer, Integer> rows = scanResult.entryRowIndexes();
         if (rows == null) {
             return;
         }

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
@@ -64,7 +64,8 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
 
     /**
      * Number of rows in the final total match statistics table, including the
-     * total row. Intermediate tables are smaller and get no filter buttons.
+     * total row. Only tables of this shape carry filter buttons, and only once
+     * the entry mapping of the running scan has arrived.
      */
     static final int FINAL_TABLE_ROWS = 8;
 
@@ -79,6 +80,18 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
     public MatchStatisticsPanel(StatisticsWindow window) {
         super(window);
         setLayout(new BorderLayout());
+    }
+
+    /**
+     * Forget the entry mapping of the previous scan before a recalculation
+     * starts. The intermediate table of the new scan has the final shape but
+     * fresh numbers; wiring filter buttons against the previous mapping would
+     * filter on stale categories. The mapping of the running scan arrives
+     * before its final table; on failure or cancellation
+     * {@link #onComplete(Completion)} restores the cached one.
+     */
+    void onCalculationStart() {
+        entryRowIndexes = null;
     }
 
     /**

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
@@ -62,13 +62,6 @@ import org.omegat.util.OStrings;
 @SuppressWarnings("serial")
 public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IStatsConsumer {
 
-    /**
-     * Number of rows in the final total match statistics table, including the
-     * total row. Only tables of this shape carry filter buttons, and only once
-     * the entry mapping of the running scan has arrived.
-     */
-    static final int FINAL_TABLE_ROWS = 8;
-
     /** Index of the filter button column, inserted before the segment counts. */
     static final int FILTER_COLUMN = 1;
 
@@ -137,7 +130,7 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
         String[][] data = lastData;
         String projectRoot = currentProjectRoot();
         if (completion.isSuccess() && rows != null && headers != null && data != null
-                && data.length == FINAL_TABLE_ROWS && projectRoot != null) {
+                && data.length == MatchStatCounts.FINAL_TABLE_ROWS && projectRoot != null) {
             MatchStatisticsCache.store(headers, data, rows, lastTextData, projectRoot);
         } else if (!completion.isSuccess()) {
             // A failed or cancelled recalculation leaves the intermediate
@@ -182,7 +175,7 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
 
     private Component createTablePanel(String[] headers, String[][] data) {
         Map<Integer, Integer> rows = entryRowIndexes;
-        if (rows == null || data.length != FINAL_TABLE_ROWS) {
+        if (rows == null || data.length != MatchStatCounts.FINAL_TABLE_ROWS) {
             return generateTableDisplay(null, headers, data);
         }
         String[] headersWithFilter = new String[headers.length + 1];

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsResult.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsResult.java
@@ -1,0 +1,106 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.stat;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Result of one total match statistics scan: the final table, the mapping
+ * from segment entry number to category row index (see
+ * {@link org.omegat.core.statistics.dso.MatchStatCounts}), and the plain
+ * text rendering. The constructor copies the arrays and the map, so a result
+ * never shares mutable state with whoever produced the parts. The array
+ * components keep the default identity-based equals/hashCode; results are
+ * carriers, not map keys.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public record MatchStatisticsResult(String[] headers, String[][] data,
+        Map<Integer, Integer> entryRowIndexes, @Nullable String textData) {
+
+    public MatchStatisticsResult {
+        headers = headers.clone();
+        data = Arrays.stream(data).map(String[]::clone).toArray(String[][]::new);
+        entryRowIndexes = Map.copyOf(entryRowIndexes);
+    }
+
+    /**
+     * Accumulator for the parts of a result, which arrive through separate
+     * {@link org.omegat.core.statistics.IStatsConsumer} callbacks. One builder
+     * holds at most one scan: the consumer replaces it when a calculation
+     * starts, so parts of different scans can never combine into one result.
+     */
+    static final class Builder {
+
+        private volatile String @Nullable [] headers;
+        private volatile String @Nullable [][] data;
+        private volatile @Nullable Map<Integer, Integer> entryRowIndexes;
+        private volatile @Nullable String textData;
+
+        void setTable(String[] headers, String[][] data) {
+            this.headers = headers;
+            this.data = data;
+        }
+
+        void setEntryRowIndexes(Map<Integer, Integer> entryRowIndexes) {
+            this.entryRowIndexes = entryRowIndexes;
+        }
+
+        void setTextData(String textData) {
+            this.textData = textData;
+        }
+
+        /**
+         * Mapping from entry number to category row of the scan accumulating
+         * here, null while it has not arrived. It arrives before the final
+         * table of the same scan.
+         */
+        @Nullable
+        Map<Integer, Integer> entryRowIndexes() {
+            return entryRowIndexes;
+        }
+
+        /**
+         * Build the result once all mandatory parts arrived.
+         *
+         * @return the copied result, or null while the table or the entry
+         *         mapping is missing
+         */
+        @Nullable
+        MatchStatisticsResult build() {
+            String[] builtHeaders = headers;
+            String[][] builtData = data;
+            Map<Integer, Integer> builtRows = entryRowIndexes;
+            if (builtHeaders == null || builtData == null || builtRows == null) {
+                return null;
+            }
+            return new MatchStatisticsResult(builtHeaders, builtData, builtRows, textData);
+        }
+    }
+}

--- a/src/main/java/org/omegat/gui/stat/StatisticsWindow.java
+++ b/src/main/java/org/omegat/gui/stat/StatisticsWindow.java
@@ -6,6 +6,7 @@
  Copyright (C) 2009 Alex Buloichik
                2012 Thomas Cordonnier
                2015 Aaron Madlon-Kay
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -32,12 +33,22 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.function.Function;
 
+import javax.swing.Box;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.statistics.CalcMatchStatistics;
 import org.omegat.core.statistics.CalcPerFileMatchStatistics;
 import org.omegat.core.statistics.CalcStandardStatistics;
@@ -47,6 +58,7 @@ import org.omegat.core.threads.LongProcessExecutor;
 import org.omegat.core.threads.LongProcessHandle;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
+import org.omegat.util.StringUtil;
 import org.omegat.util.gui.StaticUIUtils;
 
 /**
@@ -91,37 +103,120 @@ public class StatisticsWindow extends javax.swing.JDialog {
         }
     }
 
-    LongProcessHandle<Void> handle;
+    private @Nullable LongProcessHandle<Void> handle;
+
+    private static final Map<STAT_TYPE, StatisticsWindow> OPEN_WINDOWS = new EnumMap<>(STAT_TYPE.class);
+
+    /**
+     * Short date/time formatter for the last scan label.
+     */
+    private static final DateTimeFormatter LAST_SCAN_FORMAT = DateTimeFormatter
+            .ofLocalizedDateTime(FormatStyle.SHORT).withZone(ZoneId.systemDefault());
+
+    private final STAT_TYPE statType;
+    private final JComponent output;
+    private final javax.swing.JButton recalculateButton = new javax.swing.JButton();
+    private final JLabel lastScanLabel = new JLabel();
+    private final IProjectEventListener projectListener = eventType -> {
+        if (eventType == IProjectEventListener.PROJECT_CHANGE_TYPE.CLOSE) {
+            cancelCalculation();
+            dispose();
+        }
+    };
+
+    /**
+     * Show the statistics window of the given type, or bring the already open
+     * one to the front. The window is non-modal, so the editor stays usable
+     * while it is open. Must be called on the Swing thread.
+     */
+    public static void showWindow(Frame parent, STAT_TYPE statType) {
+        StatisticsWindow existing = OPEN_WINDOWS.get(statType);
+        if (existing != null) {
+            existing.toFront();
+            existing.requestFocus();
+            return;
+        }
+        StatisticsWindow window = new StatisticsWindow(parent, statType);
+        OPEN_WINDOWS.put(statType, window);
+        window.setVisible(true);
+    }
 
     /**
      * Creates new form StatisticsWindow
      */
     public StatisticsWindow(Frame parent, STAT_TYPE statType) {
-        super(parent, true);
+        super(parent, false);
+        this.statType = statType;
         initComponents();
         copyDataButton.setVisible(false);
 
         setTitle(statType.getTitle());
-        JComponent output = statType.createPanel(this);
-        ICalcStatistics calcStat = statType.createCalculator((IStatsConsumer) output);
-        LongProcessExecutor executor = Core.getLongProcessExecutor();
-        handle = executor.submit(calcStat::run);
+        output = statType.createPanel(this);
         displayPanel.add(output);
+
+        // These widgets are added programmatically because initComponents is
+        // generated from the form.
+        jPanel2.add(lastScanLabel, 0);
+        jPanel2.add(Box.createHorizontalStrut(10), 1);
+        org.openide.awt.Mnemonics.setLocalizedText(recalculateButton,
+                OStrings.getString("BUTTON_STATSMATCH_RECALCULATE"));
+        recalculateButton.setVisible(statType == STAT_TYPE.MATCHES);
+        recalculateButton.addActionListener(e -> startCalculation());
+        jPanel2.add(recalculateButton, jPanel2.getComponentZOrder(copyDataButton));
 
         StaticUIUtils.setEscapeClosable(this);
 
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
-                handle.cancel();
+                cancelCalculation();
+            }
+
+            @Override
+            public void windowClosed(WindowEvent e) {
+                OPEN_WINDOWS.remove(statType, StatisticsWindow.this);
+                CoreEvents.unregisterProjectChangeListener(projectListener);
             }
         });
+        CoreEvents.registerProjectChangeListener(projectListener);
+
+        boolean restored = statType == STAT_TYPE.MATCHES && output instanceof MatchStatisticsPanel panel
+                && panel.restoreFromCache();
+        if (restored) {
+            finishData();
+        } else {
+            startCalculation();
+        }
 
         setSize(800, 400);
         StaticUIUtils.persistGeometry(this, Preferences.STATISTICS_WINDOW_GEOMETRY_PREFIX);
         // setLocationRealativeTo called after persistGeometry
         // to make sure the stat window always pops up in the center of the parent window
         setLocationRelativeTo(parent);
+    }
+
+    private void startCalculation() {
+        recalculateButton.setEnabled(false);
+        progressBar.setValue(0);
+        progressBar.setString("");
+        progressBar.setVisible(true);
+        ICalcStatistics calcStat = statType.createCalculator((IStatsConsumer) output);
+        LongProcessExecutor executor = Core.getLongProcessExecutor();
+        handle = executor.submit(calcStat::run);
+    }
+
+    private void cancelCalculation() {
+        if (handle != null) {
+            handle.cancel();
+        }
+    }
+
+    private void updateLastScanLabel() {
+        if (statType != STAT_TYPE.MATCHES) {
+            return;
+        }
+        MatchStatisticsCache.get().ifPresent(snapshot -> lastScanLabel.setText(StringUtil.format(
+                OStrings.getString("CT_STATSMATCH_LastScan"), LAST_SCAN_FORMAT.format(snapshot.getLastScan()))));
     }
 
     /**
@@ -186,7 +281,7 @@ public class StatisticsWindow extends javax.swing.JDialog {
         // WindowListener.windowClosing() so we have to be sure to end the
         // thread here too.
         // See https://sourceforge.net/p/omegat/bugs/789/
-        handle.cancel();
+        cancelCalculation();
         dispose();
     }//GEN-LAST:event_closeButtonActionPerformed
 
@@ -218,6 +313,8 @@ public class StatisticsWindow extends javax.swing.JDialog {
                 progressBar.setString("");
                 progressBar.setVisible(false);
                 copyDataButton.setVisible(true);
+                recalculateButton.setEnabled(true);
+                updateLastScanLabel();
             }
         });
     }

--- a/src/main/java/org/omegat/gui/stat/StatisticsWindow.java
+++ b/src/main/java/org/omegat/gui/stat/StatisticsWindow.java
@@ -218,8 +218,8 @@ public class StatisticsWindow extends javax.swing.JDialog {
         if (statType != STAT_TYPE.MATCHES) {
             return;
         }
-        MatchStatisticsCache.get().ifPresent(snapshot -> lastScanLabel.setText(StringUtil.format(
-                OStrings.getString("CT_STATSMATCH_LastScan"), LAST_SCAN_FORMAT.format(snapshot.getLastScan()))));
+        MatchStatisticsCache.get().ifPresent(entry -> lastScanLabel.setText(StringUtil.format(
+                OStrings.getString("CT_STATSMATCH_LastScan"), LAST_SCAN_FORMAT.format(entry.lastScan()))));
     }
 
     /**

--- a/src/main/java/org/omegat/gui/stat/StatisticsWindow.java
+++ b/src/main/java/org/omegat/gui/stat/StatisticsWindow.java
@@ -196,6 +196,9 @@ public class StatisticsWindow extends javax.swing.JDialog {
     }
 
     private void startCalculation() {
+        if (output instanceof MatchStatisticsPanel panel) {
+            panel.onCalculationStart();
+        }
         recalculateButton.setEnabled(false);
         progressBar.setValue(0);
         progressBar.setString("");

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -733,6 +733,13 @@ CT_STATSMATCH_Total=Total:
 CT_STATSMATCH_File=File {0}: {1}
 CT_STATSMATCH_FileTotal=For all files:
 
+CT_STATSMATCH_LastScan=Last scan: {0}
+BUTTON_STATSMATCH_RECALCULATE=&Recalculate
+STATSMATCH_FILTER_BUTTON=Filter
+STATSMATCH_FILTER_BAR_LABEL=Showing segments in match category: {0} (segments across all project files: {1})
+STATSMATCH_FILTER_REPLACE_MESSAGE=The editor already has a filter applied. Replace it?
+STATSMATCH_FILTER_REPLACE_TITLE=Replace Filter
+
 STATS_FORMAT_XML=XML
 STATS_FORMAT_JSON=JSON
 STATS_FORMAT_TEXT=Text

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -697,6 +697,13 @@ CT_STATSMATCH_Total=Gesamt:
 CT_STATSMATCH_File=Datei {0}: {1}
 CT_STATSMATCH_FileTotal=F\u00FCr alle Dateien:
 
+CT_STATSMATCH_LastScan=Letzte Berechnung: {0}
+BUTTON_STATSMATCH_RECALCULATE=Neu &berechnen
+STATSMATCH_FILTER_BUTTON=Filtern
+STATSMATCH_FILTER_BAR_LABEL=Zeigt Segmente der Match-Kategorie: {0} (Segmente \u00FCber alle Projektdateien: {1})
+STATSMATCH_FILTER_REPLACE_MESSAGE=Im Editor ist bereits ein Filter aktiv. Ersetzen?
+STATSMATCH_FILTER_REPLACE_TITLE=Filter ersetzen
+
 STATS_FORMAT_XML=XML
 STATS_FORMAT_JSON=JSON
 STATS_FORMAT_TEXT=Text

--- a/src/test/java/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/src/test/java/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -38,6 +38,9 @@ import org.omegat.core.threads.Completion;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+
+import org.omegat.core.statistics.dso.MatchStatCounts;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -164,6 +167,34 @@ public class CalcMatchStatisticsTest extends TestCore {
         result = allResult.get(1);
         assertNotNull(result);
         assertStatistics(result, false);
+    }
+
+    @Test
+    public void testEntryRowIndexes() {
+        TestingStatsConsumer testingStatsConsumer = new TestingStatsConsumer();
+        CalcMatchStatistics calcMatchStatistics = new CalcMatchStatistics(project, segmenter,
+                testingStatsConsumer);
+        CancellationToken ctoken = new CancellationToken();
+        calcMatchStatistics.run(ctoken);
+        Completion completion = testingStatsConsumer.completion().join();
+        assertTrue(completion.isSuccess());
+
+        Map<Integer, Integer> rows = testingStatsConsumer.getEntryRowIndexes();
+        assertNotNull(rows);
+        // Every entry is assigned to exactly one category.
+        assertEquals(108, rows.size());
+        // Category sizes match the segment column of the statistics table.
+        assertCategoryCount(rows, MatchStatCounts.ROW_REPETITIONS, 11);
+        assertCategoryCount(rows, MatchStatCounts.getRowByPercent(Statistics.PERCENT_EXACT_MATCH), 0);
+        assertCategoryCount(rows, MatchStatCounts.getRowByPercent(95), 84);
+        assertCategoryCount(rows, MatchStatCounts.getRowByPercent(85), 0);
+        assertCategoryCount(rows, MatchStatCounts.getRowByPercent(75), 3);
+        assertCategoryCount(rows, MatchStatCounts.getRowByPercent(50), 4);
+        assertCategoryCount(rows, MatchStatCounts.getRowByPercent(0), 6);
+    }
+
+    private void assertCategoryCount(Map<Integer, Integer> rows, int categoryRow, long expected) {
+        assertEquals(expected, rows.values().stream().filter(row -> row == categoryRow).count());
     }
 
     private void assertStatistics(String[][] result, boolean perFile) {

--- a/src/test/java/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/src/test/java/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -159,14 +159,23 @@ public class CalcMatchStatisticsTest extends TestCore {
         assertEquals(2, allResult.size());
         String[][] result = allResult.get(0);
         assertNotNull(result);
-        assertEquals(3, result.length);
+        String[][] finalResult = allResult.get(1);
+        assertNotNull(finalResult);
+        // The intermediate table has the shape of the final one: same rows,
+        // every count already in its final row, similarity buckets still empty.
+        assertEquals(finalResult.length, result.length);
+        for (int i = 0; i < result.length; i++) {
+            assertEquals(finalResult[i][0], result[i][0]);
+        }
         // Repetitions: 11 90 509 583
         assertRowValues(result[0], "11", "90", "509", "583");
-        assertRowValues(result[1], "0", "0", "0", "0");
-        assertRowValues(result[2], "0", "0", "0", "0");
-        result = allResult.get(1);
-        assertNotNull(result);
-        assertStatistics(result, false);
+        // Exact match and all similarity buckets: still empty
+        for (int i = 1; i < result.length - 1; i++) {
+            assertRowValues(result[i], "0", "0", "0", "0");
+        }
+        // Total so far: the repetitions
+        assertRowValues(result[result.length - 1], "11", "90", "509", "583");
+        assertStatistics(finalResult, false);
     }
 
     @Test
@@ -181,6 +190,9 @@ public class CalcMatchStatisticsTest extends TestCore {
 
         Map<Integer, Integer> rows = testingStatsConsumer.getEntryRowIndexes();
         assertNotNull(rows);
+        // The mapping arrives after the intermediate but before the final
+        // table; the consumer wires filter buttons on that contract.
+        assertEquals(1, testingStatsConsumer.getTablesBeforeEntryRowIndexes());
         // Every entry is assigned to exactly one category.
         assertEquals(108, rows.size());
         // Category sizes match the segment column of the statistics table.

--- a/src/test/java/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/src/test/java/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -161,6 +161,8 @@ public class CalcMatchStatisticsTest extends TestCore {
         assertNotNull(result);
         String[][] finalResult = allResult.get(1);
         assertNotNull(finalResult);
+        // Fails loudly when the row set drifts away from the pinned constant.
+        assertEquals(MatchStatCounts.FINAL_TABLE_ROWS, finalResult.length);
         // The intermediate table has the shape of the final one: same rows,
         // every count already in its final row, similarity buckets still empty.
         assertEquals(finalResult.length, result.length);

--- a/src/test/java/org/omegat/core/statistics/TestingParseCallback.java
+++ b/src/test/java/org/omegat/core/statistics/TestingParseCallback.java
@@ -37,6 +37,9 @@ public class TestingParseCallback implements IParseCallback {
 
     private final List<SourceTextEntry> steList;
 
+    /** Entries are numbered sequentially, like in a real project. */
+    private int entryNum;
+
     public TestingParseCallback(final List<SourceTextEntry> ste) {
         this.steList = ste;
     }
@@ -44,8 +47,8 @@ public class TestingParseCallback implements IParseCallback {
     @Override
     public void addEntryWithProperties(String id, String source, String translation, boolean isFuzzy,
                                        String[] props, String path, IFilter filter, List<ProtectedPart> protectedParts) {
-        SourceTextEntry ste = new SourceTextEntry(new EntryKey("source.po", source, id, "", "", path), 1,
-                props, translation, protectedParts);
+        SourceTextEntry ste = new SourceTextEntry(new EntryKey("source.po", source, id, "", "", path),
+                ++entryNum, props, translation, protectedParts);
         ste.setSourceTranslationFuzzy(isFuzzy);
         steList.add(ste);
     }

--- a/src/test/java/org/omegat/core/statistics/TestingStatsConsumer.java
+++ b/src/test/java/org/omegat/core/statistics/TestingStatsConsumer.java
@@ -26,6 +26,7 @@ package org.omegat.core.statistics;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.omegat.core.threads.Completion;
 
 import java.util.concurrent.CompletableFuture;
@@ -54,11 +55,21 @@ import java.util.concurrent.CompletableFuture;
 public class TestingStatsConsumer implements IStatsConsumer {
     private final List<String[][]> result = new ArrayList<>();
     private final StringBuilder buffer = new StringBuilder();
+    private Map<Integer, Integer> entryRowIndexes;
 
     private final CompletableFuture<Completion> completion = new CompletableFuture<>();
 
     public List<String[][]> getTable() {
         return result;
+    }
+
+    public Map<Integer, Integer> getEntryRowIndexes() {
+        return entryRowIndexes;
+    }
+
+    @Override
+    public void setEntryRowIndexes(Map<Integer, Integer> entryRowIndexes) {
+        this.entryRowIndexes = entryRowIndexes;
     }
 
     public String getTextData() {

--- a/src/test/java/org/omegat/core/statistics/TestingStatsConsumer.java
+++ b/src/test/java/org/omegat/core/statistics/TestingStatsConsumer.java
@@ -56,6 +56,7 @@ public class TestingStatsConsumer implements IStatsConsumer {
     private final List<String[][]> result = new ArrayList<>();
     private final StringBuilder buffer = new StringBuilder();
     private Map<Integer, Integer> entryRowIndexes;
+    private int tablesBeforeEntryRowIndexes = -1;
 
     private final CompletableFuture<Completion> completion = new CompletableFuture<>();
 
@@ -67,9 +68,19 @@ public class TestingStatsConsumer implements IStatsConsumer {
         return entryRowIndexes;
     }
 
+    /**
+     * Number of tables delivered before {@code setEntryRowIndexes} was called,
+     * -1 when it never was. Consumers rely on the mapping arriving before the
+     * final table.
+     */
+    public int getTablesBeforeEntryRowIndexes() {
+        return tablesBeforeEntryRowIndexes;
+    }
+
     @Override
     public void setEntryRowIndexes(Map<Integer, Integer> entryRowIndexes) {
         this.entryRowIndexes = entryRowIndexes;
+        tablesBeforeEntryRowIndexes = result.size();
     }
 
     public String getTextData() {

--- a/src/test/java/org/omegat/gui/editor/filter/MatchRangeFilterTest.java
+++ b/src/test/java/org/omegat/gui/editor/filter/MatchRangeFilterTest.java
@@ -1,0 +1,64 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor.filter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.SourceTextEntry;
+
+/**
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class MatchRangeFilterTest {
+
+    @Test
+    public void testAllowed() {
+        MatchRangeFilter filter = new MatchRangeFilter("95%-100%", Arrays.asList(1, 5));
+        assertTrue(filter.allowed(createEntry(1)));
+        assertFalse(filter.allowed(createEntry(2)));
+        assertTrue(filter.allowed(createEntry(5)));
+        assertFalse(filter.allowed(null));
+    }
+
+    @Test
+    public void testProperties() {
+        MatchRangeFilter filter = new MatchRangeFilter("Repetitions", Collections.singleton(1));
+        assertFalse(filter.isSourceAsEmptyTranslation());
+        assertNotNull(filter.getControlComponent());
+    }
+
+    private SourceTextEntry createEntry(int entryNum) {
+        EntryKey key = new EntryKey("file.txt", "Source text " + entryNum, null, null, null, null);
+        return new SourceTextEntry(key, entryNum, null, null, Collections.emptyList());
+    }
+}

--- a/src/test/java/org/omegat/gui/stat/MatchStatisticsCacheTest.java
+++ b/src/test/java/org/omegat/gui/stat/MatchStatisticsCacheTest.java
@@ -1,0 +1,86 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.stat;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.omegat.core.events.IProjectEventListener;
+
+/**
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class MatchStatisticsCacheTest {
+
+    private static final String[] HEADERS = { "", "Segments" };
+    private static final String[][] DATA = { { "Repetitions:", "11" } };
+    private static final Map<Integer, Integer> ROWS = Collections.singletonMap(1, 0);
+
+    @Before
+    @After
+    public void clearCache() {
+        MatchStatisticsCache.clear();
+    }
+
+    private static final String PROJECT_ROOT = "/project/root/";
+
+    @Test
+    public void testStoreAndGet() {
+        assertFalse(MatchStatisticsCache.get().isPresent());
+        MatchStatisticsCache.store(HEADERS, DATA, ROWS, "text", PROJECT_ROOT);
+        MatchStatisticsCache.Snapshot snapshot = MatchStatisticsCache.get().orElseThrow(AssertionError::new);
+        assertArrayEquals(HEADERS, snapshot.getHeaders());
+        assertArrayEquals(DATA, snapshot.getData());
+        assertEquals(ROWS, snapshot.getEntryRowIndexes());
+        assertEquals("text", snapshot.getTextData());
+        assertEquals(PROJECT_ROOT, snapshot.getProjectRoot());
+        assertNotNull(snapshot.getLastScan());
+    }
+
+    @Test
+    public void testClearedOnProjectChange() {
+        MatchStatisticsCache.store(HEADERS, DATA, ROWS, null, PROJECT_ROOT);
+        MatchStatisticsCache.onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE.SAVE);
+        assertTrue(MatchStatisticsCache.get().isPresent());
+        MatchStatisticsCache.onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE.MODIFIED);
+        assertTrue(MatchStatisticsCache.get().isPresent());
+        MatchStatisticsCache.onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE.CLOSE);
+        assertFalse(MatchStatisticsCache.get().isPresent());
+
+        MatchStatisticsCache.store(HEADERS, DATA, ROWS, null, PROJECT_ROOT);
+        MatchStatisticsCache.onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
+        assertFalse(MatchStatisticsCache.get().isPresent());
+    }
+}

--- a/src/test/java/org/omegat/gui/stat/MatchStatisticsCacheTest.java
+++ b/src/test/java/org/omegat/gui/stat/MatchStatisticsCacheTest.java
@@ -59,19 +59,20 @@ public class MatchStatisticsCacheTest {
     @Test
     public void testStoreAndGet() {
         assertFalse(MatchStatisticsCache.get().isPresent());
-        MatchStatisticsCache.store(HEADERS, DATA, ROWS, "text", PROJECT_ROOT);
-        MatchStatisticsCache.Snapshot snapshot = MatchStatisticsCache.get().orElseThrow(AssertionError::new);
-        assertArrayEquals(HEADERS, snapshot.getHeaders());
-        assertArrayEquals(DATA, snapshot.getData());
-        assertEquals(ROWS, snapshot.getEntryRowIndexes());
-        assertEquals("text", snapshot.getTextData());
-        assertEquals(PROJECT_ROOT, snapshot.getProjectRoot());
-        assertNotNull(snapshot.getLastScan());
+        MatchStatisticsCache.store(new MatchStatisticsResult(HEADERS, DATA, ROWS, "text"), PROJECT_ROOT);
+        MatchStatisticsCache.Entry entry = MatchStatisticsCache.get().orElseThrow(AssertionError::new);
+        assertArrayEquals(HEADERS, entry.result().headers());
+        assertArrayEquals(DATA, entry.result().data());
+        assertEquals(ROWS, entry.result().entryRowIndexes());
+        assertEquals("text", entry.result().textData());
+        assertEquals(PROJECT_ROOT, entry.projectRoot());
+        assertNotNull(entry.lastScan());
     }
 
     @Test
     public void testClearedOnProjectChange() {
-        MatchStatisticsCache.store(HEADERS, DATA, ROWS, null, PROJECT_ROOT);
+        MatchStatisticsResult result = new MatchStatisticsResult(HEADERS, DATA, ROWS, null);
+        MatchStatisticsCache.store(result, PROJECT_ROOT);
         MatchStatisticsCache.onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE.SAVE);
         assertTrue(MatchStatisticsCache.get().isPresent());
         MatchStatisticsCache.onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE.MODIFIED);
@@ -79,7 +80,7 @@ public class MatchStatisticsCacheTest {
         MatchStatisticsCache.onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE.CLOSE);
         assertFalse(MatchStatisticsCache.get().isPresent());
 
-        MatchStatisticsCache.store(HEADERS, DATA, ROWS, null, PROJECT_ROOT);
+        MatchStatisticsCache.store(result, PROJECT_ROOT);
         MatchStatisticsCache.onProjectChanged(IProjectEventListener.PROJECT_CHANGE_TYPE.LOAD);
         assertFalse(MatchStatisticsCache.get().isPresent());
     }

--- a/src/test/java/org/omegat/gui/stat/MatchStatisticsPanelTest.java
+++ b/src/test/java/org/omegat/gui/stat/MatchStatisticsPanelTest.java
@@ -1,0 +1,57 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.stat;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.omegat.core.statistics.Statistics;
+import org.omegat.core.statistics.dso.MatchStatCounts;
+
+/**
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class MatchStatisticsPanelTest {
+
+    /**
+     * The displayed total table skips the repetitions-from-other-files
+     * category, so displayed rows and category rows diverge after row 0.
+     */
+    @Test
+    public void testCategoryRowForDisplayRow() {
+        // Repetitions
+        assertEquals(MatchStatCounts.ROW_REPETITIONS, MatchStatisticsPanel.categoryRowForDisplayRow(0));
+        // Exact match
+        assertEquals(MatchStatCounts.getRowByPercent(Statistics.PERCENT_EXACT_MATCH),
+                MatchStatisticsPanel.categoryRowForDisplayRow(1));
+        // Fuzzy bands and no match
+        assertEquals(MatchStatCounts.getRowByPercent(95), MatchStatisticsPanel.categoryRowForDisplayRow(2));
+        assertEquals(MatchStatCounts.getRowByPercent(85), MatchStatisticsPanel.categoryRowForDisplayRow(3));
+        assertEquals(MatchStatCounts.getRowByPercent(75), MatchStatisticsPanel.categoryRowForDisplayRow(4));
+        assertEquals(MatchStatCounts.getRowByPercent(50), MatchStatisticsPanel.categoryRowForDisplayRow(5));
+        assertEquals(MatchStatCounts.getRowByPercent(0), MatchStatisticsPanel.categoryRowForDisplayRow(6));
+    }
+}

--- a/src/test/java/org/omegat/gui/stat/MatchStatisticsResultTest.java
+++ b/src/test/java/org/omegat/gui/stat/MatchStatisticsResultTest.java
@@ -1,0 +1,83 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.stat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class MatchStatisticsResultTest {
+
+    /**
+     * The constructor is the single place that enforces the copying, so a
+     * caller mutating its arrays or map afterwards must not reach the result.
+     */
+    @Test
+    public void testConstructorCopiesParts() {
+        String[] headers = { "", "Segments" };
+        String[][] data = { { "Repetitions:", "11" } };
+        Map<Integer, Integer> rows = new HashMap<>();
+        rows.put(1, 0);
+        MatchStatisticsResult result = new MatchStatisticsResult(headers, data, rows, null);
+        headers[0] = "changed";
+        data[0][1] = "changed";
+        rows.put(2, 3);
+        assertEquals("", result.headers()[0]);
+        assertEquals("11", result.data()[0][1]);
+        assertEquals(1, result.entryRowIndexes().size());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testEntryRowIndexesImmutable() {
+        MatchStatisticsResult result = new MatchStatisticsResult(new String[] { "" },
+                new String[][] { { "" } }, Map.of(1, 0), null);
+        result.entryRowIndexes().put(2, 3);
+    }
+
+    @Test
+    public void testBuilderRequiresTableAndMapping() {
+        MatchStatisticsResult.Builder builder = new MatchStatisticsResult.Builder();
+        assertNull(builder.build());
+        builder.setTable(new String[] { "" }, new String[][] { { "" } });
+        assertNull(builder.build());
+        builder.setEntryRowIndexes(Map.of(1, 0));
+        MatchStatisticsResult result = builder.build();
+        assertNotNull(result);
+        assertNull(result.textData());
+        builder.setTextData("text");
+        MatchStatisticsResult withText = builder.build();
+        assertNotNull(withText);
+        assertEquals("text", withText.textData());
+    }
+}


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- No ticket. Related: Separate Statistics for Context-Bound (ICE/101%) and Exact (100%) Matches
  * https://sourceforge.net/p/omegat/feature-requests/1782/

## What does this PR change?

- Makes the Match Statistics window non-modal, so the editor stays usable while it is open
- Adds a Filter button per category row that restricts the editor to the segments of that category, asking before replacing an active filter
- Keeps the last result for the session with a timestamp; a Recalculate button refreshes it

## Other information

### screenshot
(not part of this PR, only as an attachment, will not be updated if implementation details should change)
<img width="1508" height="653" alt="Bildschirmfoto 2026-08-18 um 14 46 01" src="https://github.com/user-attachments/assets/201503a8-5794-4e1e-8e51-065bb91ae29a" />
