### PR TITLE
[6.1] fix(core): tolerate unknown elements in the project file parser

### DIFF
--- a/src/org/omegat/util/ProjectFileStorage.java
+++ b/src/org/omegat/util/ProjectFileStorage.java
@@ -43,6 +43,7 @@ import javax.xml.stream.XMLInputFactory;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -90,8 +91,12 @@ public final class ProjectFileStorage {
         // https://sourceforge.net/p/omegat/bugs/1170/
         xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.TRUE);
         XmlFactory xmlFactory = new XmlFactory(xmlInputFactory);
+        // Tolerate unknown elements: a project file written by a newer
+        // OmegaT with an extended schema must stay readable, otherwise one
+        // team member on a newer version locks the whole team out.
         mapper = XmlMapper.builder(xmlFactory).defaultUseWrapper(false)
-                .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).build();
+                .enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
         mapper.registerModule(new JakartaXmlBindAnnotationModule());
         SimpleModule module = new SimpleModule();
         TypeFactory typeFactory = mapper.getTypeFactory();

--- a/test/src/org/omegat/util/ProjectFileStorageTest.java
+++ b/test/src/org/omegat/util/ProjectFileStorageTest.java
@@ -33,6 +33,7 @@ import static org.xmlunit.assertj3.XmlAssert.assertThat;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -77,6 +78,25 @@ public class ProjectFileStorageTest {
     @After
     public final void tearDown() throws Exception {
         FileUtils.deleteDirectory(tempDir);
+    }
+
+    @Test
+    public void testUnknownElementsAreTolerated() throws Exception {
+        // A project file written by a newer OmegaT with an extended schema
+        // must stay readable; failing on unknown elements would let one
+        // team member on a newer version lock the whole team out.
+        ProjectProperties props = getProjectProperties();
+        props.setSourceLanguage("de-CH");
+        ProjectFileStorage.writeProjectFile(props);
+        File projectFile = new File(tempDir, OConsts.FILE_PROJECT);
+        String xml = Files.readString(projectFile.toPath(), StandardCharsets.UTF_8);
+        xml = xml.replace("</project>",
+                "  <setting_of_a_future_version>x</setting_of_a_future_version>\n  </project>");
+        Files.writeString(projectFile.toPath(), xml, StandardCharsets.UTF_8);
+
+        ProjectProperties reread = ProjectFileStorage.loadPropertiesFile(tempDir, projectFile);
+        assertEquals("known fields must survive the tolerant parse", "de-CH",
+                reread.getSourceLanguage().toString());
     }
 
     @Test


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Backport of #2274 to `releases/6.1`

## What does this PR change?

- Disables `FAIL_ON_UNKNOWN_PROPERTIES` in project file parser so `omegat.project` files containing unknown elements written by newer versions or other tools still open.
- Adds test covering unknown element tolerance.

## Other information

Cherry-pick of 573005fb1; base branch `releases/6.1`.
see also #2274