### PR TITLE
fix(languagetools+spellcheck): never show matches inside protected placeholders where translator is not supposed to change anything anyway

### DIFF
--- a/src/main/java/org/omegat/core/data/ProtectedPart.java
+++ b/src/main/java/org/omegat/core/data/ProtectedPart.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2013 Alex Buloichik
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -72,6 +73,26 @@ public class ProtectedPart {
      * Replacement for match calculation.
      */
     protected @Nullable String replacementMatchCalculation;
+
+    /**
+     * Spans of every occurrence of the given protected parts in text, as
+     * (start, end) pairs. Protected part texts are assumed to match the
+     * text character-wise, as everywhere else in OmegaT.
+     */
+    public static List<int[]> occurrencesIn(String text, ProtectedPart[] parts) {
+        List<int[]> occurrences = new ArrayList<>();
+        for (ProtectedPart pp : parts) {
+            String ppText = pp.getTextInSourceSegment();
+            if (ppText == null || ppText.isEmpty()) {
+                continue;
+            }
+            int pos = -1;
+            while ((pos = text.indexOf(ppText, pos + 1)) >= 0) {
+                occurrences.add(new int[] { pos, pos + ppText.length() });
+            }
+        }
+        return occurrences;
+    }
 
     public String getTextInSourceSegment() {
         return textInSourceSegment;

--- a/src/main/java/org/omegat/core/spellchecker/SpellCheckerMarker.java
+++ b/src/main/java/org/omegat/core/spellchecker/SpellCheckerMarker.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2010 Alex Buloichik
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -32,10 +33,12 @@ import javax.swing.text.Highlighter.HighlightPainter;
 
 import org.jetbrains.annotations.Nullable;
 import org.omegat.core.Core;
+import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.gui.editor.UnderlineFactory;
 import org.omegat.gui.editor.mark.IMarker;
 import org.omegat.gui.editor.mark.Mark;
+import org.omegat.util.Token;
 import org.omegat.util.gui.Styles;
 
 /**
@@ -61,12 +64,46 @@ public class SpellCheckerMarker implements IMarker {
         // without restarting the application
         HighlightPainter highlightPainter = new UnderlineFactory.WaveUnderline(
                 Styles.EditorColor.COLOR_SPELLCHECK.getColor());
-        return Core.getSpellChecker().getMisspelledTokens(translationText).stream().map(tok -> {
+        List<Token> misspelled = filterProtectedParts(
+                Core.getSpellChecker().getMisspelledTokens(translationText), ste, translationText);
+        return misspelled.stream().map(tok -> {
             int st = tok.getOffset();
             int en = st + tok.getLength();
             Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, st, en);
             m.painter = highlightPainter;
             return m;
         }).collect(Collectors.toList());
+    }
+
+    /**
+     * Drop misspelled tokens lying entirely inside an occurrence of one of
+     * the entry's protected parts in the translation text. Placeholder
+     * syntax is not prose the translator can fix, so words inside it (for
+     * example the "ld" inside "%1$ld") get no spelling marks. Tokens
+     * reaching beyond a single occurrence are kept: they may point at a
+     * real problem around it.
+     *
+     * @param tokens
+     *            misspelled tokens whose offsets refer to translationText
+     * @param ste
+     *            source entry providing the protected parts; may be null,
+     *            in which case nothing is filtered
+     * @param translationText
+     *            the text that was checked
+     * @return the tokens without those inside protected parts
+     */
+    public static List<Token> filterProtectedParts(List<Token> tokens, @Nullable SourceTextEntry ste,
+            String translationText) {
+        if (tokens.isEmpty() || ste == null || ste.getProtectedParts().length == 0) {
+            return tokens;
+        }
+        List<int[]> occurrences = ProtectedPart.occurrencesIn(translationText, ste.getProtectedParts());
+        if (occurrences.isEmpty()) {
+            return tokens;
+        }
+        return tokens.stream()
+                .filter(t -> occurrences.stream()
+                        .noneMatch(o -> t.getOffset() >= o[0] && t.getOffset() + t.getLength() <= o[1]))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/omegat/gui/editor/EditorPopups.java
+++ b/src/main/java/org/omegat/gui/editor/EditorPopups.java
@@ -59,6 +59,7 @@ import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -136,6 +137,12 @@ public final class EditorPopups {
             }
 
             if (tok == null) {
+                return;
+            }
+
+            if (isInsideProtectedPart(tok, sb.getSourceTextEntry(), translation)) {
+                // Placeholder syntax is not prose the translator can fix, so
+                // no suggestions and especially no learn/ignore for it.
                 return;
             }
 
@@ -221,6 +228,16 @@ public final class EditorPopups {
             }
 
             ec.remarkOneMarker(SpellCheckerMarker.class.getName());
+        }
+
+        /**
+         * True when the clicked token lies entirely inside an occurrence of
+         * one of the entry's protected parts, by the same rule the marker
+         * filters use.
+         */
+        static boolean isInsideProtectedPart(Token tok, SourceTextEntry ste, String translation) {
+            return SpellCheckerMarker.filterProtectedParts(Collections.singletonList(tok), ste, translation)
+                    .isEmpty();
         }
     }
 

--- a/src/main/java/org/omegat/gui/issues/SpellingIssueProvider.java
+++ b/src/main/java/org/omegat/gui/issues/SpellingIssueProvider.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2016 Aaron Madlon-Kay
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -40,6 +41,7 @@ import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
 import org.omegat.core.Core;
+import org.omegat.core.spellchecker.SpellCheckerMarker;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.core.spellchecker.ISpellChecker;
@@ -68,7 +70,9 @@ class SpellingIssueProvider implements IIssueProvider {
 
     @Override
     public List<IIssue> getIssues(SourceTextEntry sourceEntry, TMXEntry tmxEntry) {
-        List<Token> misspelled = Core.getSpellChecker().getMisspelledTokens(tmxEntry.translation);
+        List<Token> misspelled = SpellCheckerMarker.filterProtectedParts(
+                Core.getSpellChecker().getMisspelledTokens(tmxEntry.translation), sourceEntry,
+                tmxEntry.translation);
         return misspelled.isEmpty() ? Collections.emptyList()
                 : List.of(new SpellingIssue(sourceEntry, tmxEntry, misspelled));
     }

--- a/src/main/java/org/omegat/languagetools/LanguageToolIssueProvider.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolIssueProvider.java
@@ -63,8 +63,11 @@ public class LanguageToolIssueProvider implements IIssueProvider {
     public List<IIssue> getIssues(SourceTextEntry sourceEntry, TMXEntry tmxEntry) {
         ILanguageToolBridge bridge = LanguageToolWrapper.getBridge();
         if (bridge != null) {
-            return bridge.getCheckResults(sourceEntry.getSrcText(), tmxEntry.translation).stream()
-                    .map(match -> new LanguageToolIssue(sourceEntry, tmxEntry.translation, match))
+            return LanguageToolWrapper
+                    .filterProtectedParts(
+                            bridge.getCheckResults(sourceEntry.getSrcText(), tmxEntry.translation),
+                            sourceEntry, tmxEntry.translation)
+                    .stream().map(match -> new LanguageToolIssue(sourceEntry, tmxEntry.translation, match))
                     .collect(Collectors.toList());
         } else {
             return Collections.emptyList();

--- a/src/main/java/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolWrapper.java
@@ -30,7 +30,6 @@ package org.omegat.languagetools;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -140,14 +139,7 @@ public final class LanguageToolWrapper {
         if (matches.isEmpty() || ste == null || ste.getProtectedParts().length == 0) {
             return matches;
         }
-        List<int[]> occurrences = new ArrayList<>();
-        for (ProtectedPart pp : ste.getProtectedParts()) {
-            String text = pp.getTextInSourceSegment();
-            int pos = -1;
-            while ((pos = translationText.indexOf(text, pos + 1)) >= 0) {
-                occurrences.add(new int[] { pos, pos + text.length() });
-            }
-        }
+        List<int[]> occurrences = ProtectedPart.occurrencesIn(translationText, ste.getProtectedParts());
         if (occurrences.isEmpty()) {
             return matches;
         }

--- a/src/main/java/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolWrapper.java
@@ -6,6 +6,7 @@
  Copyright (C) 2010-2013 Alex Buloichik
                2015 Aaron Madlon-Kay
                2016 Lev Abashkin
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -29,13 +30,17 @@ package org.omegat.languagetools;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.swing.text.Highlighter.HighlightPainter;
 
+import org.jetbrains.annotations.Nullable;
+
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
+import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.gui.editor.UnderlineFactory;
@@ -109,6 +114,48 @@ public final class LanguageToolWrapper {
         return bridge;
     }
 
+    /**
+     * Drop matches that lie entirely inside an occurrence of one of the
+     * entry's protected parts in the translation text. Rules routinely
+     * misread placeholder syntax (for example a currency rule firing on the
+     * "3$" inside the placeholder "%3$@"), and protected parts are not
+     * prose the translator can fix. Matches reaching beyond a single
+     * occurrence are kept on purpose, even ones spanning two adjacent
+     * placeholders: they may point at a real problem around them. Protected
+     * part texts are assumed to match the checked text character-wise, as
+     * everywhere else in OmegaT.
+     *
+     * @param matches
+     *            check results whose offsets refer to translationText
+     * @param ste
+     *            source entry providing the protected parts; may be null
+     *            (e.g. when the marker is invoked without an entry, as in
+     *            tests), in which case nothing is filtered
+     * @param translationText
+     *            the text that was checked
+     * @return the matches without those inside protected parts
+     */
+    static List<LanguageToolResult> filterProtectedParts(List<LanguageToolResult> matches,
+            @Nullable SourceTextEntry ste, String translationText) {
+        if (matches.isEmpty() || ste == null || ste.getProtectedParts().length == 0) {
+            return matches;
+        }
+        List<int[]> occurrences = new ArrayList<>();
+        for (ProtectedPart pp : ste.getProtectedParts()) {
+            String text = pp.getTextInSourceSegment();
+            int pos = -1;
+            while ((pos = translationText.indexOf(text, pos + 1)) >= 0) {
+                occurrences.add(new int[] { pos, pos + text.length() });
+            }
+        }
+        if (occurrences.isEmpty()) {
+            return matches;
+        }
+        return matches.stream()
+                .filter(m -> occurrences.stream().noneMatch(o -> m.start >= o[0] && m.end <= o[1]))
+                .collect(Collectors.toList());
+    }
+
     static class LanguageToolMarker implements IMarker {
         static final HighlightPainter PAINTER = new UnderlineFactory.WaveUnderline(
                 Styles.EditorColor.COLOR_LANGUAGE_TOOLS.getColor());
@@ -142,7 +189,9 @@ public final class LanguageToolWrapper {
                 sourceText = ste.getSrcText();
             }
 
-            return bridge.getCheckResults(sourceText, translationText).stream().map(match -> {
+            List<LanguageToolResult> results = filterProtectedParts(
+                    bridge.getCheckResults(sourceText, translationText), ste, translationText);
+            return results.stream().map(match -> {
                 Mark m = new Mark(Mark.ENTRY_PART.TRANSLATION, match.start, match.end);
                 m.toolTipText = match.message;
                 m.painter = PAINTER;

--- a/src/test/java/org/omegat/core/data/ProtectedPartsFixtures.java
+++ b/src/test/java/org/omegat/core/data/ProtectedPartsFixtures.java
@@ -1,0 +1,59 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.omegat.util.Token;
+
+/**
+ * Shared builders for the protected-parts tests: a real SourceTextEntry
+ * carrying the given placeholder texts, and a word token addressed by its
+ * text content.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class ProtectedPartsFixtures {
+
+    private ProtectedPartsFixtures() {
+    }
+
+    public static SourceTextEntry entryWithProtectedParts(String source, String... parts) {
+        List<ProtectedPart> pps = Arrays.stream(parts).map(p -> {
+            ProtectedPart pp = new ProtectedPart();
+            pp.setTextInSourceSegment(p);
+            return pp;
+        }).collect(Collectors.toList());
+        return new SourceTextEntry(new EntryKey("file.txt", source, null, "", "", null), 1, null, null,
+                pps, true);
+    }
+
+    public static Token tokenAt(String text, String word) {
+        return new Token(word, text.indexOf(word), word.length());
+    }
+}

--- a/src/test/java/org/omegat/core/spellchecker/SpellCheckerProtectedPartsTest.java
+++ b/src/test/java/org/omegat/core/spellchecker/SpellCheckerProtectedPartsTest.java
@@ -27,15 +27,14 @@ package org.omegat.core.spellchecker;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.omegat.core.data.ProtectedPartsFixtures.entryWithProtectedParts;
+import static org.omegat.core.data.ProtectedPartsFixtures.tokenAt;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
-import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.util.Token;
@@ -48,20 +47,6 @@ import org.omegat.util.Token;
  * @author stephan.pakebusch at zollsoft.de
  */
 public class SpellCheckerProtectedPartsTest {
-
-    private static SourceTextEntry entryWithProtectedParts(String source, String... parts) {
-        List<ProtectedPart> pps = Arrays.stream(parts).map(p -> {
-            ProtectedPart pp = new ProtectedPart();
-            pp.setTextInSourceSegment(p);
-            return pp;
-        }).collect(Collectors.toList());
-        return new SourceTextEntry(new EntryKey("file.txt", source, null, "", "", null), 1, null, null,
-                pps, true);
-    }
-
-    private static Token tokenAt(String text, String word) {
-        return new Token(word, text.indexOf(word), word.length());
-    }
 
     @Test
     public void testTokenInsidePlaceholderIsDropped() {

--- a/src/test/java/org/omegat/core/spellchecker/SpellCheckerProtectedPartsTest.java
+++ b/src/test/java/org/omegat/core/spellchecker/SpellCheckerProtectedPartsTest.java
@@ -1,0 +1,151 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.spellchecker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.ProtectedPart;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.util.Token;
+
+/**
+ * Words inside protected placeholders are not prose, so they get no
+ * spelling marks: the "ld" inside "%1$ld" is placeholder syntax, not a
+ * misspelled word.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class SpellCheckerProtectedPartsTest {
+
+    private static SourceTextEntry entryWithProtectedParts(String source, String... parts) {
+        List<ProtectedPart> pps = Arrays.stream(parts).map(p -> {
+            ProtectedPart pp = new ProtectedPart();
+            pp.setTextInSourceSegment(p);
+            return pp;
+        }).collect(Collectors.toList());
+        return new SourceTextEntry(new EntryKey("file.txt", source, null, "", "", null), 1, null, null,
+                pps, true);
+    }
+
+    private static Token tokenAt(String text, String word) {
+        return new Token(word, text.indexOf(word), word.length());
+    }
+
+    @Test
+    public void testTokenInsidePlaceholderIsDropped() {
+        String translation = "Server error %1$ld: %2$@";
+        SourceTextEntry ste = entryWithProtectedParts("Serverfehler %1$ld: %2$@", "%1$ld", "%2$@");
+        List<Token> filtered = SpellCheckerMarker.filterProtectedParts(
+                Collections.singletonList(tokenAt(translation, "ld")), ste, translation);
+        assertEquals(0, filtered.size());
+    }
+
+    @Test
+    public void testTokenOutsidePlaceholderIsKept() {
+        String translation = "Server errorr %1$ld";
+        SourceTextEntry ste = entryWithProtectedParts("Serverfehler %1$ld", "%1$ld");
+        List<Token> filtered = SpellCheckerMarker.filterProtectedParts(
+                Collections.singletonList(tokenAt(translation, "errorr")), ste, translation);
+        assertEquals(1, filtered.size());
+    }
+
+    @Test
+    public void testTokenOverlappingPlaceholderBoundaryIsKept() {
+        // The tokenizer never produces such a token today, but the filter
+        // must not swallow anything reaching outside the placeholder.
+        String translation = "errld%1$ld";
+        SourceTextEntry ste = entryWithProtectedParts("%1$ld", "%1$ld");
+        List<Token> filtered = SpellCheckerMarker.filterProtectedParts(
+                Collections.singletonList(new Token("errld%1$", 0, 8)), ste, translation);
+        assertEquals(1, filtered.size());
+    }
+
+    @Test
+    public void testAllOccurrencesAreCovered() {
+        String translation = "%1$ld or %1$ld";
+        SourceTextEntry ste = entryWithProtectedParts("%1$ld oder %1$ld", "%1$ld");
+        Token second = new Token("ld", translation.lastIndexOf("ld"), 2);
+        List<Token> filtered = SpellCheckerMarker.filterProtectedParts(
+                Collections.singletonList(second), ste, translation);
+        assertEquals(0, filtered.size());
+    }
+
+    @Test
+    public void testNullEntryFiltersNothing() {
+        List<Token> tokens = Collections.singletonList(new Token("ld", 0, 2));
+        assertSame(tokens, SpellCheckerMarker.filterProtectedParts(tokens, null, "ld"));
+    }
+
+    @Test
+    public void testTokenCoveringWholePlaceholderIsDropped() {
+        String translation = "Server error %1$ld";
+        SourceTextEntry ste = entryWithProtectedParts("Serverfehler %1$ld", "%1$ld");
+        Token whole = new Token("%1$ld", translation.indexOf("%1$ld"), 5);
+        List<Token> filtered = SpellCheckerMarker.filterProtectedParts(
+                Collections.singletonList(whole), ste, translation);
+        assertEquals(0, filtered.size());
+    }
+
+    @Test
+    public void testEntryWithoutProtectedPartsReturnsSameList() {
+        String translation = "Server errorr";
+        SourceTextEntry ste = entryWithProtectedParts("Serverfehler");
+        List<Token> tokens = Collections.singletonList(tokenAt(translation, "errorr"));
+        assertSame(tokens, SpellCheckerMarker.filterProtectedParts(tokens, ste, translation));
+    }
+
+    @Test
+    public void testPlaceholderAbsentFromTranslationKeepsTokens() {
+        String translation = "Server errorr without placeholder";
+        SourceTextEntry ste = entryWithProtectedParts("Serverfehler %1$ld", "%1$ld");
+        List<Token> tokens = Collections.singletonList(tokenAt(translation, "errorr"));
+        assertSame(tokens, SpellCheckerMarker.filterProtectedParts(tokens, ste, translation));
+    }
+
+    @Test
+    public void testOccurrenceHelperSkipsNullAndEmptyPartTexts() {
+        // SourceTextEntry never delivers such parts, so the helper's guard
+        // is exercised directly: without it, null throws and the empty
+        // text loops forever.
+        ProtectedPart nullText = new ProtectedPart();
+        ProtectedPart emptyText = new ProtectedPart();
+        emptyText.setTextInSourceSegment("");
+        ProtectedPart real = new ProtectedPart();
+        real.setTextInSourceSegment("%1$ld");
+        List<int[]> occurrences = ProtectedPart.occurrencesIn("Server error %1$ld",
+                new ProtectedPart[] { nullText, emptyText, real });
+        assertEquals(1, occurrences.size());
+    }
+}

--- a/src/test/java/org/omegat/gui/editor/EditorPopupsProtectedPartsTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorPopupsProtectedPartsTest.java
@@ -1,0 +1,82 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.omegat.core.data.ProtectedPartsFixtures.entryWithProtectedParts;
+import static org.omegat.core.data.ProtectedPartsFixtures.tokenAt;
+
+import org.junit.Test;
+
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.util.Token;
+
+/**
+ * The spell checker popup must stay quiet inside protected placeholders:
+ * where the marker draws no wave, the right click offers no suggestions and
+ * especially no learn/ignore that would put placeholder fragments into the
+ * learned words.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class EditorPopupsProtectedPartsTest {
+
+    @Test
+    public void testWordInsidePlaceholderIsProtected() {
+        String translation = "Server error %1$ld: %2$@";
+        SourceTextEntry ste = entryWithProtectedParts("Serverfehler %1$ld: %2$@", "%1$ld", "%2$@");
+        assertTrue("the ld inside %1$ld must get no popup items",
+                EditorPopups.SpellCheckerPopup.isInsideProtectedPart(tokenAt(translation, "ld"), ste,
+                        translation));
+    }
+
+    @Test
+    public void testWordOutsidePlaceholderIsNotProtected() {
+        String translation = "Server errorr %1$ld";
+        SourceTextEntry ste = entryWithProtectedParts("Serverfehler %1$ld", "%1$ld");
+        assertFalse("a real typo next to the placeholder must keep its popup",
+                EditorPopups.SpellCheckerPopup.isInsideProtectedPart(tokenAt(translation, "errorr"), ste,
+                        translation));
+    }
+
+    @Test
+    public void testWordOverlappingPlaceholderBoundaryIsNotProtected() {
+        String translation = "errld%1$ld";
+        SourceTextEntry ste = entryWithProtectedParts("%1$ld", "%1$ld");
+        assertFalse("a token reaching outside the placeholder must keep its popup",
+                EditorPopups.SpellCheckerPopup.isInsideProtectedPart(new Token("errld%1$", 0, 8), ste,
+                        translation));
+    }
+
+    @Test
+    public void testEntryWithoutProtectedPartsProtectsNothing() {
+        String translation = "Server errorr";
+        SourceTextEntry ste = entryWithProtectedParts("Serverfehler");
+        assertFalse(EditorPopups.SpellCheckerPopup.isInsideProtectedPart(tokenAt(translation, "errorr"),
+                ste, translation));
+    }
+}

--- a/src/test/java/org/omegat/languagetools/LanguageToolProtectedPartsTest.java
+++ b/src/test/java/org/omegat/languagetools/LanguageToolProtectedPartsTest.java
@@ -27,16 +27,14 @@ package org.omegat.languagetools;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.omegat.core.data.ProtectedPartsFixtures.entryWithProtectedParts;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 
-import org.omegat.core.data.EntryKey;
-import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SourceTextEntry;
 
 /**
@@ -45,16 +43,6 @@ import org.omegat.core.data.SourceTextEntry;
  * @author Stephan Pakebusch stephan.pakebusch at zollsoft.de
  */
 public class LanguageToolProtectedPartsTest {
-
-    private static SourceTextEntry entryWithProtectedParts(String source, String... parts) {
-        List<ProtectedPart> pps = Arrays.stream(parts).map(p -> {
-            ProtectedPart pp = new ProtectedPart();
-            pp.setTextInSourceSegment(p);
-            return pp;
-        }).collect(Collectors.toList());
-        return new SourceTextEntry(new EntryKey("file.txt", source, null, "", "", null), 1, null, null,
-                pps, true);
-    }
 
     private static LanguageToolResult result(int start, int end) {
         return new LanguageToolResult("message", start, end, "RULE_ID", "rule description");

--- a/src/test/java/org/omegat/languagetools/LanguageToolProtectedPartsTest.java
+++ b/src/test/java/org/omegat/languagetools/LanguageToolProtectedPartsTest.java
@@ -1,0 +1,140 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.languagetools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.ProtectedPart;
+import org.omegat.core.data.SourceTextEntry;
+
+/**
+ * Tests for suppressing LanguageTool matches inside protected parts.
+ *
+ * @author Stephan Pakebusch stephan.pakebusch at zollsoft.de
+ */
+public class LanguageToolProtectedPartsTest {
+
+    private static SourceTextEntry entryWithProtectedParts(String source, String... parts) {
+        List<ProtectedPart> pps = Arrays.stream(parts).map(p -> {
+            ProtectedPart pp = new ProtectedPart();
+            pp.setTextInSourceSegment(p);
+            return pp;
+        }).collect(Collectors.toList());
+        return new SourceTextEntry(new EntryKey("file.txt", source, null, "", "", null), 1, null, null,
+                pps, true);
+    }
+
+    private static LanguageToolResult result(int start, int end) {
+        return new LanguageToolResult("message", start, end, "RULE_ID", "rule description");
+    }
+
+    @Test
+    public void testMatchInsidePlaceholderIsDropped() {
+        // The currency rule fires on the "3$" inside the placeholder.
+        String translation = "Error: %3$@ Do you want to save the e-prescriptions?";
+        SourceTextEntry ste = entryWithProtectedParts("Fehler: %3$@ Wollen Sie speichern?", "%3$@");
+        int pos = translation.indexOf("3$");
+        List<LanguageToolResult> filtered = LanguageToolWrapper.filterProtectedParts(
+                Collections.singletonList(result(pos, pos + 2)), ste, translation);
+        assertEquals(0, filtered.size());
+    }
+
+    @Test
+    public void testMatchOutsidePlaceholderIsKept() {
+        String translation = "Error: %3$@ Do you want too save?";
+        SourceTextEntry ste = entryWithProtectedParts("Fehler: %3$@ Speichern?", "%3$@");
+        int pos = translation.indexOf("too");
+        List<LanguageToolResult> filtered = LanguageToolWrapper.filterProtectedParts(
+                Collections.singletonList(result(pos, pos + 3)), ste, translation);
+        assertEquals(1, filtered.size());
+    }
+
+    @Test
+    public void testMatchOverlappingPlaceholderBoundaryIsKept() {
+        // A match reaching beyond the placeholder is not fully inside it and
+        // may point at a real problem around it, so it survives.
+        String translation = "Error:%3$@ text";
+        SourceTextEntry ste = entryWithProtectedParts("Fehler: %3$@ Text", "%3$@");
+        int start = translation.indexOf(":");
+        int end = translation.indexOf("@") + 1;
+        List<LanguageToolResult> filtered = LanguageToolWrapper.filterProtectedParts(
+                Collections.singletonList(result(start, end)), ste, translation);
+        assertEquals(1, filtered.size());
+    }
+
+    @Test
+    public void testAllOccurrencesAreCovered() {
+        String translation = "%1$@ and %1$@ again";
+        SourceTextEntry ste = entryWithProtectedParts("%1$@ und %1$@ nochmal", "%1$@");
+        int first = translation.indexOf("1$");
+        int second = translation.lastIndexOf("1$");
+        List<LanguageToolResult> filtered = LanguageToolWrapper.filterProtectedParts(
+                Arrays.asList(result(first, first + 2), result(second, second + 2)), ste, translation);
+        assertEquals(0, filtered.size());
+    }
+
+    @Test
+    public void testMatchCoveringWholePlaceholderIsDropped() {
+        String translation = "Error: %3$@ text";
+        SourceTextEntry ste = entryWithProtectedParts("Fehler: %3$@ Text", "%3$@");
+        int start = translation.indexOf("%3$@");
+        List<LanguageToolResult> filtered = LanguageToolWrapper.filterProtectedParts(
+                Collections.singletonList(result(start, start + "%3$@".length())), ste, translation);
+        assertEquals(0, filtered.size());
+    }
+
+    @Test
+    public void testNullEntryReturnsSameList() {
+        List<LanguageToolResult> matches = Collections.singletonList(result(0, 2));
+        assertSame(matches, LanguageToolWrapper.filterProtectedParts(matches, null, "some text"));
+    }
+
+    @Test
+    public void testEntryWithoutProtectedPartsReturnsSameList() {
+        String translation = "Plain text";
+        SourceTextEntry ste = entryWithProtectedParts("Reiner Text");
+        List<LanguageToolResult> matches = Collections.singletonList(result(0, 5));
+        assertSame(matches, LanguageToolWrapper.filterProtectedParts(matches, ste, translation));
+    }
+
+    @Test
+    public void testPlaceholderAbsentFromTranslationKeepsMatches() {
+        String translation = "No placeholder here";
+        SourceTextEntry ste = entryWithProtectedParts("%3$@ hier", "%3$@");
+        List<LanguageToolResult> filtered = LanguageToolWrapper.filterProtectedParts(
+                Collections.singletonList(result(0, 2)), ste, translation);
+        assertEquals(1, filtered.size());
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- (no ticket)

## What does this PR change?

- LanguageTool matches lying entirely inside a protected part in the translation are suppressed, in the editor marker and in the Issues window. Style rules routinely misread placeholder syntax, for example the currency rule firing on the "3$" inside "%3$@". Matches reaching beyond a placeholder are kept.

## Other information
