### PR TITLE
docs(adr): propose number-only segment auto-conversion architecture (RFE-794)

### DIFF
--- a/src/docs/developer/adr/2026007.NumberOnlyAutofill.md
+++ b/src/docs/developer/adr/2026007.NumberOnlyAutofill.md
@@ -1,0 +1,40 @@
+# ADR 2026007: Number-Only Segment Auto-Conversion
+
+## Status
+
+Proposed. Engine and marking implemented, window pending.
+
+- Feature request: https://sourceforge.net/p/omegat/feature-requests/794/ ("Auto fill 'number only' segments")
+- Builds on ADR 2025002 (CoreState singleton seam).
+
+## Context
+
+RFE #794: fill and mark segments whose source is number only, so translators need not confirm each cell and "skip to next untranslated" passes over them. Widened scope:
+
+- All writing and numbering systems, not just Western digits.
+- Parse value in source locale, re-render in target locale: integer, decimal, grouping, percent, currency, date, time, ordinal.
+- Dedicated window modeled on Issues window: data-type checklist, scope selector, results table with per-row accept checkbox, minimum-confidence threshold.
+- Mark applied conversions with distinct external tag, recognizable and skippable.
+
+## Decision
+
+1. **Numeral foundation.** Integer recognition across writing systems delegated to `org.omegat.util.NumeralValueParser` (ICU-based).
+2. **Engine.** Stateless, GUI-free `org.omegat.util.NumberAutoConverter`. `convert(source, sourceLocale, targetLocale, types)` returns confidence-ranked `Conversion{type, target, confidence}` list; empty list means source is not number-only for any enabled type.
+   - Number-only gate: type reported only when strict parser consumes entire cleaned source; surrounding prose disqualifies segment.
+   - Normalization: format controls (bidi marks, zero-width and no-break spaces) stripped, whitespace folded. Numeric paths additionally use NFKC-folded form (full-width digits, percent signs); ordinal path uses unfolded form because NFKC destroys Spanish/Italian ordinal indicator (`º` → `o`).
+   - Ordinals recognized via ICU rule-based ordinal formatter in source locale; bare digit run never ordinal; parsed value below 1 rejected. Result: `3.` ordinal in German, decimal in English.
+   - Confidence: unambiguous forms high (INTEGER 0.9, PERCENT 0.85, ISO DATE 0.8), ambiguous forms low (localized numeric DATE 0.55). Ambiguity surfaces as multiple candidates; window resolves, never silent guessing.
+3. **Marking.** Applied conversions registered via `Core.getProject().setTranslation(...)` with new `TMXEntry.ExternalLinked` value `xNUMBER`, persisted as TMX property `x-number`, gated by `SAVE_AUTO_STATUS` exactly like `x-auto`. Own marker color `COLOR_MARK_COMES_FROM_TM_XNUMBER` (light and dark schemes) via `ComesFromAutoTMMarker`. Round-trip test pins persisted and gated-off behavior.
+4. **Window (planned).** Modeled on `org.omegat.gui.issues`: provider selector → scan → results table with editable accept column → preview split panel; row click jumps to segment.
+
+## Documented limits
+
+- Ordinals ICU cannot parse per locale yield no conversion (pinned by tests): Italian `1º`, Finnish `3:s`, Greek `3ος`, CJK `第三`, French `2ème`.
+- No scientific notation.
+- Currency re-formats grouping/placement only; no exchange conversion.
+- Date rendering uses target-locale MEDIUM style; style choice open follow-up.
+
+## Alternatives considered
+
+- Reuse round-tripped `origin` property instead of new `ExternalLinked` value: less plumbing, no distinct marker — rejected.
+- Trailing-punctuation heuristic for ordinal/integer boundary: rejected after multi-perspective review. Findings: multi-character suffixes (`1st`, `1er`, `1.º`) missed by single-character stripping; Finnish/Swedish infix colon (`3:s`) and CJK prefix (`第三`) structurally invisible to last-character tests; trailing bidi controls and NBSP break naive checks (NFKC must precede strip); dot-means-ordinal assumption misreads English `3.`; Arabic percent sign `٪` (U+066A) needs explicit handling. Locale-driven ICU design above resolves all; unsupported cases recorded as limits.

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -20,6 +20,10 @@
 
 - 2026001 [Glossary Search and Sort Implementation](2026001.GlossarySearchAndSort.md)
 
+### Numbers and Numerals
+
+- 2026007 [Number-Only Segment Auto-Conversion](2026007.NumberOnlyAutofill.md)
+
 ### Filters
 
 - 2025009 [Yaml Filter Specification](2025009.YAMLFilterSpecification.md) 


### PR DESCRIPTION
## Pull request type

Please mark github LABEL of the type of change your PR introduces:

- Documentation -> [documentation]

## Which ticket is resolved?

- Auto fill "number only" segments
  * https://sourceforge.net/p/omegat/feature-requests/794/

## What does this PR change?

- Add ADR 2026007: engine, marking and planned window for number-only segment auto-conversion.
- Split out of #2159 per review for separate dev-list discussion.

## Other information
