### PR TITLE
chore(filters): add NullMarked annotations for filters

### DIFF
--- a/src/main/java/org/omegat/filters2/AbstractFilter.java
+++ b/src/main/java/org/omegat/filters2/AbstractFilter.java
@@ -356,7 +356,7 @@ public abstract class AbstractFilter implements IFilter {
      * @throws IOException
      *             If any I/O Error occurs upon writer creation
      */
-    protected @Nullable BufferedWriter createWriter(File outFile, String outEncoding)
+    protected @Nullable BufferedWriter createWriter(@Nullable File outFile, @Nullable String outEncoding)
             throws UnsupportedEncodingException, IOException {
         if (outFile == null) {
             return null;
@@ -676,7 +676,10 @@ public abstract class AbstractFilter implements IFilter {
     }
 
     @Override
-    public @Nullable String getInEncodingLastParsedFile() {
+    public String getInEncodingLastParsedFile() {
+        if (inEncodingLastParsedFile == null) {
+            inEncodingLastParsedFile = Charset.defaultCharset().name();
+        }
         return inEncodingLastParsedFile;
     }
 

--- a/src/main/java/org/omegat/filters2/FilterContext.java
+++ b/src/main/java/org/omegat/filters2/FilterContext.java
@@ -39,17 +39,17 @@ public class FilterContext {
 
     private final @Nullable Language targetLang;
 
-    private String inEncoding;
+    private @Nullable String inEncoding;
 
-    private String outEncoding;
+    private @Nullable String outEncoding;
 
     private final boolean sentenceSegmentingEnabled;
 
     private boolean isRemoveAllTags;
 
-    private Class<?> sourceTokenizerClass;
+    private @Nullable Class<?> sourceTokenizerClass;
 
-    private Class<?> targetTokenizerClass;
+    private @Nullable Class<?> targetTokenizerClass;
 
     public FilterContext(ProjectProperties props) {
         this.sourceLang = props.getSourceLanguage();

--- a/src/main/java/org/omegat/filters2/FilterContext.java
+++ b/src/main/java/org/omegat/filters2/FilterContext.java
@@ -79,7 +79,7 @@ public class FilterContext {
     }
 
     /** Source file encoding, but can be 'null'. */
-    public String getInEncoding() {
+    public @Nullable String getInEncoding() {
         return inEncoding;
     }
 

--- a/src/main/java/org/omegat/filters2/hhc/package-info.java
+++ b/src/main/java/org/omegat/filters2/hhc/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.hhc;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/html2/FilterVisitor.java
+++ b/src/main/java/org/omegat/filters2/html2/FilterVisitor.java
@@ -50,6 +50,7 @@ import org.htmlparser.Tag;
 import org.htmlparser.Text;
 import org.htmlparser.nodes.TextNode;
 import org.htmlparser.visitors.NodeVisitor;
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.filters2.FilterContext;
 import org.omegat.util.HTMLUtils;
@@ -70,9 +71,9 @@ import org.omegat.util.StringUtil;
 public class FilterVisitor extends NodeVisitor {
     protected HTMLFilter2 filter;
     private final BufferedWriter writer;
-    private final HTMLOptions options;
+    private final @Nullable HTMLOptions options;
 
-    public FilterVisitor(HTMLFilter2 htmlfilter, BufferedWriter bufwriter, HTMLOptions opts,
+    public FilterVisitor(HTMLFilter2 htmlfilter, BufferedWriter bufwriter, @Nullable HTMLOptions opts,
             FilterContext fc) {
         this.filter = htmlfilter;
         // HHC filter has no options

--- a/src/main/java/org/omegat/filters2/html2/HTMLFilter2.java
+++ b/src/main/java/org/omegat/filters2/html2/HTMLFilter2.java
@@ -50,6 +50,7 @@ import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.Instance;
 import org.omegat.filters2.TranslationException;
 import org.omegat.util.Log;
+import org.omegat.util.NullBufferedWriter;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
 
@@ -109,13 +110,16 @@ public class HTMLFilter2 extends AbstractFilter {
     @Override
     protected String getInputEncoding(FilterContext filterContext, File infile) throws IOException {
         String encoding = filterContext.getInEncoding();
-        if (encoding == null && isSourceEncodingVariable()) {
+        if (encoding != null) {
+            return encoding;
+        }
+        if (isSourceEncodingVariable()) {
             try (HTMLReader hreader = new HTMLReader(infile.getAbsolutePath(),
                     StandardCharsets.UTF_8.name())) {
-                encoding = hreader.getEncoding();
+                return hreader.getEncoding();
             }
         }
-        return encoding;
+        return StandardCharsets.UTF_8.name();
     }
 
     /**
@@ -138,16 +142,20 @@ public class HTMLFilter2 extends AbstractFilter {
      * @see HTMLWriter
      */
     @Override
-    public BufferedWriter createWriter(File outfile, String encoding) throws IOException {
-        HTMLWriter hwriter;
-        HTMLOptions options = new HTMLOptions(processOptions);
-        if (encoding == null) {
-            this.targetEncoding = sourceEncoding;
+    public BufferedWriter createWriter(@Nullable File outfile, @Nullable String encoding) throws IOException {
+        if (outfile == null) {
+            return new NullBufferedWriter();
         } else {
-            this.targetEncoding = encoding;
+            HTMLWriter hwriter;
+            HTMLOptions options = new HTMLOptions(processOptions);
+            if (encoding == null) {
+                targetEncoding = sourceEncoding;
+            } else {
+                targetEncoding = encoding;
+            }
+            hwriter = new HTMLWriter(outfile.getAbsolutePath(), targetEncoding, options);
+            return new BufferedWriter(hwriter);
         }
-        hwriter = new HTMLWriter(outfile.getAbsolutePath(), this.targetEncoding, options);
-        return new BufferedWriter(hwriter);
     }
 
     @Override
@@ -320,7 +328,10 @@ public class HTMLFilter2 extends AbstractFilter {
     }
 
     @Override
-    public @Nullable String getInEncodingLastParsedFile() {
+    public String getInEncodingLastParsedFile() {
+        if (sourceEncoding == null) {
+            return StandardCharsets.UTF_8.name();
+        }
         return sourceEncoding;
     }
 

--- a/src/main/java/org/omegat/filters2/html2/HTMLWriter.java
+++ b/src/main/java/org/omegat/filters2/html2/HTMLWriter.java
@@ -36,7 +36,7 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 
-import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 import org.omegat.util.PatternConsts;
 
 /**
@@ -63,9 +63,9 @@ public class HTMLWriter extends Writer {
     private BufferedWriter realWriter;
 
     /** Replacement string for HTML content-type META */
-    private String htmlMeta;
+    private @Nullable String htmlMeta;
     /** Replacement string for XML (XHTML) header */
-    private String xmlHeader;
+    private @Nullable String xmlHeader;
 
     /**
      * Encoding to write this file in. null value means no encoding declaration.
@@ -84,7 +84,7 @@ public class HTMLWriter extends Writer {
      *            - the encoding to write HTML file in (null means OS-default
      *            encoding)
      */
-    public HTMLWriter(String fileName, String encoding, HTMLOptions options)
+    public HTMLWriter(String fileName, @Nullable String encoding, HTMLOptions options)
             throws FileNotFoundException, UnsupportedEncodingException {
         this.encoding = encoding;
 
@@ -219,7 +219,7 @@ public class HTMLWriter extends Writer {
      *             - If an I/O error occurs
      */
     @Override
-    public void write(@NotNull char[] cbuf, int off, int len) throws IOException {
+    public void write(char[] cbuf, int off, int len) throws IOException {
         writer.write(cbuf, off, len);
         if (writer.getBuffer().length() >= MAX_BUFFER_SIZE) {
             flush();

--- a/src/main/java/org/omegat/filters2/html2/package-info.java
+++ b/src/main/java/org/omegat/filters2/html2/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.html2;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/main/java/org/omegat/filters2/latex/LatexFilter.java
@@ -45,7 +45,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.VisibleForTesting;
-import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
@@ -66,7 +65,6 @@ import org.omegat.util.OStrings;
  * @author Adiel Mittmann
  * @author Hiroshi Miura
  */
-@NullMarked
 public class LatexFilter extends AbstractFilter {
 
     /**
@@ -152,7 +150,7 @@ public class LatexFilter extends AbstractFilter {
         return 12;
     }
 
-    private String lineBreak;
+    private @Nullable String lineBreak;
 
     /**
      * Processes a LaTeX document.

--- a/src/main/java/org/omegat/filters2/latex/package-info.java
+++ b/src/main/java/org/omegat/filters2/latex/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.latex;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/master/package-info.java
+++ b/src/main/java/org/omegat/filters2/master/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.master;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
+++ b/src/main/java/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
@@ -61,7 +61,7 @@ public class MoodlePHPFilter extends AbstractFilter {
     protected static final Pattern RE_ENTITY = Pattern.compile("\\$string\\['(.+)'] (=) '(.+)(';)$",
             Pattern.DOTALL);
 
-    protected Map<String, String> align;
+    protected @Nullable Map<String, String> align;
 
     /**
      * If true, will remove non-translated segments in the target files

--- a/src/main/java/org/omegat/filters2/moodlephp/package-info.java
+++ b/src/main/java/org/omegat/filters2/moodlephp/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.moodlephp;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
+++ b/src/main/java/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
@@ -69,7 +69,7 @@ public class MozillaDTDFilter extends AbstractFilter {
     protected static final Pattern RE_ENTITY = Pattern.compile("<!ENTITY\\s+(\\S+)\\s+([\"'])(.+)\\2\\s*>",
             Pattern.DOTALL);
 
-    protected Map<String, String> align;
+    protected @Nullable Map<String, String> align;
 
     /**
      * If true, will remove non-translated segments in the target files

--- a/src/main/java/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
+++ b/src/main/java/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
@@ -182,7 +182,7 @@ public class MozillaDTDFilter extends AbstractFilter {
                 out.write(trans != null ? trans : text);
                 out.write(block.substring(m.end(3)));
             }
-        } else if (entryAlignCallback != null && id != null) {
+        } else if (align != null && entryAlignCallback != null && id != null) {
             align.put(id, text);
         }
     }

--- a/src/main/java/org/omegat/filters2/mozdtd/package-info.java
+++ b/src/main/java/org/omegat/filters2/mozdtd/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.mozdtd;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/mozlang/package-info.java
+++ b/src/main/java/org/omegat/filters2/mozlang/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.mozlang;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/pdf/package-info.java
+++ b/src/main/java/org/omegat/filters2/pdf/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.pdf;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/po/PoFilter.java
+++ b/src/main/java/org/omegat/filters2/po/PoFilter.java
@@ -46,7 +46,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SegmentProperties;
@@ -79,7 +79,6 @@ import org.omegat.util.TagUtil;
  * @author Didier Briel
  * @author Enrique Estevez
  */
-@NullMarked
 public class PoFilter extends AbstractFilter {
 
     public static final String OPTION_ALLOW_BLANK = "disallowBlank";
@@ -314,20 +313,20 @@ public class PoFilter extends AbstractFilter {
         MSGID, MSGSTR, MSGID_PLURAL, MSGSTR_PLURAL, MSGCTX
     }
 
-    private StringBuilder[] sources;
-    private StringBuilder[] targets;
-    private StringBuilder translatorComments;
-    private StringBuilder extractedComments;
-    private StringBuilder references;
-    private StringBuilder sourceFuzzyTrue;
+    private StringBuilder@Nullable [] sources;
+    private StringBuilder@Nullable [] targets;
+    private @Nullable StringBuilder translatorComments;
+    private @Nullable StringBuilder extractedComments;
+    private @Nullable StringBuilder references;
+    private @Nullable StringBuilder sourceFuzzyTrue;
     private int plurals = 2;
-    private String path;
+    private @Nullable String path;
     private boolean nowrap, fuzzy, fuzzyTrue;
     private boolean headerProcessed;
 
-    private BufferedWriter out;
+    private @Nullable BufferedWriter out;
 
-    private MODE currentMode;
+    private @Nullable MODE currentMode;
     private int currentPlural;
 
     @Override
@@ -358,7 +357,7 @@ public class PoFilter extends AbstractFilter {
     }
 
     @Override
-    public void processFile(File inFile, File outFile, FilterContext fc)
+    public void processFile(File inFile, @Nullable File outFile, FilterContext fc)
             throws IOException, TranslationException {
 
         String allowBlankStr = processOptions.get(OPTION_ALLOW_BLANK);
@@ -392,7 +391,7 @@ public class PoFilter extends AbstractFilter {
     }
 
     @Override
-    public void processFile(BufferedReader in, BufferedWriter writer, FilterContext fc) throws IOException {
+    public void processFile(BufferedReader in, @Nullable BufferedWriter writer, FilterContext fc) throws IOException {
         out = writer;
         processPoFile(in, fc);
     }

--- a/src/main/java/org/omegat/filters2/po/package-info.java
+++ b/src/main/java/org/omegat/filters2/po/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.po;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/rc/package-info.java
+++ b/src/main/java/org/omegat/filters2/rc/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.rc;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/subtitles/package-info.java
+++ b/src/main/java/org/omegat/filters2/subtitles/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.subtitles;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
+++ b/src/main/java/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.core.data.ProtectedPart;
 import org.omegat.filters2.AbstractFilter;
@@ -98,7 +99,7 @@ public class ResourceBundleFilter extends AbstractFilter {
     public static final String DEFAULT_SOURCE_ENCODING = StandardCharsets.UTF_8.name();
     public static final String DEFAULT_TARGET_ENCODING = StandardCharsets.UTF_8.name();
 
-    protected Map<String, String> align;
+    protected @Nullable Map<String, String> align;
 
     /**
      * If true, will not convert characters into \\uXXXX notation
@@ -563,7 +564,7 @@ public class ResourceBundleFilter extends AbstractFilter {
     }
 
     @Override
-    public Map<String, String> changeOptions(Window parent, Map<String, String> config) {
+    public @Nullable Map<String, String> changeOptions(Window parent, Map<String, String> config) {
         try {
             ResourceBundleOptionsDialog dialog = new ResourceBundleOptionsDialog(parent, config);
             dialog.setVisible(true);

--- a/src/main/java/org/omegat/filters2/text/bundles/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/bundles/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.text.bundles;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/text/dokuwiki/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/dokuwiki/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.text.dokuwiki;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/text/ilias/ILIASFilter.java
+++ b/src/main/java/org/omegat/filters2/text/ilias/ILIASFilter.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
@@ -59,7 +60,7 @@ import org.omegat.util.StringUtil;
  * @author Michael Zakharov <trapman.hunt@gmail.com>
  */
 public class ILIASFilter extends AbstractFilter {
-    protected Map<String, String> align;
+    protected @Nullable Map<String, String> align;
 
     /**
      * Register plugin into OmegaT.

--- a/src/main/java/org/omegat/filters2/text/ilias/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/ilias/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.text.ilias;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/text/ini/INIFilter.java
+++ b/src/main/java/org/omegat/filters2/text/ini/INIFilter.java
@@ -35,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
@@ -53,7 +54,7 @@ import org.omegat.util.StringUtil;
  * @author Didier Briel
  */
 public class INIFilter extends AbstractFilter {
-    protected Map<String, String> align;
+    protected @Nullable Map<String, String> align;
 
     /**
      * Register plugin into OmegaT.

--- a/src/main/java/org/omegat/filters2/text/ini/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/ini/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.text.ini;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/text/magento/MagentoFilter.java
+++ b/src/main/java/org/omegat/filters2/text/magento/MagentoFilter.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
@@ -49,7 +50,7 @@ import org.omegat.util.StringUtil;
  * @author Michael Zakharov <trapman.hunt@gmail.com>
  */
 public class MagentoFilter extends AbstractFilter {
-    protected Map<String, String> align;
+    protected @Nullable Map<String, String> align;
 
     /**
      * Register plugin into OmegaT.

--- a/src/main/java/org/omegat/filters2/text/magento/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/magento/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.text.magento;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/text/mozftl/MozillaFTLFilter.java
+++ b/src/main/java/org/omegat/filters2/text/mozftl/MozillaFTLFilter.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
@@ -55,7 +56,7 @@ public class MozillaFTLFilter extends AbstractFilter {
 
     public static final String OPTION_REMOVE_STRINGS_UNTRANSLATED = "unremoveStringsUntranslated";
 
-    protected Map<String, String> align;
+    protected @Nullable Map<String, String> align;
     // For the entries with attributes. Example: .title = When using
     // But, it also can be of type: .tooltiptext =
     // There always is something, then dot, then the key + space + = and
@@ -281,7 +282,7 @@ public class MozillaFTLFilter extends AbstractFilter {
     }
 
     @Override
-    public Map<String, String> changeOptions(Window parent, Map<String, String> config) {
+    public @Nullable Map<String, String> changeOptions(Window parent, Map<String, String> config) {
         try {
             MozillaFTLOptionsDialog dialog = new MozillaFTLOptionsDialog(parent, config);
             dialog.setVisible(true);

--- a/src/main/java/org/omegat/filters2/text/mozftl/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/mozftl/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.text.mozftl;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/text/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.text;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/xtagqxp/package-info.java
+++ b/src/main/java/org/omegat/filters2/xtagqxp/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters2.xtagqxp;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/android/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/android/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.android;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/camtasiawindows/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/camtasiawindows/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.camtasiawindows;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/docbook/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/docbook/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.docbook;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/flash/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/flash/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.flash;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/helpandmanual/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/helpandmanual/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.helpandmanual;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/infix/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/infix/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.infix;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/l10nmgr/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/l10nmgr/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.l10nmgr;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/opendoc/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/opendoc/package-info.java
@@ -3,7 +3,7 @@
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
 
- Copyright (C) 2025 Hiroshi Miura
+ Copyright (C) 2026 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -22,7 +22,6 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  **************************************************************************/
-
 
 @NullMarked
 package org.omegat.filters3.xml.opendoc;

--- a/src/main/java/org/omegat/filters3/xml/properties/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/properties/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.properties;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/relaxng/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/relaxng/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.relaxng;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/resx/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/resx/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.resx;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/schematron/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/schematron/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.schematron;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/scribus/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/scribus/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.scribus;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/svg/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/svg/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.svg;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/txml/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/txml/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.txml;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/typo3/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/typo3/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.typo3;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/visio/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/visio/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.visio;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/wix/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/wix/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.wix;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/wordpress/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/wordpress/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.wordpress;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters3/xml/xmlspreadsheet/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/xmlspreadsheet/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters3.xml.xmlspreadsheet;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters4/package-info.java
+++ b/src/main/java/org/omegat/filters4/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters4;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters4/xml/openxml/package-info.java
+++ b/src/main/java/org/omegat/filters4/xml/openxml/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters4.xml.openxml;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters4/xml/package-info.java
+++ b/src/main/java/org/omegat/filters4/xml/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters4.xml;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters4/xml/xliff/package-info.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/package-info.java
@@ -24,6 +24,6 @@
  **************************************************************************/
 
 @NullMarked
-package org.omegat.filters2.text.yaml;
+package org.omegat.filters4.xml.xliff;
 
 import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
- split #2272
- Fix Null handling of the HTML2 and MozilaDTD filters

## Pull request type

- Bug fix -> [bug]
- Build and release changes -> [build/release]

## Which ticket is resolved?
None

## What does this PR change?

- When HTML filter try to detect encoding and failed, it may become NPE
- MozillaDTD filter has doggy code for null handling.
- HTML filter may become NPE when running align feature.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
