### PR TITLE
chore(spellchecker): add `@NullMarked` annotations and `jspecify` dependency

### DIFF
--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -16,6 +16,7 @@ dependencies {
         compileOnly(libs.slf4j.format.jdk14)
         compileOnly(libs.languagetool.core)
         compileOnly(libs.lucene.analyzers.common)
+        compileOnly(libs.jspecify)
     }
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)

--- a/spellchecker/hunspell/build.gradle
+++ b/spellchecker/hunspell/build.gradle
@@ -8,7 +8,7 @@ dependencies {
         implementation fileTree(dir: providedModuleLibsDir, includes: ['**/hunspell-*.jar'])
         compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/languagetool-core-*.jar',
                 '**/commons-io-*.jar', '**/lib-mnemonics-*.jar', '**/slf4j-format-jdk14-*.jar',
-                '**/lucene-analyzers-common-*.jar'])
+                '**/lucene-analyzers-common-*.jar', '**/jspecify-*.jar'])
     } else {
         implementation(libs.dumont.hunspell)
         compileOnly(libs.commons.io)

--- a/spellchecker/hunspell/src/main/java/org/omegat/spellchecker/hunspell/package-info.java
+++ b/spellchecker/hunspell/src/main/java/org/omegat/spellchecker/hunspell/package-info.java
@@ -1,0 +1,29 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+@NullMarked
+package org.omegat.spellchecker.hunspell;
+
+import org.jspecify.annotations.NullMarked;

--- a/spellchecker/lucene/build.gradle
+++ b/spellchecker/lucene/build.gradle
@@ -5,12 +5,12 @@ plugins {
 dependencies {
     compileOnly(project.rootProject)
     if (providedCoreLibsDir.directory) {
-        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-io-*.jar', '**/lucene-*.jar'])
+        compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/jspecify-*.jar', '**/commons-io-*.jar', '**/lucene-*.jar'])
     } else {
         compileOnly(libs.commons.io)
         compileOnly(libs.bundles.lucene)
+        compileOnly(libs.jspecify)
     }
-    compileOnly(libs.jspecify)
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)
     testImplementation(testFixtures(project.rootProject))

--- a/spellchecker/lucene/src/main/java/org/omegat/spellchecker/lucene/package-info.java
+++ b/spellchecker/lucene/src/main/java/org/omegat/spellchecker/lucene/package-info.java
@@ -1,0 +1,29 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+@NullMarked
+package org.omegat.spellchecker.lucene;
+
+import org.jspecify.annotations.NullMarked;

--- a/spellchecker/morfologik/build.gradle
+++ b/spellchecker/morfologik/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     compileOnly(project.rootProject)
     if (providedModuleLibsDir.directory) {
         compileOnly fileTree(dir: providedCoreLibsDir, includes: ['**/commons-io-*.jar', '**/languagetool-core-*.jar',
-                                       '**/lib-mnemonics-*.jar', '**/slf4j-format-jdk14-*.jar', '**/morfologik-*.jar'])
+                                       '**/lib-mnemonics-*.jar', '**/slf4j-format-jdk14-*.jar', '**/morfologik-*.jar',
+                                       '**/jspecify-*.jar'])
     } else {
         // morfologik stemming and speller are dependency of languagetool-core
         compileOnly(libs.morfologik.stemming)
@@ -15,6 +16,7 @@ dependencies {
         compileOnly(libs.omegat.mnemonics)
         compileOnly(libs.slf4j.format.jdk14)
         compileOnly(libs.languagetool.core)
+        compileOnly(libs.jspecify)
     }
     testImplementation(libs.junit4)
     testImplementation(libs.assertj)

--- a/spellchecker/morfologik/src/main/java/org/omegat/spellchecker/morfologik/package-info.java
+++ b/spellchecker/morfologik/src/main/java/org/omegat/spellchecker/morfologik/package-info.java
@@ -1,0 +1,29 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+@NullMarked
+package org.omegat.spellchecker.morfologik;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Split #2272

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

Dev ML discussion https://sourceforge.net/p/omegat/mailman/message/59377180/
[OmTdev] [PR https://github.com/omegat-org/omegat/pull/2270] New tool for measuring JSpecify @NullMarked coverage (ADR#2025008 update)

## What does this PR change?

- Add package-info.java with NullMarked
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
