### PR TITLE
refactor(filters4): add nullability annotations and improve collections handling in XLIFF filters

### DIFF
--- a/src/main/java/org/omegat/filters4/xml/AbstractXmlFilter.java
+++ b/src/main/java/org/omegat/filters4/xml/AbstractXmlFilter.java
@@ -31,12 +31,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.LinkedList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -388,7 +388,6 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
         }
     }
 
-    @SuppressWarnings("unchecked")
     protected final void fromEventToWriter(XMLEvent ev, XMLStreamWriter writer) throws XMLStreamException {
         switch (ev.getEventType()) {
         case XMLEvent.ENTITY_REFERENCE:
@@ -484,7 +483,7 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
      * after buildTags(src, true) to have the necessary variables filled!
      **/
     protected List<XMLEvent> restoreTags(String tra) {
-        List<XMLEvent> res = new LinkedList<>();
+        List<XMLEvent> res = new ArrayList<>();
         while (!tra.isEmpty()) {
             Matcher m = OMEGAT_TAG.matcher(tra);
             if (m.find()) {
@@ -523,7 +522,7 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
     }
 
     protected List<ProtectedPart> buildProtectedParts(String src) {
-        List<ProtectedPart> protectedParts = new LinkedList<ProtectedPart>();
+        List<ProtectedPart> protectedParts = new ArrayList<>();
         while (!src.isEmpty()) {
             Matcher m = OMEGAT_TAG.matcher(src);
             if (!m.find()) {
@@ -552,17 +551,16 @@ public abstract class AbstractXmlFilter extends AbstractFilter {
 
     /** Convert <xxx/> to <xxx></xxx> **/
     protected List<XMLEvent> toPair(StartElement ev) {
-        List<XMLEvent> l = new LinkedList<>();
+        List<XMLEvent> l = new ArrayList<>();
         l.add(ev);
         l.add(eFactory.createEndElement(ev.getName(), null));
         return l;
     }
 
-    @SuppressWarnings("unchecked")
     protected String findKey(StartElement findEl, boolean isEmpty) {
         for (Map.Entry<String, List<XMLEvent>> me : tagsMap.entrySet()) {
             try {
-                StartElement mapEl = me.getValue().get(0).asStartElement();
+                StartElement mapEl = me.getValue().getFirst().asStartElement();
                 if (mapEl.getName().equals(findEl.getName())) {
                     boolean foundDiff = false;
                     for (Iterator<Attribute> iter = mapEl.getAttributes(); iter.hasNext();) {

--- a/src/main/java/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
@@ -25,8 +25,8 @@
 
 package org.omegat.filters4.xml.xliff;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -44,6 +44,7 @@ import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.filters2.FilterContext;
 import org.omegat.filters2.Instance;
 import org.omegat.filters4.xml.AbstractXmlFilter;
@@ -62,7 +63,7 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
         return new Instance[] { new Instance("*.xlf"), new Instance("*.xliff") };
     }
 
-    protected String namespace = null;
+    protected @Nullable String namespace = null;
 
     @Override
     public boolean isFileSupported(java.io.File inFile, Map<String, String> config, FilterContext context) {
@@ -101,12 +102,12 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
 
     /* -- Data about current unit */
     protected String path = "/";
-    protected String ignoreScope = null;
-    protected List<XMLEvent> currentBuffer = null;
+    protected @Nullable String ignoreScope = null;
+    protected @Nullable List<XMLEvent> currentBuffer = null;
     protected boolean inTarget = false;
-    protected List<XMLEvent> source = new LinkedList<>();
-    protected List<XMLEvent> target = null;
-    protected List<XMLEvent> note = new LinkedList<>();
+    protected List<XMLEvent> source = new ArrayList<>();
+    protected @Nullable List<XMLEvent> target = null;
+    protected final List<XMLEvent> note = new ArrayList<>();
 
     protected void cleanBuffers() {
         source.clear();
@@ -115,7 +116,7 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
     }
 
     @Override
-    protected boolean processCharacters(Characters event, XMLStreamWriter evWriter)
+    protected boolean processCharacters(Characters event, @Nullable XMLStreamWriter evWriter)
             throws XMLStreamException {
         if (currentBuffer != null) {
             currentBuffer.add(event);
@@ -138,13 +139,13 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
     protected abstract String buildTags(List<XMLEvent> srcList, boolean reuse);
 
     /** Enables not to add some entries. To be overridden by subtypes **/
-    protected boolean isToIgnore(String src, String tra) {
+    protected boolean isToIgnore(String src, @Nullable String tra) {
         return false;
     }
 
     /** Add one unit to OmegaT, or more in case of <mrk mtype="seg"> **/
     protected void registerCurrentTransUnit(String entryId, List<XMLEvent> unitSource,
-            List<XMLEvent> unitTarget, String notePattern) {
+            @Nullable List<XMLEvent> unitTarget, @Nullable String notePattern) {
         String src = buildTags(unitSource, false);
         String tra = null;
         if (unitTarget != null && !unitTarget.isEmpty()) {
@@ -154,9 +155,9 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
             return; // may ignore some pre-translated src->tra pairs
         }
         if (entryParseCallback != null) {
-            StringBuffer noteStr = null;
-            if (notePattern != null && note != null && !note.isEmpty()) {
-                noteStr = new StringBuffer();
+            StringBuilder noteStr = null;
+            if (notePattern != null && !note.isEmpty()) {
+                noteStr = new StringBuilder();
                 for (XMLEvent ev : note) {
                     String noteContent = ev.getEventType() == XMLStreamConstants.CHARACTERS
                             ? ((Characters) ev).getData()
@@ -165,9 +166,9 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
                 }
             }
             if (notePattern != null && !".*".equals(notePattern)) {
-                StringBuffer subNoteBuf = noteStr;
+                StringBuilder subNoteBuf = noteStr;
                 if (subNoteBuf != null) {
-                    subNoteBuf = new StringBuffer();
+                    subNoteBuf = new StringBuilder();
                     Matcher noteMatch = Pattern.compile(notePattern).matcher(noteStr.toString());
                     while (noteMatch.find()) {
                         if (noteMatch.group(1).equals(entryId.substring(entryId.lastIndexOf("/") + 1))) {
@@ -226,15 +227,14 @@ abstract class AbstractXliffFilter extends AbstractXmlFilter {
                 break;
             }
         }
-        String key = pairedHolders.get(pairId.getValue());
+        String key = pairedHolders.get(Objects.requireNonNull(pairId).getValue());
         if (!reuse) {
             tagsMap.put("/" + key, nativeCode);
         }
         return "</" + key + ">";
     }
 
-    protected void startStackElement(boolean reuse, StartElement stEl, char prefix, int count,
-            StringBuffer res) {
+    protected void startStackElement(boolean reuse, StartElement stEl, char prefix, int count, StringBuilder res) {
         if (reuse) {
             String k = findKey(stEl, false);
             Matcher m = OMEGAT_TAG.matcher(k);

--- a/src/main/java/org/omegat/filters4/xml/xliff/SdlXliff.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/SdlXliff.java
@@ -28,6 +28,7 @@ package org.omegat.filters4.xml.xliff;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -43,12 +44,14 @@ import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.Characters;
 import javax.xml.stream.events.XMLEvent;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.TMXEntry;
 import org.omegat.filters2.Instance;
 import org.omegat.filters2.FilterContext;
+import org.omegat.util.Log;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
 
@@ -103,15 +106,15 @@ public class SdlXliff extends Xliff1Filter {
 
     // ----------------------------- specific part ----------------------
 
-    private String currentMid = null;
-    private Map<String, StringBuffer> sdlComments = new TreeMap<>();
-    private StringBuffer commentBuf = null;
-    private Map<UUID, String> omegatNotes = new TreeMap<>();
-    private Map<String, UUID> defaultNoteLocations = new TreeMap<>();
-    private Map<EntryKey, UUID> altNoteLocations = new TreeMap<>();
-    private Map<String, List<XMLEvent>> tagDefs = new TreeMap<>();
-    private String currentProp = null;
-    private Set<String> midSet = new java.util.HashSet<>();
+    private @Nullable String currentMid = null;
+    private final Map<String, StringBuffer> sdlComments = new TreeMap<>();
+    private @Nullable StringBuffer commentBuf = null;
+    private final Map<UUID, String> omegatNotes = new TreeMap<>();
+    private final Map<String, UUID> defaultNoteLocations = new TreeMap<>();
+    private final Map<EntryKey, UUID> altNoteLocations = new TreeMap<>();
+    private final Map<String, List<XMLEvent>> tagDefs = new TreeMap<>();
+    private @Nullable String currentProp = null;
+    private final Set<String> midSet = new java.util.HashSet<>();
     private boolean has_seg_defs = false;
     private boolean mid_has_modifier = false;
     private boolean mid_has_modif_date = false;
@@ -135,8 +138,7 @@ public class SdlXliff extends Xliff1Filter {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    protected boolean processStartElement(StartElement startElement, XMLStreamWriter writer)
+    protected boolean processStartElement(StartElement startElement, @Nullable XMLStreamWriter writer)
             throws XMLStreamException {
         if (startElement.getName().getLocalPart().equals("cmt-def")) {
             commentBuf = new StringBuffer();
@@ -152,11 +154,11 @@ public class SdlXliff extends Xliff1Filter {
                 String id = startElement
                         .getAttributeByName(new QName("http://sdl.com/FileTypes/SdlXliff/1.0", "cid"))
                         .getValue();
-                this.addNoteFromSource(currentMid, sdlComments.get(id).toString());
+                this.addNoteFromSource(Objects.requireNonNull(currentMid), sdlComments.get(id).toString());
             }
         }
         if (startElement.getName().getLocalPart().equals("tag")) {
-            currentBuffer = new java.util.LinkedList<XMLEvent>();
+            currentBuffer = new java.util.LinkedList<>();
             tagDefs.put(startElement.getAttributeByName(new QName("id")).getValue(), currentBuffer);
         }
         if (writer != null) {
@@ -194,7 +196,7 @@ public class SdlXliff extends Xliff1Filter {
     }
 
     @Override
-    protected boolean processEndElement(EndElement endElement, XMLStreamWriter writer)
+    protected boolean processEndElement(EndElement endElement, @Nullable XMLStreamWriter writer)
             throws XMLStreamException {
         if (endElement.getName().getLocalPart().equals("seg")) {
             if ((writer != null) && isCurrentSegmentTranslated(currentMid)) {
@@ -217,7 +219,7 @@ public class SdlXliff extends Xliff1Filter {
         }
         if (endElement.getName().getLocalPart().equals("trans-unit")) {
             if (writer != null) {
-                if ((midSet.size() > 0) && (!has_seg_defs)) {
+                if ((!midSet.isEmpty()) && (!has_seg_defs)) {
                     writer.writeStartElement("http://sdl.com/FileTypes/SdlXliff/1.0", "seg-defs");
                 }
                 for (String mid0 : midSet) { // those which were not generated
@@ -239,7 +241,7 @@ public class SdlXliff extends Xliff1Filter {
                     }
                     writer.writeEndElement(/* "sdl:seg */);
                 }
-                if ((midSet.size() > 0) && (!has_seg_defs)) {
+                if ((!midSet.isEmpty()) && (!has_seg_defs)) {
                     writer.writeEndElement(/* "sdl:seg-defs */);
                 }
             }
@@ -355,12 +357,12 @@ public class SdlXliff extends Xliff1Filter {
             writer.writeEndElement(/* Comments */);
             writer.writeEndElement(/* cmt-def */);
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.log(e);
         }
     }
 
     @Override
-    protected boolean processCharacters(Characters event, XMLStreamWriter writer) throws XMLStreamException {
+    protected boolean processCharacters(Characters event, @Nullable XMLStreamWriter writer) throws XMLStreamException {
         if (commentBuf != null) {
             commentBuf.append(event.getData());
             if ((writer != null) && isCurrentSegmentTranslated(currentMid)) {
@@ -393,11 +395,11 @@ public class SdlXliff extends Xliff1Filter {
             addNote = defaultNoteLocations.get(src);
         }
         if ((addNote != null) && (omegatNotes.get(addNote) != null)) {
-            List<Attribute> attr = new java.util.LinkedList<Attribute>();
+            List<Attribute> attr = new java.util.LinkedList<>();
             attr.add(eFactory.createAttribute("sdl", "http://sdl.com/FileTypes/SdlXliff/1.0", "cid",
                     addNote.toString()));
             attr.add(eFactory.createAttribute(new QName("mtype"), "x-sdl-comment"));
-            res.add(0, eFactory.createStartElement(new QName("urn:oasis:names:tc:xliff:document:1.2", "mrk"),
+            res.addFirst(eFactory.createStartElement(new QName("urn:oasis:names:tc:xliff:document:1.2", "mrk"),
                     attr.iterator(), null));
             res.add(eFactory.createEndElement(new QName("urn:oasis:names:tc:xliff:document:1.2", "mrk"),
                     null));
@@ -407,7 +409,7 @@ public class SdlXliff extends Xliff1Filter {
 
     /** Remove entries with only tags **/
     @Override
-    protected boolean isToIgnore(String src, String tra) {
+    protected boolean isToIgnore(String src, @Nullable String tra) {
         if (tra == null) {
             return false;
         }
@@ -417,7 +419,7 @@ public class SdlXliff extends Xliff1Filter {
         while (tra.startsWith("<")) {
             tra = tra.substring(Math.max(1, tra.indexOf(">") + 1));
         }
-        return (src.length() == 0) && (tra.length() == 0);
+        return (src.isEmpty()) && (tra.isEmpty());
     }
 
     @Override
@@ -446,7 +448,7 @@ public class SdlXliff extends Xliff1Filter {
                     } catch (Exception ignored) {
                     }
                 }
-                return base + ": " + writer.toString();
+                return base + ": " + writer;
             }
         }
         return base;

--- a/src/main/java/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -25,10 +25,14 @@
 
 package org.omegat.filters4.xml.xliff;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import javax.xml.namespace.QName;
@@ -41,6 +45,7 @@ import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.util.OStrings;
 
@@ -84,13 +89,13 @@ public class Xliff1Filter extends AbstractXliffFilter {
     private static final String TRANSLATED_STATE = "translated";
 
     /** Current translation unit **/
-    private String unitId = null;
+    private @Nullable String unitId = null;
     private boolean flushedUnit = false;
     private int lastGroupId = 0; // only used when group id is not present in
                                  // the file
     private final List<XMLEvent> segSource = new LinkedList<>();
     private final Map<String, List<XMLEvent>> subSegments = new TreeMap<>();
-    private StartElement targetStartEvent = null;
+    private @Nullable StartElement targetStartEvent = null;
     private int inSubSeg = 0;
 
     @Override
@@ -130,7 +135,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
     }
 
     @Override
-    protected boolean processStartElement(StartElement startElement, XMLStreamWriter writer)
+    protected boolean processStartElement(StartElement startElement, @Nullable XMLStreamWriter writer)
             throws XMLStreamException {
         switch (startElement.getName().getLocalPart()) {
         case "xliff":
@@ -189,11 +194,11 @@ public class Xliff1Filter extends AbstractXliffFilter {
         return !inTarget;
     }
 
-    private void handleMrkElement(StartElement element, XMLStreamWriter writer) throws XMLStreamException {
+    private void handleMrkElement(StartElement element, @Nullable XMLStreamWriter writer) throws XMLStreamException {
         if (element.getAttributeByName(new QName("mtype")).getValue().equals("seg")) {
             String mid = element.getAttributeByName(new QName("mid")).getValue();
-            currentBuffer.add(element);
-            currentBuffer = new LinkedList<>();
+            Objects.requireNonNull(currentBuffer).add(element);
+            currentBuffer = new ArrayList<>();
             if (!inTarget) {
                 subSegments.put(mid, currentBuffer);
             }
@@ -216,7 +221,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
         return attribute.getValue();
     }
 
-    private void handleDefaultElement(StartElement element, XMLStreamWriter writer)
+    private void handleDefaultElement(StartElement element, @Nullable XMLStreamWriter writer)
             throws XMLStreamException {
         if (currentBuffer != null) {
             currentBuffer.add(element);
@@ -233,7 +238,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
     }
 
     @Override
-    protected boolean processEndElement(EndElement endElement, XMLStreamWriter writer)
+    protected boolean processEndElement(EndElement endElement, @Nullable XMLStreamWriter writer)
             throws XMLStreamException {
         switch (endElement.getName().getLocalPart()) {
         case SOURCE_ELEMENT:
@@ -277,17 +282,17 @@ public class Xliff1Filter extends AbstractXliffFilter {
         }
     }
 
-    private void handleTransUnitEndElement(EndElement endElement, XMLStreamWriter writer) throws XMLStreamException {
+    private void handleTransUnitEndElement(EndElement endElement, @Nullable XMLStreamWriter writer) throws XMLStreamException {
         if (ignoreScope == null || ignoreScope.startsWith("!")) {
             flushTranslations(writer); // if there was no <target> at all
         }
         if (ignoreScope == null || ignoreScope.startsWith("!")) {
             if (subSegments.isEmpty()) {
-                registerCurrentTransUnit(unitId, source, target, ".*");
+                registerCurrentTransUnit(Objects.requireNonNull(unitId), source, target, ".*");
             } else {
                 for (Map.Entry<String, List<XMLEvent>> me : subSegments.entrySet()) {
                     registerCurrentTransUnit(unitId + "/" + me.getKey(), me.getValue(),
-                            findSubsegment(target, me.getKey()), "\\[(\\d+)\\](.*)\\[\\1\\]");
+                            findSubsegment(Objects.requireNonNull(target), me.getKey()), "\\[(\\d+)\\](.*)\\[\\1\\]");
                 }
             }
         }
@@ -314,8 +319,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
 
     private void handleMrkEndElement(EndElement endElement) {
         if (inSubSeg == 1) {
-            List<XMLEvent> save = inTarget ? target : segSource;
-            save.addAll(currentBuffer);
+            List<XMLEvent> save = inTarget ? Objects.requireNonNull(target) : segSource;
+            save.addAll(Objects.requireNonNull(currentBuffer));
             currentBuffer = save;
             currentBuffer.add(endElement);
             inSubSeg = 0;
@@ -343,7 +348,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
         return new String[] { "rid", "id", "i" };
     }
 
-    protected boolean isCurrentSegmentTranslated(String mid) {
+    protected boolean isCurrentSegmentTranslated(@Nullable String mid) {
         if ((entryTranslateCallback == null) || (mid == null)) {
             return false;
         }
@@ -364,8 +369,8 @@ public class Xliff1Filter extends AbstractXliffFilter {
             tagsMap.clear();
             tagsCount.replaceAll((c, v) -> 0);
         }
-        StringBuffer res = new StringBuffer();
-        LinkedList<StringBuffer> saveBuf = new LinkedList<>();
+        StringBuilder res = new StringBuilder();
+        Deque<StringBuilder> saveBuf = new ArrayDeque<>();
         List<XMLEvent> nativeCode = null;
         for (XMLEvent ev : srcList) {
             if (nativeCode != null) {
@@ -398,14 +403,14 @@ public class Xliff1Filter extends AbstractXliffFilter {
                     nativeCode = new LinkedList<>();
                     res.append(startPair(reuse, false, stEl, prefix, count, nativeCode));
                     saveBuf.push(res);
-                    res = new StringBuffer();
+                    res = new StringBuilder();
                     nativeCode.add(ev);
                     break;
                 case "ept": // paired native code, end
                     nativeCode = new LinkedList<>();
                     res.append(endPair(reuse, stEl, prefix, count, nativeCode));
                     saveBuf.push(res);
-                    res = new StringBuffer();
+                    res = new StringBuilder();
                     nativeCode.add(ev);
                     break;
                 default: // g, mrk, ph, it and other-namespace
@@ -433,7 +438,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
                             }
                         }
                         saveBuf.push(res);
-                        res = new StringBuffer();
+                        res = new StringBuilder();
                         nativeCode.add(ev);
                         tagStack.push("mark-protected");
                         break;
@@ -441,7 +446,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
                         // generate nothing, not either the contents
                         tagStack.push("mark-deleted");
                         saveBuf.add(res);
-                        res = new StringBuffer();
+                        res = new StringBuilder();
                         break;
                     } else if (isUntaggedTag(stEl)) {
                         tagStack.push("mark-ignored");
@@ -504,14 +509,16 @@ public class Xliff1Filter extends AbstractXliffFilter {
         }
 
         String name = stEl.getName().getLocalPart();
-        if (name.equals("bx") || name.equals("ex")) {
-            return 'e';
-        }
-        if (name.equals("bpt") || name.equals("ept")) {
-            return 't';
-        }
-        if (name.equals("it")) {
-            return 'a'; // alone
+        switch (name) {
+            case "bx", "ex" -> {
+                return 'e';
+            }
+            case "bpt", "ept" -> {
+                return 't';
+            }
+            case "it" -> {
+                return 'a'; // alone
+            }
         }
         if (!stEl.getName().getNamespaceURI().equals(this.namespace)) {
             return 'o'; // other: not conform to spec, but may happen
@@ -549,7 +556,6 @@ public class Xliff1Filter extends AbstractXliffFilter {
         return true;
     }
 
-    @SuppressWarnings("unchecked")
     protected final void generateTargetStartElement(XMLStreamWriter writer) throws XMLStreamException {
         if (!isStandardTranslationState()) {
             writeDefaultTarget(writer);
@@ -599,7 +605,7 @@ public class Xliff1Filter extends AbstractXliffFilter {
     }
 
     /** Replace <target> by OmegaT's translation, if found **/
-    private void flushTranslations(XMLStreamWriter writer) throws XMLStreamException {
+    private void flushTranslations(@Nullable XMLStreamWriter writer) throws XMLStreamException {
         if (writer == null) {
             return; // we are only reading the source file
         }
@@ -646,14 +652,14 @@ public class Xliff1Filter extends AbstractXliffFilter {
                                 tra = entryTranslateCallback.getTranslation(unitId + "/" + mid, src, path);
                             }
                             if (tra != null) {
-                                for (XMLEvent tev : restoreTags(unitId, path, src, tra)) {
+                                for (XMLEvent tev : restoreTags(Objects.requireNonNull(unitId), path, src, tra)) {
                                     fromEventToWriter(tev, writer);
                                 }
                             } else {
                                 // Second, check in the target buffer
                                 // (translation in source file)
                                 List<XMLEvent> fromTarget = findSubsegment(target, mid);
-                                if (fromTarget != null && !fromTarget.isEmpty()) {
+                                if (!fromTarget.isEmpty()) {
                                     for (XMLEvent tev : fromTarget) {
                                         fromEventToWriter(tev, writer);
                                     }
@@ -702,14 +708,14 @@ public class Xliff1Filter extends AbstractXliffFilter {
      * Extracts from <seg-source> or <target> the part between
      * <mrk type=seg mid=xxx> and </mrk>
      **/
-    private List<XMLEvent> findSubsegment(List<XMLEvent> list, String mid) {
+    private List<XMLEvent> findSubsegment(@Nullable List<XMLEvent> list, String mid) {
         if (list == null || list.isEmpty()) {
             return Collections.emptyList();
         }
 
-        List<XMLEvent> buf = new LinkedList<>();
+        List<XMLEvent> buf = new ArrayList<>();
         int depth = 0;
-        for (XMLEvent ev : target) {
+        for (XMLEvent ev : Objects.requireNonNull(target)) {
             if (ev.isEndElement()) {
                 EndElement el = ev.asEndElement();
                 if (el.getName().getLocalPart().equals("mrk")) {

--- a/src/main/java/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -25,9 +25,10 @@
 
 package org.omegat.filters4.xml.xliff;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import javax.xml.namespace.QName;
@@ -38,6 +39,7 @@ import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.util.OStrings;
 
@@ -93,12 +95,13 @@ public class Xliff2Filter extends AbstractXliffFilter {
     }
 
     /** Current translation unit **/
-    private String segId = null;
+    private @Nullable String segId = null;
     private boolean flushedSegment = false;
 
     @Override
-    protected boolean processStartElement(StartElement startElement, XMLStreamWriter writer)
+    protected boolean processStartElement(StartElement startElement, @Nullable XMLStreamWriter writer)
             throws XMLStreamException {
+        Attribute idAttr;
         switch (startElement.getName().getLocalPart()) {
         case "xliff":
             if (namespace == null) {
@@ -108,7 +111,7 @@ public class Xliff2Filter extends AbstractXliffFilter {
         case "file":
         case "group":
         case "unit":
-            Attribute idAttr = startElement.getAttributeByName(new QName(("id")));
+            idAttr = startElement.getAttributeByName(new QName(("id")));
             if (idAttr != null) {
                 path += "/" + idAttr.getValue();
             } else {
@@ -137,7 +140,7 @@ public class Xliff2Filter extends AbstractXliffFilter {
             source.clear();
             break;
         case "target":
-            target = new LinkedList<XMLEvent>();
+            target = new ArrayList<>();
             currentBuffer = target;
             inTarget = true;
             break;
@@ -166,7 +169,7 @@ public class Xliff2Filter extends AbstractXliffFilter {
     }
 
     @Override
-    protected boolean processEndElement(EndElement endElement, XMLStreamWriter writer)
+    protected boolean processEndElement(EndElement endElement, @Nullable XMLStreamWriter writer)
             throws XMLStreamException {
         switch (endElement.getName().getLocalPart()) {
         case "source":
@@ -185,7 +188,7 @@ public class Xliff2Filter extends AbstractXliffFilter {
                 flushTranslations(writer); // if there was no <target> at all
             }
             if (ignoreScope == null || ignoreScope.startsWith("!")) {
-                registerCurrentTransUnit(segId, source, target, ".*");
+                registerCurrentTransUnit(Objects.requireNonNull(segId), source, target, ".*");
             }
             segId = null;
             cleanBuffers();
@@ -227,11 +230,9 @@ public class Xliff2Filter extends AbstractXliffFilter {
     protected String buildTags(List<XMLEvent> srcList, boolean reuse) {
         if (!reuse) {
             tagsMap.clear();
-            for (Character c : tagsCount.keySet()) {
-                tagsCount.put(c, 0);
-            }
+            tagsCount.replaceAll((c, v) -> 0);
         }
-        StringBuffer res = new StringBuffer();
+        StringBuilder res = new StringBuilder();
         for (XMLEvent ev : srcList) {
             if (ev.isCharacters()) {
                 res.append(ev.asCharacters().getData());
@@ -297,14 +298,16 @@ public class Xliff2Filter extends AbstractXliffFilter {
                         // don't know which one
         }
         String name = stEl.getName().getLocalPart();
-        if (name.equals("pc")) {
-            return 'g';
-        }
-        if (name.equals("sc") || name.equals("ec")) {
-            return 't';
-        }
-        if (name.equals("sm") || name.equals("em")) {
-            return 'a';
+        switch (name) {
+            case "pc" -> {
+                return 'g';
+            }
+            case "sc", "ec" -> {
+                return 't';
+            }
+            case "sm", "em" -> {
+                return 'a';
+            }
         }
         if (!stEl.getName().getNamespaceURI().equals(this.namespace)) {
             return 'o'; // other (normally not allowed by specification)
@@ -314,7 +317,7 @@ public class Xliff2Filter extends AbstractXliffFilter {
     }
 
     /** Replace <target> by OmegaT's translation, if found **/
-    private void flushTranslations(XMLStreamWriter writer) throws XMLStreamException {
+    private void flushTranslations(@Nullable XMLStreamWriter writer) throws XMLStreamException {
         if (writer == null) {
             return;
         }


### PR DESCRIPTION
Refactor for null safety

## Pull request type
- refactor

## Which ticket is resolved?
None; preparation for enforcing nullaway check

## What does this PR change?
- add `@Nullable` annotation to fields, arguments and methods
- Replace legacy LinkedList with ArrayList or ArrayDeque
- Add `Objects.requireNotNull()` guard where the parameter should be non-null but provide nullable field
- Replace legacy StringBuffer with StringBuilder
- Use `isEmpty()` where usable
- replace `e.printStackTrace()`` with `Log.log()`
- Use advanced switch where applicable

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
