### PR TITLE
chore(mt): enforce Locale.ROOT for language code normalization in YandexCloudTranslate

### DIFF
--- a/machinetranslators/yandex/src/main/java/org/omegat/machinetranslators/yandex/YandexCloudTranslate.java
+++ b/machinetranslators/yandex/src/main/java/org/omegat/machinetranslators/yandex/YandexCloudTranslate.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.TreeMap;
@@ -212,7 +213,6 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
         return ALLOW_YANDEX_CLOUD_TRANSLATE;
     }
 
-    @SuppressWarnings("unchecked")
     private String extractErrorMessage(final String json) {
         JsonNode rootNode;
         ObjectMapper mapper = new ObjectMapper();
@@ -228,8 +228,8 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
     protected String createJsonRequest(final Language sLang, final Language tLang, final String trText,
             final String folderId) throws JsonProcessingException {
         Map<String, Object> params = new TreeMap<>();
-        params.put("sourceLanguageCode", sLang.getLanguageCode().toLowerCase());
-        params.put("targetLanguageCode", tLang.getLanguageCode().toLowerCase());
+        params.put("sourceLanguageCode", sLang.getLanguageCode().toLowerCase(Locale.ROOT));
+        params.put("targetLanguageCode", tLang.getLanguageCode().toLowerCase(Locale.ROOT));
         params.put("folderId", folderId);
         if (Preferences.isPreference(PROPERTY_KEEP_TAGS)) {
             params.put("format", "HTML");
@@ -244,7 +244,6 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
         return new ObjectMapper().writeValueAsString(params);
     }
 
-    @SuppressWarnings("unchecked")
     protected String extractTranslation(final String json) throws MachineTranslateError {
         JsonNode rootNode;
         ObjectMapper mapper = new ObjectMapper();
@@ -258,7 +257,6 @@ public class YandexCloudTranslate extends BaseCachedTranslate {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private @Nullable String getIAMToken(final String oAuthToken) {
         if (System.currentTimeMillis() - lastIAMTokenTime > IAM_TOKEN_TTL_SECONDS * 1_000) {
 


### PR DESCRIPTION


## Pull request type

-refactoring

## What does this PR change?

- There is no feature change.
- use explicit Locale.ROOT for `toLower`
- streamline unused warning suppression

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
