### PR TITLE
feat(editor): additional editing shortcuts for more efficient editing

### DIFF
--- a/src/docs/tips/de/editing_shortcuts.html
+++ b/src/docs/tips/de/editing_shortcuts.html
@@ -1,0 +1,52 @@
+<html lang="de">
+<!--
+  ~  OmegaT - Computer Assisted Translation (CAT) tool
+  ~           with fuzzy matching, translation memory, keyword search,
+  ~           glossaries, and translation leveraging into updated projects.
+  ~
+  ~  Copyright (C) 2026 Stephan Pakebusch.
+  ~                Home page: https://www.omegat.org/
+  ~                Support center: https://omegat.org/support
+  ~
+  ~  This file is part of OmegaT.
+  ~
+  ~  OmegaT is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  OmegaT is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<head>
+    <meta charset="UTF-8">
+    <title>Schneller editieren</title>
+    <link rel="stylesheet" type="text/css" href="../tips.css">
+</head> <body>
+<h3 class="title">Schneller editieren</h3>
+<p>Zusätzliche Editier-Kürzel (macOS in Klammern):</p>
+<ul>
+    <li>Alles links oder rechts vom Cursor löschen:
+        <span class="keycap">Strg+Umschalt+Rücktaste</span> / <span class="keycap">Strg+Umschalt+Entf</span>
+        (<span class="keycap">Cmd+Rücktaste</span> / <span class="keycap">Cmd+Umschalt+Rücktaste</span>)</li>
+    <li>Nächstes Wort löschen, ganz ohne Entf-Taste:
+        <span class="keycap">Alt+Umschalt+Rücktaste</span></li>
+    <li>An Segmentanfang oder -ende springen, mit Umschalt markieren:
+        <span class="keycap">Strg+Pos1</span> / <span class="keycap">Strg+Ende</span>
+        (<span class="keycap">Cmd+&#8593;</span> / <span class="keycap">Cmd+&#8595;</span>)</li>
+    <li>Nächste fehlende Zahl, Tag oder URL einfügen:
+        <span class="keycap">Strg+Komma</span>; letztes Element:
+        <span class="keycap">Strg+Umschalt+Komma</span></li>
+    <li>Geschütztes Leerzeichen einfügen: <span class="keycap">Strg+Umschalt+Leertaste</span></li>
+    <li>Erstes fehlendes Tag-Paar einfügen, um Selektion herum falls vorhanden:
+        <span class="keycap">Strg+Punkt</span></li>
+    <li>Wort am Cursor nach links oder rechts verschieben:
+        <span class="keycap">Strg+Alt+&#8592;</span> / <span class="keycap">Strg+Alt+&#8594;</span>
+        (<span class="keycap">Cmd+Alt+&#8592;</span> / <span class="keycap">Cmd+Alt+&#8594;</span>)</li>
+</ul>
+</body></html>

--- a/src/docs/tips/de/tips.yaml
+++ b/src/docs/tips/de/tips.yaml
@@ -82,3 +82,5 @@ tips:
   name: "MT-4tw-3"
 - file: "machine_translation_4tw_3.html"
   name: "MT-4tw-4"
+- file: "editing_shortcuts.html"
+  name: "Schneller editieren"

--- a/src/docs/tips/en/editing_shortcuts.html
+++ b/src/docs/tips/en/editing_shortcuts.html
@@ -1,0 +1,52 @@
+<html lang="en">
+<!--
+  ~  OmegaT - Computer Assisted Translation (CAT) tool
+  ~           with fuzzy matching, translation memory, keyword search,
+  ~           glossaries, and translation leveraging into updated projects.
+  ~
+  ~  Copyright (C) 2026 Stephan Pakebusch.
+  ~                Home page: https://www.omegat.org/
+  ~                Support center: https://omegat.org/support
+  ~
+  ~  This file is part of OmegaT.
+  ~
+  ~  OmegaT is free software: you can redistribute it and/or modify
+  ~  it under the terms of the GNU General Public License as published by
+  ~  the Free Software Foundation, either version 3 of the License, or
+  ~  (at your option) any later version.
+  ~
+  ~  OmegaT is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~  GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License
+  ~  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<head>
+    <meta charset="UTF-8">
+    <title>Faster editing</title>
+    <link rel="stylesheet" type="text/css" href="../tips.css">
+</head> <body>
+<h3 class="title">Faster editing</h3>
+<p>Extra editing shortcuts (macOS in parentheses):</p>
+<ul>
+    <li>Delete everything left or right of cursor:
+        <span class="keycap">Ctrl+Shift+Backspace</span> / <span class="keycap">Ctrl+Shift+Delete</span>
+        (<span class="keycap">Cmd+Backspace</span> / <span class="keycap">Cmd+Shift+Backspace</span>)</li>
+    <li>Delete next word, no Forward-Delete key needed:
+        <span class="keycap">Alt+Shift+Backspace</span></li>
+    <li>Jump to segment start or end, Shift selects:
+        <span class="keycap">Ctrl+Home</span> / <span class="keycap">Ctrl+End</span>
+        (<span class="keycap">Cmd+&#8593;</span> / <span class="keycap">Cmd+&#8595;</span>)</li>
+    <li>Insert next number, tag or URL still missing from translation:
+        <span class="keycap">Ctrl+Comma</span>; last one:
+        <span class="keycap">Ctrl+Shift+Comma</span></li>
+    <li>Insert non-breaking space: <span class="keycap">Ctrl+Shift+Space</span></li>
+    <li>Insert first missing tag pair, around selection if any:
+        <span class="keycap">Ctrl+Period</span></li>
+    <li>Move word at cursor left or right:
+        <span class="keycap">Ctrl+Alt+&#8592;</span> / <span class="keycap">Ctrl+Alt+&#8594;</span>
+        (<span class="keycap">Cmd+Alt+&#8592;</span> / <span class="keycap">Cmd+Alt+&#8594;</span>)</li>
+</ul>
+</body></html>

--- a/src/docs/tips/en/tips.yaml
+++ b/src/docs/tips/en/tips.yaml
@@ -74,3 +74,5 @@ tips:
   name: Ignore a word in the dictionary
 - file: fuzzy_match_numbers.html
   name: Let fuzzy matching understand numbers
+- file: editing_shortcuts.html
+  name: Faster editing

--- a/src/main/java/org/omegat/gui/editor/EditorTextArea3.java
+++ b/src/main/java/org/omegat/gui/editor/EditorTextArea3.java
@@ -9,6 +9,7 @@
                2013 Zoltan Bartko
                2014 Aaron Madlon-Kay
                2015 Yu Tang
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -74,6 +75,7 @@ import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
+import org.omegat.util.TagUtil;
 import org.omegat.util.gui.Styles;
 import org.omegat.util.gui.UIDesignManager;
 
@@ -122,6 +124,32 @@ public class EditorTextArea3 extends JEditorPane {
             .getKeyStroke("editorToggleCursorLock");
     private static final KeyStroke KEYSTROKE_TOGGLE_OVERTYPE = PropertiesShortcuts.getEditorShortcuts()
             .getKeyStroke("editorToggleOvertype");
+    private static final KeyStroke KEYSTROKE_DELETE_TO_SEGMENT_START = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorDeleteToSegmentStart");
+    private static final KeyStroke KEYSTROKE_DELETE_TO_SEGMENT_END = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorDeleteToSegmentEnd");
+    private static final KeyStroke KEYSTROKE_DELETE_NEXT_TOKEN_ALTERNATE = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorDeleteNextTokenAlternate");
+    private static final KeyStroke KEYSTROKE_MOVE_TO_SEGMENT_START = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorMoveToSegmentStart");
+    private static final KeyStroke KEYSTROKE_MOVE_TO_SEGMENT_END = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorMoveToSegmentEnd");
+    private static final KeyStroke KEYSTROKE_MOVE_TO_SEGMENT_START_SEL = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorMoveToSegmentStartWithSelection");
+    private static final KeyStroke KEYSTROKE_MOVE_TO_SEGMENT_END_SEL = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorMoveToSegmentEndWithSelection");
+    private static final KeyStroke KEYSTROKE_INSERT_NEXT_PLACEABLE = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorInsertNextMissingPlaceable");
+    private static final KeyStroke KEYSTROKE_INSERT_PREV_PLACEABLE = PropertiesShortcuts
+            .getEditorShortcuts().getKeyStroke("editorInsertPrevMissingPlaceable");
+    private static final KeyStroke KEYSTROKE_INSERT_NBSP = PropertiesShortcuts.getEditorShortcuts()
+            .getKeyStroke("editorInsertNonBreakingSpace");
+    private static final KeyStroke KEYSTROKE_INSERT_TAG_PAIR = PropertiesShortcuts.getEditorShortcuts()
+            .getKeyStroke("editorInsertMissingTagPair");
+    private static final KeyStroke KEYSTROKE_MOVE_TOKEN_PREV = PropertiesShortcuts.getEditorShortcuts()
+            .getKeyStroke("editorMoveTokenPrev");
+    private static final KeyStroke KEYSTROKE_MOVE_TOKEN_NEXT = PropertiesShortcuts.getEditorShortcuts()
+            .getKeyStroke("editorMoveTokenNext");
 
     /** Undo Manager to store edits */
     protected final TranslationUndoManager undoManager = new TranslationUndoManager(this);
@@ -459,8 +487,10 @@ public class EditorTextArea3 extends JEditorPane {
             } catch (BadLocationException ex) {
                 // do nothing
             }
-        } else if (s.equals(KEYSTROKE_DELETE_NEXT_TOKEN)) {
-            // Delete next token
+        } else if (s.equals(KEYSTROKE_DELETE_NEXT_TOKEN)
+                || s.equals(KEYSTROKE_DELETE_NEXT_TOKEN_ALTERNATE)) {
+            // Delete next token; the alternate binding serves keyboards
+            // without a forward-delete key
             try {
                 processed = wholeTagDelete(true);
                 if (!processed) {
@@ -480,6 +510,30 @@ public class EditorTextArea3 extends JEditorPane {
             } catch (BadLocationException ex) {
                 // do nothing
             }
+        } else if (s.equals(KEYSTROKE_DELETE_TO_SEGMENT_START)) {
+            processed = deleteToSegmentBound(false);
+        } else if (s.equals(KEYSTROKE_DELETE_TO_SEGMENT_END)) {
+            processed = deleteToSegmentBound(true);
+        } else if (s.equals(KEYSTROKE_MOVE_TO_SEGMENT_START)) {
+            processed = moveToSegmentBound(false, false);
+        } else if (s.equals(KEYSTROKE_MOVE_TO_SEGMENT_END)) {
+            processed = moveToSegmentBound(true, false);
+        } else if (s.equals(KEYSTROKE_MOVE_TO_SEGMENT_START_SEL)) {
+            processed = moveToSegmentBound(false, true);
+        } else if (s.equals(KEYSTROKE_MOVE_TO_SEGMENT_END_SEL)) {
+            processed = moveToSegmentBound(true, true);
+        } else if (s.equals(KEYSTROKE_INSERT_NEXT_PLACEABLE)) {
+            processed = insertMissingPlaceable(true);
+        } else if (s.equals(KEYSTROKE_INSERT_PREV_PLACEABLE)) {
+            processed = insertMissingPlaceable(false);
+        } else if (s.equals(KEYSTROKE_INSERT_NBSP)) {
+            processed = insertNonBreakingSpace();
+        } else if (s.equals(KEYSTROKE_INSERT_TAG_PAIR)) {
+            processed = insertMissingTagPair();
+        } else if (s.equals(KEYSTROKE_MOVE_TOKEN_PREV)) {
+            processed = moveTokenAtCaret(false);
+        } else if (s.equals(KEYSTROKE_MOVE_TOKEN_NEXT)) {
+            processed = moveTokenAtCaret(true);
         } else if (s.equals(KEYSTROKE_FIRST_SEG)) {
             // Jump to beginning of document
             int segNum = controller.m_docSegList[0].segmentNumberInProject;
@@ -540,6 +594,243 @@ public class EditorTextArea3 extends JEditorPane {
             checkAndFixCaret(false);
             autoCompleter.updatePopup(true);
         }
+    }
+
+    /**
+     * Delete from the segment bound to the caret: everything before the
+     * caret ({@code toEnd} false) or everything after it ({@code toEnd}
+     * true), clamped to the editable range. A live selection is deleted
+     * instead, so a slipped modifier never wipes more than the visible
+     * selection. Always consumes the event, even as a no-op: the mac
+     * binding shadows a native Cocoa gesture, and letting the event fall
+     * through would put two semantics on one key.
+     */
+    private boolean deleteToSegmentBound(boolean toEnd) {
+        Document3 doc = getOmDocument();
+        if (doc == null || !doc.isEditMode()) {
+            return true;
+        }
+        int start = doc.getTranslationStart();
+        int end = doc.getTranslationEnd();
+        int selStart = getSelectionStart();
+        int selEnd = getSelectionEnd();
+        if (selStart != selEnd) {
+            selStart = Math.max(selStart, start);
+            selEnd = Math.min(selEnd, end);
+        } else {
+            int caret = getCaretPosition();
+            if (caret < start || caret > end) {
+                return true;
+            }
+            selStart = toEnd ? caret : start;
+            selEnd = toEnd ? end : caret;
+        }
+        if (selStart >= selEnd) {
+            return true;
+        }
+        int caretBefore = getCaretPosition();
+        int lengthBefore = getDocument().getLength();
+        int rangeStart = selStart;
+        int rangeEnd = selEnd;
+        // pause only the undo bookkeeping and record one snapshot with the
+        // caret position of the moment the shortcut fired: the automatic
+        // snapshot would stamp the end of the removed range, making an undo
+        // jump to the segment end instead of back to where the user was
+        undoManager.runAtomic(() -> {
+            setSelectionStart(rangeStart);
+            setSelectionEnd(rangeEnd);
+            replaceSelection("");
+        }, caretBefore - start);
+        if (getDocument().getLength() == lengthBefore) {
+            // the range touched a protected tag and the document filter
+            // rejected the removal: collapse the leftover selection so the
+            // editor does not sit on a dead, boundary-crossing selection
+            setCaretPosition(caretBefore);
+        }
+        autoCompleter.updatePopup(true);
+        return true;
+    }
+
+    /**
+     * Move the caret to the start or end of the editable range, optionally
+     * extending the selection. The document outside the active segment is
+     * not editable, so this is the segment-scoped reading of the native
+     * "to start/end of document" gestures.
+     */
+    private boolean moveToSegmentBound(boolean toEnd, boolean extendSelection) {
+        Document3 doc = getOmDocument();
+        if (doc == null || !doc.isEditMode()) {
+            return true;
+        }
+        int target = toEnd ? doc.getTranslationEnd() : doc.getTranslationStart();
+        if (extendSelection) {
+            moveCaretPosition(target);
+        } else {
+            setCaretPosition(target);
+        }
+        autoCompleter.updatePopup(true);
+        return true;
+    }
+
+    /**
+     * Insert the first (or last) placeable of the source text that is still
+     * missing from the translation: tags and other protected parts, URLs,
+     * e-mail addresses, numbers. The missing list is recomputed on every
+     * call, so pressing repeatedly works through it.
+     */
+    private boolean insertMissingPlaceable(boolean fromStart) {
+        Document3 doc = getOmDocument();
+        if (doc == null || !doc.isEditMode()) {
+            return true;
+        }
+        SourceTextEntry ste = doc.getController().getCurrentEntry();
+        String translation = doc.extractTranslation();
+        if (ste == null || translation == null) {
+            return true;
+        }
+        int start = doc.getTranslationStart();
+        int end = doc.getTranslationEnd();
+        int selStart = Math.max(getSelectionStart(), start);
+        int selEnd = Math.min(getSelectionEnd(), end);
+        if (selStart < selEnd) {
+            // the insertion replaces the selection, so its content must not
+            // count as present when computing what is missing
+            translation = translation.substring(0, selStart - start) + translation.substring(selEnd - start);
+        }
+        List<String> protectedTexts = protectedTexts(ste);
+        List<String> missing = SegmentEditingOps.missingPlaceables(ste.getSrcText(), translation,
+                protectedTexts);
+        if (missing.isEmpty()) {
+            return true;
+        }
+        String insertion = fromStart ? missing.get(0) : missing.get(missing.size() - 1);
+        // the canonical insert path wraps tags in bidi controls for RTL
+        // targets and fixes the caret before inserting
+        controller.insertText(insertion);
+        autoCompleter.updatePopup(true);
+        return true;
+    }
+
+    private static List<String> protectedTexts(SourceTextEntry ste) {
+        List<String> result = new ArrayList<>();
+        for (ProtectedPart pp : ste.getProtectedParts()) {
+            result.add(pp.getTextInSourceSegment());
+        }
+        return result;
+    }
+
+    /**
+     * Insert the first missing tag pair of the segment: around the selection
+     * when one exists, otherwise at the caret with the caret placed between
+     * the tags (SF-1302).
+     */
+    private boolean insertMissingTagPair() {
+        Document3 doc = getOmDocument();
+        if (doc == null || !doc.isEditMode() || doc.getController().getCurrentEntry() == null) {
+            return true;
+        }
+        String[] pair = SegmentEditingOps.firstMissingTagPair(TagUtil.getGroupedMissingTagsFromTarget(),
+                TagUtil.TAG_SEPARATOR_SENTINEL);
+        if (pair == null) {
+            return true;
+        }
+        int start = doc.getTranslationStart();
+        int end = doc.getTranslationEnd();
+        int selStart = Math.max(getSelectionStart(), start);
+        int selEnd = Math.min(getSelectionEnd(), end);
+        if (selStart < selEnd) {
+            // wrap the (clamped) selection: one insertText call keeps the
+            // bidi handling of the canonical path, runAtomic keeps the
+            // remove+insert pair a single undo step
+            int caretBefore = getCaretPosition();
+            String wrapped;
+            try {
+                wrapped = pair[0] + getDocument().getText(selStart, selEnd - selStart) + pair[1];
+            } catch (BadLocationException ex) {
+                return true;
+            }
+            select(selStart, selEnd);
+            undoManager.runAtomic(() -> controller.insertText(wrapped),
+                    Math.min(Math.max(caretBefore, start), end) - start);
+        } else {
+            if (getSelectionStart() != getSelectionEnd()) {
+                // selection lies entirely outside the editable range:
+                // collapse it so insertText cannot replace protected text
+                setCaretPosition(Math.min(Math.max(getCaretPosition(), start), end));
+            }
+            controller.insertText(pair[0] + pair[1]);
+            // land the caret between the tags; search backwards so any bidi
+            // controls the canonical path added around the tags are skipped
+            String translation = doc.extractTranslation();
+            if (translation != null) {
+                int posRel = translation.lastIndexOf(pair[1],
+                        Math.min(getCaretPosition() - start, translation.length()));
+                if (posRel >= 0) {
+                    setCaretPosition(start + posRel);
+                }
+            }
+        }
+        autoCompleter.updatePopup(true);
+        return true;
+    }
+
+    /** Insert a no-break space (U+00A0) at the caret. */
+    private boolean insertNonBreakingSpace() {
+        Document3 doc = getOmDocument();
+        if (doc == null || !doc.isEditMode()) {
+            return true;
+        }
+        controller.insertText("\u00A0");
+        autoCompleter.updatePopup(true);
+        return true;
+    }
+
+    /**
+     * Swap the token at the caret with its neighbour in logical order,
+     * keeping the caret on the moved token so repeated presses walk the
+     * token through the segment. One document mutation, one undo step.
+     */
+    private boolean moveTokenAtCaret(boolean forward) {
+        Document3 doc = getOmDocument();
+        if (doc == null || !doc.isEditMode()) {
+            return true;
+        }
+        int start = doc.getTranslationStart();
+        int end = doc.getTranslationEnd();
+        int caret = getCaretPosition();
+        if (caret < start || caret > end) {
+            return true;
+        }
+        String translation = doc.extractTranslation();
+        SourceTextEntry ste = doc.getController().getCurrentEntry();
+        if (translation == null || ste == null) {
+            return true;
+        }
+        Locale locale = targetLocale != null ? targetLocale : Locale.getDefault();
+        SegmentEditingOps.TokenSwap swap = SegmentEditingOps.computeTokenSwap(translation, caret - start,
+                forward, locale, protectedTexts(ste));
+        if (swap == null) {
+            return true;
+        }
+        // the swap replaces a non-empty region with non-empty text, which
+        // the undo manager would record as two snapshots (remove + insert);
+        // run it atomically with the pre-swap caret, so an undo returns the
+        // caret to where the user was, not to the moved token
+        undoManager.runAtomic(() -> {
+            setSelectionStart(start + swap.regionStart);
+            setSelectionEnd(start + swap.regionEnd);
+            replaceSelection(swap.replacement);
+        }, caret - start);
+        if (swap.replacement.equals(doc.extractTranslation().substring(swap.regionStart,
+                swap.regionStart + swap.replacement.length()))) {
+            setCaretPosition(start + swap.caretAfter);
+        } else {
+            // the document filter rejected the replacement (tag protection):
+            // collapse the leftover selection back to the original caret
+            setCaretPosition(caret);
+        }
+        autoCompleter.updatePopup(true);
+        return true;
     }
 
     private void updateLockInsertMessage() {
@@ -928,7 +1219,7 @@ public class EditorTextArea3 extends JEditorPane {
         if (isEditable() && omDocument != null && overtypeMode && getSelectionStart() == getSelectionEnd()
                 && getCaretPosition() < omDocument.getTranslationEnd()) {
             int pos = getCaretPosition();
-            int lastPos = Math.min(getDocument().getLength(), pos + content.length());
+            int lastPos = Math.min(omDocument.getTranslationEnd(), pos + content.length());
             select(pos, lastPos);
         }
         super.replaceSelection(content);

--- a/src/main/java/org/omegat/gui/editor/SegmentEditingOps.java
+++ b/src/main/java/org/omegat/gui/editor/SegmentEditingOps.java
@@ -1,0 +1,279 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor;
+
+import java.text.BreakIterator;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jspecify.annotations.Nullable;
+import org.omegat.util.PatternConsts;
+
+/**
+ * Pure text computations behind the accelerating editing shortcuts: the
+ * placeable cycle and the token swap. Kept free of any Swing or document
+ * state so the semantics stay unit-testable and rebuild-safe: callers
+ * recompute on every invocation instead of holding positions across
+ * segment rebuilds.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class SegmentEditingOps {
+
+    /**
+     * Untranslatables recognised in plain text, tried in this order; earlier
+     * matches shadow later ones on overlap (a number inside a URL is not a
+     * separate placeable). Deliberately simple: false negatives only make
+     * the cycle skip a candidate, never corrupt text.
+     */
+    private static final Pattern[] PLACEABLE_PATTERNS = { PatternConsts.OMEGAT_TAG,
+            Pattern.compile("(?:https?|ftp)://[^\\s<>\"]+"),
+            Pattern.compile("[\\w.+-]+@[\\w-]+(?:\\.[\\w-]+)+"),
+            Pattern.compile("\\d+(?:[.,]\\d+)*"), };
+
+    private SegmentEditingOps() {
+    }
+
+    /**
+     * The placeables of the source text in source order, one entry per
+     * occurrence: protected parts (tags, custom patterns) first at their
+     * positions, then URLs, e-mail addresses and numbers found by pattern,
+     * skipping matches that overlap an already claimed span.
+     *
+     * @param source
+     *            source segment text
+     * @param protectedTexts
+     *            the source-text forms of the segment's protected parts
+     */
+    public static List<String> extractPlaceables(String source, List<String> protectedTexts) {
+        List<int[]> spans = occurrenceSpans(source, protectedTexts);
+        for (Pattern p : PLACEABLE_PATTERNS) {
+            Matcher m = p.matcher(source);
+            while (m.find()) {
+                addIfFree(spans, m.start(), m.end());
+            }
+        }
+        spans.sort((a, b) -> Integer.compare(a[0], b[0]));
+        List<String> result = new ArrayList<>(spans.size());
+        for (int[] span : spans) {
+            result.add(source.substring(span[0], span[1]));
+        }
+        return result;
+    }
+
+    /**
+     * All non-overlapping occurrences of the given texts as {@code [start,
+     * end)} spans, earlier texts claiming their spans first. Null or empty
+     * entries are skipped: filters may deliver protected parts without a
+     * source-text form.
+     */
+    private static List<int[]> occurrenceSpans(String text, List<String> texts) {
+        List<int[]> spans = new ArrayList<>();
+        for (String t : texts) {
+            if (t == null || t.isEmpty()) {
+                continue;
+            }
+            int from = 0;
+            int at;
+            while ((at = text.indexOf(t, from)) >= 0) {
+                addIfFree(spans, at, at + t.length());
+                from = at + t.length();
+            }
+        }
+        return spans;
+    }
+
+    private static void addIfFree(List<int[]> spans, int start, int end) {
+        for (int[] span : spans) {
+            if (start < span[1] && end > span[0]) {
+                return;
+            }
+        }
+        spans.add(new int[] { start, end });
+    }
+
+    /**
+     * The source placeables not yet present in the target, in source order,
+     * counting occurrences: a placeable appearing twice in the source and
+     * once in the target is reported missing once. Recomputed from scratch
+     * on every call, so inserting the head of the list and calling again
+     * naturally works through the list.
+     */
+    public static List<String> missingPlaceables(String source, String target,
+            List<String> protectedTexts) {
+        List<String> ordered = extractPlaceables(source, protectedTexts);
+        Map<String, Integer> remaining = new HashMap<>();
+        for (String p : ordered) {
+            remaining.computeIfAbsent(p, key -> countOccurrences(target, key));
+        }
+        List<String> missing = new ArrayList<>();
+        for (String p : ordered) {
+            int r = remaining.get(p);
+            if (r > 0) {
+                remaining.put(p, r - 1);
+            } else {
+                missing.add(p);
+            }
+        }
+        return missing;
+    }
+
+    private static int countOccurrences(String text, String needle) {
+        int count = 0;
+        int from = 0;
+        int at;
+        while ((at = text.indexOf(needle, from)) >= 0) {
+            count++;
+            from = at + needle.length();
+        }
+        return count;
+    }
+
+    /**
+     * The first tag pair among the grouped missing-tag offerings of
+     * {@code TagUtil.getGroupedMissingTagsFromTarget()}: pair entries carry
+     * the separator sentinel between opening and closing tag. Returns
+     * {@code [open, close]}, or null when no pair is on offer.
+     */
+    public static String @Nullable [] firstMissingTagPair(List<String> groupedMissingTags,
+            String separatorSentinel) {
+        for (String entry : groupedMissingTags) {
+            int sep = entry.indexOf(separatorSentinel);
+            if (sep >= 0) {
+                return new String[] { entry.substring(0, sep),
+                        entry.substring(sep + separatorSentinel.length()) };
+            }
+        }
+        return null;
+    }
+
+    /** Result of {@link #computeTokenSwap}: one region, one replacement. */
+    public static final class TokenSwap {
+        /** Start of the region to replace, in text coordinates. */
+        public final int regionStart;
+        /** End (exclusive) of the region to replace. */
+        public final int regionEnd;
+        /** The swapped text for the region. */
+        public final String replacement;
+        /** Caret position after the swap, keeping it inside the moved token. */
+        public final int caretAfter;
+
+        TokenSwap(int regionStart, int regionEnd, String replacement, int caretAfter) {
+            this.regionStart = regionStart;
+            this.regionEnd = regionEnd;
+            this.replacement = replacement;
+            this.caretAfter = caretAfter;
+        }
+    }
+
+    /**
+     * Swap the token at the caret with its neighbour, as a single
+     * replacement over the covering region so the caller can apply it with
+     * one document mutation (one undo step). The separator between the
+     * tokens is preserved. Protected parts (tags, placeholders) count as
+     * atomic tokens: a swap moves a whole tag or hops over it, but never
+     * splits it. Null when the caret is not on a token or there is no
+     * neighbour in the requested direction.
+     *
+     * @param text
+     *            the editable text (translation only)
+     * @param caret
+     *            caret offset within {@code text}
+     * @param forward
+     *            true to swap with the following token, false the preceding
+     * @param locale
+     *            target-language locale for word breaking
+     * @param atomicTexts
+     *            texts treated as indivisible tokens wherever they occur
+     */
+    public static @Nullable TokenSwap computeTokenSwap(String text, int caret, boolean forward,
+            Locale locale, List<String> atomicTexts) {
+        List<int[]> tokens = tokenize(text, locale, atomicTexts);
+        int idx = -1;
+        for (int i = 0; i < tokens.size(); i++) {
+            if (caret >= tokens.get(i)[0] && caret <= tokens.get(i)[1]) {
+                idx = i;
+                break;
+            }
+        }
+        if (idx < 0) {
+            return null;
+        }
+        int otherIdx = forward ? idx + 1 : idx - 1;
+        if (otherIdx < 0 || otherIdx >= tokens.size()) {
+            return null;
+        }
+        int[] first = tokens.get(Math.min(idx, otherIdx));
+        int[] second = tokens.get(Math.max(idx, otherIdx));
+        String firstText = text.substring(first[0], first[1]);
+        String gap = text.substring(first[1], second[0]);
+        String secondText = text.substring(second[0], second[1]);
+        int caretInToken = caret - tokens.get(idx)[0];
+        int caretAfter;
+        if (forward) {
+            caretAfter = first[0] + secondText.length() + gap.length() + caretInToken;
+        } else {
+            caretAfter = first[0] + caretInToken;
+        }
+        return new TokenSwap(first[0], second[1], secondText + gap + firstText, caretAfter);
+    }
+
+    /**
+     * Word tokens (runs containing at least one letter or digit) as
+     * {@code [start, end)} pairs via the locale's word BreakIterator, plus
+     * the occurrences of the atomic texts as indivisible tokens; word
+     * tokens intersecting an atomic span are dropped in its favour.
+     */
+    private static List<int[]> tokenize(String text, Locale locale, List<String> atomicTexts) {
+        List<int[]> tokens = new ArrayList<>(occurrenceSpans(text, atomicTexts));
+        List<int[]> atomicSpans = new ArrayList<>(tokens);
+        BreakIterator bi = BreakIterator.getWordInstance(locale);
+        bi.setText(text);
+        int start = bi.first();
+        for (int end = bi.next(); end != BreakIterator.DONE; start = end, end = bi.next()) {
+            if (text.substring(start, end).codePoints().anyMatch(Character::isLetterOrDigit)
+                    && !intersectsAny(atomicSpans, start, end)) {
+                tokens.add(new int[] { start, end });
+            }
+        }
+        tokens.sort((a, b) -> Integer.compare(a[0], b[0]));
+        return tokens;
+    }
+
+    private static boolean intersectsAny(List<int[]> spans, int start, int end) {
+        for (int[] span : spans) {
+            if (start < span[1] && end > span[0]) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/omegat/gui/editor/TranslationUndoManager.java
+++ b/src/main/java/org/omegat/gui/editor/TranslationUndoManager.java
@@ -127,6 +127,30 @@ public class TranslationUndoManager implements UndoableEditListener {
     }
 
     /**
+     * Run a mutation whose document events shall form a single undo step,
+     * then remember the result once. Unlike the document's trusted-changes
+     * flag this pauses only the undo bookkeeping: the document filter and
+     * the text-change notifications stay fully active.
+     *
+     * @param mutation
+     *            the document mutation to run
+     * @param caretPos
+     *            caret position, relative to the translation start, that an
+     *            undo of this mutation shall restore
+     */
+    void runAtomic(Runnable mutation, int caretPos) {
+        UIThreadsUtil.mustBeSwingThread();
+
+        inProgress = true;
+        try {
+            mutation.run();
+        } finally {
+            inProgress = false;
+        }
+        remember(caretPos);
+    }
+
+    /**
      * Remember change.
      */
     public void remember(int caretPos) {

--- a/src/main/resources/org/omegat/gui/main/EditorShortcuts.mac.properties
+++ b/src/main/resources/org/omegat/gui/main/EditorShortcuts.mac.properties
@@ -17,6 +17,19 @@ editorSkipNextTokenWithSelection=alt shift RIGHT
 editorSkipPrevTokenWithSelection=alt shift LEFT
 editorToggleCursorLock=F2
 editorToggleOvertype=F3
+editorDeleteToSegmentStart=meta BACK_SPACE
+editorDeleteToSegmentEnd=meta shift BACK_SPACE
+editorDeleteNextTokenAlternate=alt shift BACK_SPACE
+editorMoveToSegmentStart=meta UP
+editorMoveToSegmentEnd=meta DOWN
+editorMoveToSegmentStartWithSelection=meta shift UP
+editorMoveToSegmentEndWithSelection=meta shift DOWN
+editorInsertNextMissingPlaceable=ctrl COMMA
+editorInsertPrevMissingPlaceable=ctrl shift COMMA
+editorInsertMissingTagPair=ctrl PERIOD
+editorInsertNonBreakingSpace=ctrl shift SPACE
+editorMoveTokenPrev=meta alt LEFT
+editorMoveTokenNext=meta alt RIGHT
 
 ## Autocompleter ##
 autocompleterTrigger=ESCAPE

--- a/src/main/resources/org/omegat/gui/main/EditorShortcuts.properties
+++ b/src/main/resources/org/omegat/gui/main/EditorShortcuts.properties
@@ -16,6 +16,19 @@ editorSkipNextTokenWithSelection=ctrl shift RIGHT
 editorSkipPrevTokenWithSelection=ctrl shift LEFT
 editorToggleCursorLock=F2
 editorToggleOvertype=INSERT
+editorDeleteToSegmentStart=ctrl shift BACK_SPACE
+editorDeleteToSegmentEnd=ctrl shift DELETE
+editorDeleteNextTokenAlternate=alt shift BACK_SPACE
+editorMoveToSegmentStart=ctrl HOME
+editorMoveToSegmentEnd=ctrl END
+editorMoveToSegmentStartWithSelection=ctrl shift HOME
+editorMoveToSegmentEndWithSelection=ctrl shift END
+editorInsertNextMissingPlaceable=ctrl COMMA
+editorInsertPrevMissingPlaceable=ctrl shift COMMA
+editorInsertMissingTagPair=ctrl PERIOD
+editorInsertNonBreakingSpace=ctrl shift SPACE
+editorMoveTokenPrev=ctrl alt LEFT
+editorMoveTokenNext=ctrl alt RIGHT
 
 ## Autocompleter ##
 autocompleterTrigger=ctrl SPACE

--- a/src/test/java/org/omegat/gui/editor/SegmentEditingOpsTest.java
+++ b/src/test/java/org/omegat/gui/editor/SegmentEditingOpsTest.java
@@ -1,0 +1,220 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.editor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Test;
+
+import org.omegat.gui.editor.SegmentEditingOps.TokenSwap;
+
+/**
+ * Tests for the pure text computations behind the editing shortcuts.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class SegmentEditingOpsTest {
+
+    private static final List<String> NO_PROTECTED = Collections.emptyList();
+
+    @Test
+    public void testPlaceablesComeInSourceOrder() {
+        List<String> found = SegmentEditingOps.extractPlaceables(
+                "Send 12 units to sales@example.com via https://example.com/track?id=9 by 2026", NO_PROTECTED);
+        assertEquals(Arrays.asList("12", "sales@example.com", "https://example.com/track?id=9", "2026"),
+                found);
+    }
+
+    @Test
+    public void testProtectedPartsShadowPatternMatches() {
+        // the number inside the protected placeholder must not surface as a
+        // second, separate placeable
+        List<String> found = SegmentEditingOps.extractPlaceables("Order %1 of 5 pieces",
+                Collections.singletonList("%1"));
+        assertEquals(Arrays.asList("%1", "5"), found);
+    }
+
+    @Test
+    public void testNumberInsideUrlIsNotASeparatePlaceable() {
+        List<String> found = SegmentEditingOps.extractPlaceables("See https://host/path/42 now",
+                NO_PROTECTED);
+        assertEquals(Collections.singletonList("https://host/path/42"), found);
+    }
+
+    @Test
+    public void testMissingPlaceablesCountOccurrences() {
+        // "7" appears twice in the source but only once in the target: it is
+        // missing exactly once, and earlier source occurrences claim the
+        // target occurrences first
+        List<String> missing = SegmentEditingOps.missingPlaceables("7 of 7 by 12", "7 Stück", NO_PROTECTED);
+        assertEquals(Arrays.asList("7", "12"), missing);
+    }
+
+    @Test
+    public void testWorkingThroughTheMissingListConverges() {
+        String source = "<t0>5</t0> kg";
+        List<String> protectedTexts = Arrays.asList("<t0>", "</t0>");
+        String target = "";
+        for (int i = 0; i < 4; i++) {
+            List<String> missing = SegmentEditingOps.missingPlaceables(source, target, protectedTexts);
+            if (missing.isEmpty()) {
+                break;
+            }
+            target += missing.get(0);
+        }
+        assertEquals("<t0>5</t0>",
+                target);
+        assertTrue(SegmentEditingOps.missingPlaceables(source, target, protectedTexts).isEmpty());
+    }
+
+    @Test
+    public void testTokenSwapForwardKeepsSeparatorAndCaret() {
+        // caret inside "quick"; swapping forward moves it past "brown",
+        // separator ", " stays where it was
+        String text = "quick, brown fox";
+        TokenSwap swap = SegmentEditingOps.computeTokenSwap(text, 2, true, Locale.ENGLISH, NO_PROTECTED);
+        assertNotNull(swap);
+        assertEquals(0, swap.regionStart);
+        assertEquals("quick, brown".length(), swap.regionEnd);
+        assertEquals("brown, quick", swap.replacement);
+        // caret stays at offset 2 inside the moved token "quick"
+        assertEquals("brown, ".length() + 2, swap.caretAfter);
+    }
+
+    @Test
+    public void testTokenSwapBackwardMovesTokenToFront() {
+        String text = "quick brown";
+        int caretInBrown = "quick b".length();
+        TokenSwap swap = SegmentEditingOps.computeTokenSwap(text, caretInBrown, false, Locale.ENGLISH, NO_PROTECTED);
+        assertNotNull(swap);
+        assertEquals("brown quick", swap.replacement);
+        // caret keeps its offset inside "brown", which now starts the text
+        assertEquals(1, swap.caretAfter);
+    }
+
+    @Test
+    public void testTokenSwapAtEdgesIsRefused() {
+        String text = "one two";
+        assertNull(SegmentEditingOps.computeTokenSwap(text, 1, false, Locale.ENGLISH, NO_PROTECTED));
+        assertNull(SegmentEditingOps.computeTokenSwap(text, text.length(), true, Locale.ENGLISH, NO_PROTECTED));
+    }
+
+    @Test
+    public void testTokenSwapTreatsTagsAsAtomicTokens() {
+        // swapping "foo" forward moves it over the whole tag instead of
+        // splitting the tag into pieces
+        String text = "foo <t0> bar";
+        TokenSwap swap = SegmentEditingOps.computeTokenSwap(text, 1, true, Locale.ENGLISH,
+                Collections.singletonList("<t0>"));
+        assertNotNull(swap);
+        assertEquals("<t0> foo", swap.replacement);
+        assertEquals(0, swap.regionStart);
+        assertEquals("foo <t0>".length(), swap.regionEnd);
+        // caret keeps its offset inside "foo", which now follows the tag
+        assertEquals("<t0> ".length() + 1, swap.caretAfter);
+    }
+
+    @Test
+    public void testTokenSwapFromInsideTagMovesTheTag() {
+        String text = "foo <t0> bar";
+        TokenSwap swap = SegmentEditingOps.computeTokenSwap(text, 6, false, Locale.ENGLISH,
+                Collections.singletonList("<t0>"));
+        assertNotNull(swap);
+        assertEquals("<t0> foo", swap.replacement);
+    }
+
+    @Test
+    public void testNullProtectedTextsAreIgnored() {
+        List<String> found = SegmentEditingOps.extractPlaceables("Order 5 pieces",
+                Arrays.asList(null, "", "5"));
+        assertEquals(Collections.singletonList("5"), found);
+    }
+
+    @Test
+    public void testEmailInsideUrlIsNotASeparatePlaceable() {
+        List<String> found = SegmentEditingOps.extractPlaceables("See https://user@host.example/x now",
+                NO_PROTECTED);
+        assertEquals(Collections.singletonList("https://user@host.example/x"), found);
+    }
+
+    @Test
+    public void testNumberInsideWordIsAPlaceable() {
+        // documented simple semantics: digits in mixed tokens still count,
+        // consistently on both the source and the target side
+        assertTrue(SegmentEditingOps.missingPlaceables("Bond007", "Bond007", NO_PROTECTED).isEmpty());
+        assertEquals(Collections.singletonList("007"),
+                SegmentEditingOps.missingPlaceables("Bond007", "", NO_PROTECTED));
+    }
+
+    @Test
+    public void testWorkingThroughTheMissingListBackwards() {
+        String source = "1 a 2 b 3";
+        String target = "";
+        for (int i = 0; i < 4; i++) {
+            List<String> missing = SegmentEditingOps.missingPlaceables(source, target, NO_PROTECTED);
+            if (missing.isEmpty()) {
+                break;
+            }
+            target = missing.get(missing.size() - 1) + target;
+        }
+        assertEquals("123", target);
+    }
+
+    @Test
+    public void testCaretOnTokenBoundaryBelongsToTheLeftToken() {
+        // caret exactly between "one" and the space: the left token moves
+        TokenSwap swap = SegmentEditingOps.computeTokenSwap("one two", 3, true, Locale.ENGLISH,
+                NO_PROTECTED);
+        assertNotNull(swap);
+        assertEquals("two one", swap.replacement);
+    }
+
+    @Test
+    public void testFirstMissingTagPairPicksThePairEntry() {
+        // grouped offerings mix single tags and pair entries; only entries
+        // carrying the sentinel are pairs
+        String[] pair = SegmentEditingOps.firstMissingTagPair(
+                Arrays.asList("<t0>", "<t0>\uE100</t0>", "</t0>"), "\uE100");
+        assertNotNull(pair);
+        assertEquals("<t0>", pair[0]);
+        assertEquals("</t0>", pair[1]);
+        assertNull(SegmentEditingOps.firstMissingTagPair(Arrays.asList("<t0>", "</t0>"), "\uE100"));
+    }
+
+    @Test
+    public void testTokenSwapOffTokenIsRefused() {
+        // caret in the separator between the tokens: no token to move
+        assertNull(SegmentEditingOps.computeTokenSwap("one  two", 4, true, Locale.ENGLISH, NO_PROTECTED));
+    }
+}


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Additional editing functions based on Readline shortcuts
  * https://sourceforge.net/p/omegat/feature-requests/536/

- Placeables auto-completer view (partially)
  * https://sourceforge.net/p/omegat/feature-requests/1266/

- Shortcut for inserting "tag pairs" (partially)
  * https://sourceforge.net/p/omegat/feature-requests/1302/

## What does this PR change?

- New editor shortcuts, each user-adjustable via `EditorShortcuts.properties` in config dir: delete to segment start/end, forward word delete without Forward-Delete key, caret/selection to segment bounds, cycle through source placeables (numbers, tags, URLs, e-mails) missing from target, no-break space, first missing tag pair (around selection if any), move word at caret over neighbours.
- Range deletes and word move clamp to editable range, respect tag protection and form single undo steps via new `TranslationUndoManager.runAtomic` — undo restores text and caret position.
- Pure text computations live in new, unit-tested `SegmentEditingOps`; tag-pair offerings reuse `TagUtil.getGroupedMissingTagsFromTarget`.
- Tip of the day (en+de) documents shortcuts, separate commit.

Notes: `ctrl+shift+SPACE` on non-mac platforms yields to open auto-completer popup; on Linux `ctrl+PERIOD` may be taken by IBus emoji hotkey and `ctrl+alt+arrows` by desktop workspace switching — remappable per user config.

## Other information

Tip of the day text:

> **Faster editing**
> Extra editing shortcuts (macOS in parentheses):
> - Delete everything left or right of cursor: Ctrl+Shift+Backspace / Ctrl+Shift+Delete (Cmd+Backspace / Cmd+Shift+Backspace)
> - Delete next word, no Forward-Delete key needed: Alt+Shift+Backspace
> - Jump to segment start or end, Shift selects: Ctrl+Home / Ctrl+End (Cmd+Up / Cmd+Down)
> - Insert next number, tag or URL still missing from translation: Ctrl+Comma; last one: Ctrl+Shift+Comma
> - Insert non-breaking space: Ctrl+Shift+Space
> - Insert first missing tag pair, around selection if any: Ctrl+Period
> - Move word at cursor left or right: Ctrl+Alt+Left / Ctrl+Alt+Right (Cmd+Alt+Left / Cmd+Alt+Right)
