### PR TITLE
[6.1]fix(team): repositories mapping cancel

### DIFF
--- a/src/org/omegat/Bundle.properties
+++ b/src/org/omegat/Bundle.properties
@@ -944,6 +944,8 @@ RMD_INVALID_REPO_TYPE=Invalid repository type: {0}
 RMD_INVALID_DUPLICATE_REPO=Repository {0} is already present
 RMD_INVALID_UNKNOWN_REPO=Repository {0} unknown
 RMD_INVALID_BLANK_REPO=Empty repository URL in the mapping
+RMD_INVALID_DUPLICATE_MAPPING=More than one mapping for local folder ''{0}''
+TEAM_DUPLICATE_MAPPING_IGNORED=Ignored duplicate repository mapping local=''{0}'' repository=''{1}'' of repository {2}
 RMD_TABLE_REPO_TYPE_GIT=Git
 RMD_TABLE_REPO_TYPE_SVN=Subversion
 RMD_TABLE_REPO_TYPE_HTTP=HTTP(S)

--- a/src/org/omegat/Bundle_de.properties
+++ b/src/org/omegat/Bundle_de.properties
@@ -821,6 +821,8 @@ RMD_INVALID_REPO_TYPE=Ung\u00FCltiger Repository-Typ: {0}
 RMD_INVALID_DUPLICATE_REPO=Repository {0} existiert bereits
 RMD_INVALID_UNKNOWN_REPO=Repository {0} unbekannt
 RMD_INVALID_BLANK_REPO=Leere Repository-URL in der Zuordnung
+RMD_INVALID_DUPLICATE_MAPPING=Mehrere Zuordnungen f\u00fcr den lokalen Ordner ''{0}''
+TEAM_DUPLICATE_MAPPING_IGNORED=Doppelte Repository-Zuordnung local=''{0}'' repository=''{1}'' von Repository {2} wurde ignoriert
 RMD_TABLE_REPO_TYPE_GIT=Git
 RMD_TABLE_REPO_TYPE_SVN=Subversion
 RMD_TABLE_REPO_TYPE_HTTP=HTTP(S)

--- a/src/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -31,6 +31,8 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -129,6 +131,27 @@ public class RemoteRepositoryProvider {
                 if (m.getLocal() == null || m.getRepository() == null) {
                     throw new IllegalArgumentException("Invalid mapping: local and/or remote is not set.");
                 }
+            }
+            dropDuplicateMappings(r);
+        }
+    }
+
+    /**
+     * Drop mapping entries that duplicate an earlier entry of the same
+     * repository. Exact duplicates carry no information but make every file
+     * under them match more than one mapping, and oneMapping() then refuses
+     * to load the project. Mappings that differ only in leading or trailing
+     * slashes address the same folders and count as duplicates.
+     */
+    static void dropDuplicateMappings(RepositoryDefinition repo) {
+        Set<String> seen = new HashSet<>();
+        for (Iterator<RepositoryMapping> it = repo.getMapping().iterator(); it.hasNext();) {
+            RepositoryMapping m = it.next();
+            String key = withoutSlashes(m.getLocal()) + ' ' + withoutSlashes(m.getRepository());
+            if (!seen.add(key)) {
+                Log.logWarningRB("TEAM_DUPLICATE_MAPPING_IGNORED", m.getLocal(), m.getRepository(),
+                        repo.getUrl());
+                it.remove();
             }
         }
     }

--- a/src/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
+++ b/src/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
@@ -34,6 +34,8 @@ package org.omegat.gui.dialogs;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,6 +78,12 @@ public class ProjectPropertiesDialogController {
     /** Project ExternalFinder config */
     private ExternalFinderConfiguration externalFinderConfig;
 
+    /**
+     * Project team repositories mapping. Buffered like the SRX and filter
+     * settings, so edits reach the live project properties on OK only.
+     */
+    private List<RepositoryDefinition> repositories;
+
     private final List<String> srcExcludes = new ArrayList<>();
 
     /**
@@ -93,6 +101,7 @@ public class ProjectPropertiesDialogController {
         this.projectProperties = projectProperties;
         this.srx = projectProperties.getProjectSRX();
         this.filters = projectProperties.getProjectFilters();
+        this.repositories = projectProperties.getRepositories();
         srcExcludes.addAll(projectProperties.getSourceRootExcludes());
         externalFinderConfig = ExternalFinder.getProjectConfig();
         initFromProperties();
@@ -140,6 +149,15 @@ public class ProjectPropertiesDialogController {
                 doCancel();
             }
         });
+        // The window close button must count as Cancel; without this it
+        // leaves dialogCancelled at its initial false and getResult()
+        // reports the properties as confirmed.
+        dialog.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                doCancel();
+            }
+        });
 
         // Configure locale actions and initialize
         ActionListener sourceLocaleListener = e -> {
@@ -174,9 +192,9 @@ public class ProjectPropertiesDialogController {
 
         dialog.repositoriesButton.addActionListener(e -> {
             RepositoriesMappingDialog rmd = new RepositoriesMappingDialog(parent, true);
-            List<RepositoryDefinition> r = rmd.show(projectProperties.getRepositories());
+            List<RepositoryDefinition> r = rmd.show(repositories);
             if (r != null) {
-                projectProperties.setRepositories(r);
+                repositories = r;
             }
         });
         dialog.externalFinderButton.addActionListener(e -> {
@@ -566,6 +584,7 @@ public class ProjectPropertiesDialogController {
 
         projectProperties.setProjectSRX(srx);
         projectProperties.setProjectFilters(filters);
+        projectProperties.setRepositories(repositories);
         projectProperties.getSourceRootExcludes().clear();
         projectProperties.getSourceRootExcludes().addAll(srcExcludes);
 

--- a/src/org/omegat/gui/dialogs/RepositoriesMappingDialog.java
+++ b/src/org/omegat/gui/dialogs/RepositoriesMappingDialog.java
@@ -51,8 +51,10 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public class RepositoriesMappingDialog extends JDialog {
-    private JButton cancelButton;
-    private JButton okButton;
+    JButton cancelButton;
+    JButton okButton;
+
+    List<RepositoryDefinition> result;
 
     /**
      * Creates new form RepositoriesMappingDialog
@@ -67,6 +69,20 @@ public class RepositoriesMappingDialog extends JDialog {
      * Show the dialog and return the resulting repositories definitions, or null if cancelled.
      */
     public List<RepositoryDefinition> show(List<RepositoryDefinition> input) {
+        result = null;
+        init(input);
+        setVisible(true);
+        dispose();
+        return result;
+    }
+
+    /**
+     * Bind panel and controller and register the button actions. The result
+     * is captured on a successful OK only, so every other way of leaving the
+     * dialog (Cancel, Escape, window close) discards the table state instead
+     * of applying it.
+     */
+    void init(List<RepositoryDefinition> input) {
         RepositoriesMappingPanel panel = new RepositoriesMappingPanel();
         add(panel, BorderLayout.CENTER);
         // Core controller binds logic to the panel
@@ -80,16 +96,13 @@ public class RepositoriesMappingDialog extends JDialog {
                 JOptionPane.showMessageDialog(panel, err, OStrings.getString("TF_ERROR"), JOptionPane.ERROR_MESSAGE);
                 return;
             }
+            result = controller.getResult();
             setVisible(false);
         });
         cancelButton.addActionListener(e -> {
             controller.onCancel();
             setVisible(false);
         });
-
-        setVisible(true);
-        dispose();
-        return controller.getResult();
     }
 
     private void initComponents() {

--- a/src/org/omegat/gui/repositoriesmapping/RepositoriesMappingController.java
+++ b/src/org/omegat/gui/repositoriesmapping/RepositoriesMappingController.java
@@ -443,10 +443,13 @@ public class RepositoriesMappingController {
     }
 
     /**
-     * Result after ok. In embedded use, if onOk() hasn't been called, returns current data snapshot.
+     * Result after a successful onOk(), otherwise null. Embedded users that
+     * want the current table state regardless of confirmation call getData()
+     * explicitly; returning the snapshot from here let a cancelled dialog
+     * apply its table edits anyway.
      */
     public List<RepositoryDefinition> getResult() {
-        return result != null ? result : getData();
+        return result;
     }
 
     String normalizeMapping(String mapping) {

--- a/src/org/omegat/gui/repositoriesmapping/RepositoriesMappingController.java
+++ b/src/org/omegat/gui/repositoriesmapping/RepositoriesMappingController.java
@@ -385,12 +385,22 @@ public class RepositoriesMappingController {
                 return MessageFormat.format(OStrings.getString("RMD_INVALID_DUPLICATE_REPO"), r.url);
             }
         }
+        Set<String> locals = new TreeSet<String>();
         for (RowMapping r : listMapping) {
             if (StringUtil.isEmpty(r.repoUrl)) {
                 return OStrings.getString("RMD_INVALID_BLANK_REPO");
             }
             if (!urls.contains(r.repoUrl)) {
                 return MessageFormat.format(OStrings.getString("RMD_INVALID_UNKNOWN_REPO"), r.repoUrl);
+            }
+            // Two mappings onto the same local folder make every file under
+            // it match more than one mapping, and the project then refuses
+            // to load with "Multiple mappings for file". Leading and
+            // trailing slashes address the same folder, like in the
+            // repository provider's path matching.
+            if (!locals.add(normalizeMapping(r.local).replaceAll("^/+|/+$", ""))) {
+                return MessageFormat.format(OStrings.getString("RMD_INVALID_DUPLICATE_MAPPING"),
+                        normalizeMapping(r.local));
             }
         }
         return null;

--- a/test/src/org/omegat/core/team2/RemoteRepositoryProviderMappingsTest.java
+++ b/test/src/org/omegat/core/team2/RemoteRepositoryProviderMappingsTest.java
@@ -1,0 +1,81 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * A repository definition with duplicated mapping entries used to make the
+ * project unloadable: every file under the duplicated folder matched more
+ * than one mapping and oneMapping() threw. Duplicates carry no information,
+ * so loading drops them instead.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class RemoteRepositoryProviderMappingsTest {
+
+    private static RepositoryDefinition repoWithMappings(String... localRepositoryPairs) {
+        RepositoryDefinition repo = new RepositoryDefinition();
+        repo.setType("git");
+        repo.setUrl("https://example.com/team-project.git");
+        for (int i = 0; i < localRepositoryPairs.length; i += 2) {
+            RepositoryMapping mapping = new RepositoryMapping();
+            mapping.setLocal(localRepositoryPairs[i]);
+            mapping.setRepository(localRepositoryPairs[i + 1]);
+            repo.getMapping().add(mapping);
+        }
+        return repo;
+    }
+
+    @Test
+    public void testExactDuplicateIsDropped() {
+        RepositoryDefinition repo = repoWithMappings("/", "/", "/", "/");
+        RemoteRepositoryProvider.dropDuplicateMappings(repo);
+        assertEquals(1, repo.getMapping().size());
+    }
+
+    @Test
+    public void testSlashVariantsCountAsDuplicates() {
+        // the root mapping is written as ""/"" by team checkouts and as
+        // "/"/"/" by the mapping dialog
+        RepositoryDefinition repo = repoWithMappings("", "", "/", "/");
+        RemoteRepositoryProvider.dropDuplicateMappings(repo);
+        assertEquals(1, repo.getMapping().size());
+        assertEquals("the first entry must survive", "", repo.getMapping().get(0).getLocal());
+    }
+
+    @Test
+    public void testDistinctMappingsAreKept() {
+        RepositoryDefinition repo = repoWithMappings("/", "/", "/glossary", "/shared/glossary");
+        RemoteRepositoryProvider.dropDuplicateMappings(repo);
+        assertEquals(2, repo.getMapping().size());
+    }
+}

--- a/test/src/org/omegat/gui/dialogs/RepositoriesMappingDialogTest.java
+++ b/test/src/org/omegat/gui/dialogs/RepositoriesMappingDialogTest.java
@@ -1,0 +1,111 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.dialogs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.event.WindowEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Leaving the repositories mapping dialog through any path other than a
+ * successful OK must return null, so the caller keeps the previous mapping.
+ * A team project whose repository row was removed before cancelling used to
+ * receive the emptied table state anyway, and the next project save then
+ * silently dropped the repositories element from omegat.project.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class RepositoriesMappingDialogTest {
+
+    @Before
+    public final void setUp() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+    }
+
+    private static List<RepositoryDefinition> teamRepositories() {
+        RepositoryDefinition repo = new RepositoryDefinition();
+        repo.setType("git");
+        repo.setUrl("https://example.com/team-project.git");
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        repo.getMapping().add(mapping);
+        List<RepositoryDefinition> repositories = new ArrayList<>();
+        repositories.add(repo);
+        return repositories;
+    }
+
+    @Test
+    public void testOkReturnsTableState() {
+        RepositoriesMappingDialog dialog = new RepositoriesMappingDialog(null, false);
+        dialog.init(teamRepositories());
+        dialog.okButton.doClick();
+        assertNotNull("OK must return the table state", dialog.result);
+        assertEquals(1, dialog.result.size());
+        assertEquals("https://example.com/team-project.git", dialog.result.get(0).getUrl());
+        dialog.dispose();
+    }
+
+    @Test
+    public void testCancelReturnsNull() {
+        RepositoriesMappingDialog dialog = new RepositoriesMappingDialog(null, false);
+        dialog.init(teamRepositories());
+        dialog.cancelButton.doClick();
+        assertNull("Cancel must not return the table state", dialog.result);
+        dialog.dispose();
+    }
+
+    @Test
+    public void testClosingWithoutOkReturnsNull() {
+        // Escape and the window close button leave the dialog without
+        // passing through either button; show() must then return null.
+        RepositoriesMappingDialog dialog = new RepositoriesMappingDialog(null, false);
+        List<RepositoryDefinition> result = dialog.show(teamRepositories());
+        assertNull("Leaving the dialog without OK must return null", result);
+    }
+
+    @Test
+    public void testWindowClosingReturnsNull() {
+        // Escape is translated into a WINDOW_CLOSING event, so this covers
+        // both the Escape key and the window close button.
+        RepositoriesMappingDialog dialog = new RepositoriesMappingDialog(null, false);
+        dialog.init(teamRepositories());
+        dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING));
+        assertNull("Closing the window must not return the table state", dialog.result);
+    }
+}

--- a/test/src/org/omegat/gui/repositoriesmapping/RepositoriesMappingControllerTest.java
+++ b/test/src/org/omegat/gui/repositoriesmapping/RepositoriesMappingControllerTest.java
@@ -1,0 +1,85 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.repositoriesmapping;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * The mapping table must refuse two mappings onto the same local folder:
+ * every file under it would match more than one mapping and the project
+ * would no longer load ("Multiple mappings for file").
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class RepositoriesMappingControllerTest {
+
+    private static List<RepositoryDefinition> reposWithLocals(String... locals) {
+        RepositoryDefinition repo = new RepositoryDefinition();
+        repo.setType("git");
+        repo.setUrl("https://example.com/team-project.git");
+        for (String local : locals) {
+            RepositoryMapping mapping = new RepositoryMapping();
+            mapping.setLocal(local);
+            mapping.setRepository(local);
+            repo.getMapping().add(mapping);
+        }
+        List<RepositoryDefinition> repos = new ArrayList<>();
+        repos.add(repo);
+        return repos;
+    }
+
+    private static String validate(List<RepositoryDefinition> input) {
+        RepositoriesMappingController controller = new RepositoriesMappingController(
+                new RepositoriesMappingPanel(), input);
+        return controller.validateInput();
+    }
+
+    @Test
+    public void testDistinctLocalFoldersAreValid() {
+        assertNull(validate(reposWithLocals("/", "/glossary")));
+    }
+
+    @Test
+    public void testDuplicateLocalFolderIsRejected() {
+        assertNotNull("duplicate local folders must be rejected",
+                validate(reposWithLocals("/", "/")));
+    }
+
+    @Test
+    public void testSlashVariantsOfSameFolderAreRejected() {
+        assertNotNull("the empty local path and the root slash address the same folder",
+                validate(reposWithLocals("", "/")));
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- (none)

## What does this PR change?

- Repositories mapping dialog returns result only after confirmed OK. Since #1752, every exit path returned current table snapshot written straight into live project properties; one cancelled dialog plus next auto-save silently dropped `repositories` element from `omegat.project`.
- Properties dialog buffers mapping edits like SRX and filters, applies on OK; window close counts as Cancel.
- Validation rejects two mappings onto same local folder (previously saved fine, project then failed to load with "Multiple mappings for file").
- Project load drops exact duplicate mapping entries with logged warning instead of failing.
- Tests cover dialog exit paths, validation, duplicate cleanup.

Regression ships in 6.1.0/6.1.1; see also #2276

## Other information
