### PR TITLE
Fix MyMemory machine translation endpoint

### DIFF
--- a/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/AbstractMyMemoryTranslate.java
+++ b/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/AbstractMyMemoryTranslate.java
@@ -57,7 +57,7 @@ public abstract class AbstractMyMemoryTranslate extends BaseCachedTranslate {
 
     protected static final String MYMEMORY_API_EMAIL = "mymemory.api.email";
     protected static final String MYMEMORY_API_KEY = "mymemory.api.key";
-    private static final String DEFAULT_GT_URL = "https://mymemory.translated.net/api/get";
+    private static final String DEFAULT_GT_URL = "https://api.mymemory.translated.net/get";
 
     protected static final String BUNDLE_BASENAME = "org.omegat.machinetranslators.mymemory.Bundle";
 


### PR DESCRIPTION
## Pull request type

Bug fix

## Which ticket is resolved?

- Java Exception while trying to access MyMemory (machine)
- https://sourceforge.net/p/omegat/bugs/1319/

## What does this PR change?

- Updates the default MyMemory API endpoint from
  `https://mymemory.translated.net/api/get` to
  `https://api.mymemory.translated.net/get`.
- Restores machine translation results from MyMemory instead of falling
  back to unrelated fuzzy translation-memory matches.
- Keeps the existing MyMemory request and result-selection logic unchanged.

## Other information

Reproduced with OmegaT 6.0.1 and current master.

For the source segment:

`The bicycle frame is made from steel.`

the previous endpoint returns HTTP 200 but no machine-translation entry.
OmegaT therefore falls back to an unrelated fuzzy match:

`Der Lauf der Waffe ist fest montiert.`

The updated endpoint returns the expected MT entry (`created-by: MT!`) and:

`Der Fahrradrahmen ist aus Stahl gefertigt.`

Validation:

`./gradlew :machinetranslators:mymemory:test`

BUILD SUCCESSFUL.

I also verified the change with a development build of OmegaT on Fedora 43.
The MyMemory machine-translation pane returned the expected translation.