### PR TITLE
fix(gui): stop menu hover from parsing the current source file

### DIFF
--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -55,13 +55,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
 import javax.swing.JMenu;
 import javax.xml.stream.XMLStreamException;
+
+import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
 
 import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.Nullable;
@@ -207,6 +215,62 @@ public class RealProject implements IProject {
 
     /** Segments count in project files. */
     protected List<FileInfo> projectFilesList = new ArrayList<>();
+
+    /**
+     * Source path to target path, as computed by
+     * {@link #getTargetPathForSourceFile(String)}. Selecting the filter that
+     * determines a target path can require parsing the source file, so
+     * callers must not recompute it on every call. JCache layer (Caffeine)
+     * bounds cache by size and age; cleared on project close and when
+     * another {@link FilterMaster} instance gets installed, see
+     * {@link #cacheSource}. Key includes source root, so an in-flight lookup
+     * of a closed project cannot leak its target path into the next one.
+     * Lazy holder keeps a JCache provider failure out of RealProject class
+     * init.
+     */
+    private static final class TargetPathCache {
+        private static final String NAME = "realProjectTargetPath";
+        private static final int SIZE = 1_000;
+        static final Cache<String, String> CACHE = create();
+
+        /**
+         * FilterMaster instance {@link #CACHE} was computed against. Editing
+         * filter preferences installs a new instance without firing a project
+         * event or forcing a reload (FiltersCustomizerController#persist), so
+         * cache empties itself when instance changed.
+         */
+        private static volatile @Nullable FilterMaster cacheSource;
+
+        static void ensureSource(FilterMaster filterMaster) {
+            if (filterMaster != cacheSource) {
+                CACHE.clear();
+                cacheSource = filterMaster;
+            }
+        }
+
+        static boolean isSource(FilterMaster filterMaster) {
+            return filterMaster == cacheSource;
+        }
+
+        private static Cache<String, String> create() {
+            CacheManager manager = Caching.getCachingProvider().getCacheManager();
+            Cache<String, String> cache = manager.getCache(NAME);
+            if (cache == null) {
+                CaffeineConfiguration<String, String> cacheConfig = new CaffeineConfiguration<>();
+                cacheConfig.setExpiryPolicyFactory(() -> new CreatedExpiryPolicy(Duration.ONE_DAY));
+                cacheConfig.setMaximumSize(OptionalLong.of(SIZE));
+                cache = manager.createCache(NAME, cacheConfig);
+            }
+            Cache<String, String> created = cache;
+            CoreEvents.registerProjectChangeListener(eventType -> {
+                if (eventType == IProjectEventListener.PROJECT_CHANGE_TYPE.CLOSE) {
+                    created.clear();
+                    cacheSource = null;
+                }
+            });
+            return cache;
+        }
+    }
 
     private final boolean allowTranslationEqualToSource = Preferences
             .isPreference(Preferences.ALLOW_TRANS_EQUAL_TO_SRC);
@@ -1671,9 +1735,22 @@ public class RealProject implements IProject {
         if (StringUtil.isEmpty(currentSource)) {
             return null;
         }
+        FilterMaster filterMaster = Core.getFilterMaster();
+        TargetPathCache.ensureSource(filterMaster);
+        String cacheKey = config.getSourceRoot() + '\0' + currentSource;
+        String cached = TargetPathCache.CACHE.get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
         try {
-            return Core.getFilterMaster().getTargetForSource(config.getSourceRoot(), currentSource,
+            String target = filterMaster.getTargetForSource(config.getSourceRoot(), currentSource,
                     new FilterContext(config));
+            // Recheck keeps a value computed under a replaced FilterMaster
+            // out of the fresh cache.
+            if (target != null && TargetPathCache.isSource(filterMaster)) {
+                TargetPathCache.CACHE.put(cacheKey, target);
+            }
+            return target;
         } catch (Exception e) {
             Log.log(e);
         }

--- a/src/main/java/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/main/java/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -45,6 +45,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,6 +58,7 @@ import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.KeyStroke;
+import javax.swing.SwingWorker;
 import javax.swing.UIManager;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
@@ -66,6 +68,8 @@ import org.openide.awt.Mnemonics;
 
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
+import org.omegat.core.data.IProject;
+import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.events.IApplicationEventListener;
 import org.omegat.gui.editor.EditorSettings;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
@@ -114,6 +118,12 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
 
     /** MainWindow menu handler instance. */
     protected final BaseMainWindowMenuHandler mainWindowMenuHandler;
+
+    /**
+     * Distinguishes the latest enablement check of the access-project-files
+     * menu from superseded ones. Only touched on the EDT.
+     */
+    private int projectAccessDocumentsGeneration;
 
     public BaseMainWindowMenu(final IMainWindow mainWindow,
             final BaseMainWindowMenuHandler mainWindowMenuHandler) {
@@ -663,19 +673,48 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         projectAccessProjectFilesMenu.addMenuListener(new MenuListener() {
             @Override
             public void menuSelected(MenuEvent e) {
-                if (Core.getProject().isProjectLoaded()) {
-                    String sourcePath = Core.getEditor().getCurrentFile();
-                    projectAccessCurrentSourceDocumentMenuItem.setEnabled(!StringUtil.isEmpty(sourcePath)
-                            && new File(Core.getProject().getProjectProperties().getSourceRoot(), sourcePath)
-                                    .isFile());
-                    String targetPath = Core.getEditor().getCurrentTargetFile();
-                    projectAccessCurrentTargetDocumentMenuItem.setEnabled(!StringUtil.isEmpty(targetPath)
-                            && new File(Core.getProject().getProjectProperties().getTargetRoot(), targetPath)
-                                    .isFile());
-                    String glossaryPath = Core.getProject().getProjectProperties().getWriteableGlossary();
-                    projectAccessWriteableGlossaryMenuItem
-                            .setEnabled(!StringUtil.isEmpty(glossaryPath) && new File(glossaryPath).isFile());
+                IProject project = Core.getProject();
+                if (!project.isProjectLoaded()) {
+                    return;
                 }
+                ProjectProperties props = project.getProjectProperties();
+                String sourcePath = Core.getEditor().getCurrentFile();
+                int generation = ++projectAccessDocumentsGeneration;
+                new SwingWorker<boolean[], Void>() {
+                    @Override
+                    protected boolean[] doInBackground() {
+                        // Resolving the target path can require parsing the
+                        // source file to select a filter, and existence checks
+                        // can hit slow storage; keep both off the EDT.
+                        boolean source = !StringUtil.isEmpty(sourcePath)
+                                && new File(props.getSourceRoot(), sourcePath).isFile();
+                        String targetPath = sourcePath == null ? null
+                                : project.getTargetPathForSourceFile(sourcePath);
+                        boolean target = !StringUtil.isEmpty(targetPath)
+                                && new File(props.getTargetRoot(), targetPath).isFile();
+                        String glossaryPath = props.getWriteableGlossary();
+                        boolean glossary = !StringUtil.isEmpty(glossaryPath)
+                                && new File(glossaryPath).isFile();
+                        return new boolean[] { source, target, glossary };
+                    }
+
+                    @Override
+                    protected void done() {
+                        if (generation != projectAccessDocumentsGeneration || Core.getProject() != project) {
+                            // a newer check was started or the project changed
+                            // in the meantime
+                            return;
+                        }
+                        try {
+                            boolean[] exists = get();
+                            projectAccessCurrentSourceDocumentMenuItem.setEnabled(exists[0]);
+                            projectAccessCurrentTargetDocumentMenuItem.setEnabled(exists[1]);
+                            projectAccessWriteableGlossaryMenuItem.setEnabled(exists[2]);
+                        } catch (InterruptedException | ExecutionException ex) {
+                            Log.log(ex);
+                        }
+                    }
+                }.execute();
             }
 
             @Override

--- a/src/test/java/org/omegat/core/data/RealProjectTest.java
+++ b/src/test/java/org/omegat/core/data/RealProjectTest.java
@@ -32,11 +32,15 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+import javax.swing.SwingUtilities;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -44,9 +48,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.omegat.core.Core;
+import org.omegat.core.CoreEvents;
+import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.segmentation.SRX;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.filters2.text.TextFilter;
 import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.filters.Filters;
 
 /**
  * Tests for RealProject classs.
@@ -65,6 +75,8 @@ public class RealProjectTest {
         Core.initializeConsole();
         TestPreferencesInitializer.init();
         Core.initializeConsole();
+        FilterMaster.setFilterClasses(Collections.singletonList(TextFilter.class));
+        Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
     }
 
     @After
@@ -301,6 +313,50 @@ public class RealProjectTest {
         tr.source = source;
         tr.translation = translation;
         return tr;
+    }
+
+    /**
+     * The target path lookup can parse the source file to select a filter, so
+     * RealProject must answer repeated calls from a cache.
+     */
+    @Test
+    public void testGetTargetPathForSourceFileIsCached() throws Exception {
+        createProject(true);
+        project.getProjectProperties().setSourceLanguage("en");
+        project.getProjectProperties().setTargetLanguage("fr");
+        File sourceDir = new File(project.getProjectProperties().getSourceRoot());
+        assertTrue(sourceDir.isDirectory() || sourceDir.mkdirs());
+        Files.write(sourceDir.toPath().resolve("cached.txt"),
+                "Probe sentence for the filter lookup.".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals("cached.txt", project.getTargetPathForSourceFile("cached.txt"));
+
+        // Deleting the source file makes a fresh lookup impossible, so a
+        // repeated answer proves it comes from the cache.
+        Files.delete(sourceDir.toPath().resolve("cached.txt"));
+        assertEquals("cached.txt", project.getTargetPathForSourceFile("cached.txt"));
+        assertNull(project.getTargetPathForSourceFile("uncached.txt"));
+
+        // Project close event must empty the cache; a fresh lookup on the
+        // deleted file then answers null.
+        CoreEvents.fireProjectChange(IProjectEventListener.PROJECT_CHANGE_TYPE.CLOSE);
+        SwingUtilities.invokeAndWait(() -> { });
+        assertNull(project.getTargetPathForSourceFile("cached.txt"));
+
+        // Re-prime the cache for the FilterMaster part.
+        Files.write(sourceDir.toPath().resolve("cached.txt"),
+                "Probe sentence for the filter lookup.".getBytes(StandardCharsets.UTF_8));
+        assertEquals("cached.txt", project.getTargetPathForSourceFile("cached.txt"));
+        Files.delete(sourceDir.toPath().resolve("cached.txt"));
+        assertEquals("cached.txt", project.getTargetPathForSourceFile("cached.txt"));
+
+        // Installing another FilterMaster instance must empty the cache.
+        try {
+            Core.setFilterMaster(new FilterMaster(new Filters()));
+            assertNull(project.getTargetPathForSourceFile("cached.txt"));
+        } finally {
+            Core.setFilterMaster(new FilterMaster(FilterMaster.createDefaultFiltersConfig()));
+        }
     }
 
     /**


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- (no SourceForge ticket; found during development)

## What does this PR change?

- Run enablement checks of the access-project-contents submenu in a SwingWorker instead of the EDT; the target-path lookup there can parse the whole current source file (XHTML for example) and froze the UI on every hover.
- Cache source-to-target path mapping in RealProject, invalidated when another FilterMaster instance is installed.
- Add RealProjectTest coverage for cache hit and invalidation.

## Other information

First hover after project load shows previous enablement until the background check finishes; clicking a stale entry degrades to the existing status-bar message.
