### PR TITLE
feat(matches): character equivalence classes in fuzzy matching and search (SF-RFE-1681)

### DIFF
--- a/src/docs/manual/en/Dialogs_ProjectProperties.xml
+++ b/src/docs/manual/en/Dialogs_ProjectProperties.xml
@@ -196,23 +196,43 @@
                </note>
             </listitem>
          </varlistentry>
-         <varlistentry xml:id="dialogs.project.properties.match.numbers">
-            <term xml:id="dialogs.project.properties.match.numbers.title">
-               <option>Consider numbers in fuzzy matching</option>
+         <varlistentry xml:id="dialogs.project.properties.match.equivalence">
+            <term xml:id="dialogs.project.properties.match.equivalence.title">
+               <option>Character equivalence...</option>
             </term>
             <listitem>
-               <para>By default, the word-based match percentages ignore numbers, and
-                  		  a segment that consists only of numbers (a date, a bare quantity)
-                  		  scores too low against a segment with different numbers to be
-                  		  offered as a match.</para>
-               <para>Activating this option makes fuzzy matching compare number
-                  		  tokens by their numeric value: numbers written in different
-                  		  numbering systems (Roman numerals, ideographic numbers,
-                  		  Arabic-Indic or full-width digits, and so on) count as equal to
-                  		  their Western counterpart of the same value. Two segments that
-                  		  consist only of numbers are scored against each other as number
-                  		  sequences, with a small fixed penalty, so differing dates or bare
-                  		  numbers surface as fuzzy matches at all.</para>
+               <para>Opens a dialog with the character equivalence classes used by
+                  		  fuzzy matching and search: quote, dash, space and
+                  		  invisible-format variants fold onto each other. Each class
+                  		  lists its complete character inventory, a test area compares
+                  		  two sample texts with the current selection, and the dialog
+                  		  also holds the number matching option described below.</para>
+            </listitem>
+         </varlistentry>
+         <varlistentry xml:id="dialogs.project.properties.match.numbers">
+            <term xml:id="dialogs.project.properties.match.numbers.title">
+               <option>Number value equality</option>
+            </term>
+            <listitem>
+               <para>This option is part of the equivalence dialog opened with the
+                  		  <option>Character equivalence...</option> button. It is active
+                  		  by default.</para>
+               <para>While active, fuzzy matching compares number tokens by their
+                  		  numeric value: numbers written in different numbering systems
+                  		  (ideographic numbers, Arabic-Indic or full-width digits, and so
+                  		  on) count as equal to their Western counterpart of the same
+                  		  value. Two segments that consist only of numbers are scored
+                  		  against each other as number sequences, with a small fixed
+                  		  penalty, so differing dates or bare numbers surface as fuzzy
+                  		  matches at all. Roman numerals written with Latin letters are
+                  		  only read as numbers when the indented sub-option is also
+                  		  activated (off by default, since ordinary words such as
+                  		  <literal>I</literal> or <literal>MIX</literal> read as Roman
+                  		  numerals too).</para>
+               <para>Deactivated, the word-based match percentages ignore numbers,
+                  		  and a segment that consists only of numbers (a date, a bare
+                  		  quantity) scores too low against a segment with different
+                  		  numbers to be offered as a match.</para>
                <para>The setting is stored in the project and applies to everyone
                   		  working on it. Hover over a match in the
                   <link linkend="panes.fuzzy.matches" endterm="panes.fuzzy.matches.title"></link> pane to see how its score was

--- a/src/docs/tips/de/fuzzy_match_numbers.html
+++ b/src/docs/tips/de/fuzzy_match_numbers.html
@@ -34,15 +34,17 @@
 anderen Zahlen: &bdquo;Mit 12&nbsp;Nm anziehen&ldquo; und &bdquo;Mit
 8&nbsp;Nm anziehen&ldquo; &ndash; und reine Zahlensegmente (Datum, Betrag)
 finden normalerweise gar keinen unscharfen Treffer.</p>
-<p><b>Zahlen bei unscharfen Treffern berücksichtigen</b> in den
-Projekteigenschaften lässt das Fuzzy-Matches-Fenster Zahlen nach Wert
+<p><b>Zahlen-Wertgleichheit</b> &ndash;
+standardmäßig aktiv, hinter dem Knopf <b>Zeichen-Äquivalenz...</b> der
+Projekteigenschaften &ndash; lässt das Fuzzy-Matches-Fenster Zahlen nach Wert
 vergleichen:</p>
 <ul>
 <li>Reine Zahlensegmente (Daten, Mengen, Preise) treffen einander, mit
 kleinem Abzug.</li>
-<li>Gleicher Wert zählt über Schriftsysteme hinweg als gleich: XIV,
+<li>Gleicher Wert zählt über Schriftsysteme hinweg als gleich:
 &#21313;&#22235;, &#1633;&#1636; und die vollbreite &#65297;&#65300; sind
-alle 14.</li>
+alle 14. Römische Zahlen aus lateinischen Buchstaben (XIV) kommen über eine
+Opt-in-Unteroption dazu.</li>
 <li>Ein Tooltip zeigt die Berechnung und warnt, wenn die Zahlen des Treffers
 vom Segment abweichen &ndash; keine falsche Zahl rutscht unbemerkt durch.</li>
 </ul>

--- a/src/docs/tips/en/fuzzy_match_numbers.html
+++ b/src/docs/tips/en/fuzzy_match_numbers.html
@@ -34,14 +34,16 @@
 numbers: "Tighten to 12&nbsp;Nm" and "Tighten to 8&nbsp;Nm" &mdash; and
 number-only segments (a date, an amount) normally find no fuzzy match at
 all.</p>
-<p><b>Consider numbers in fuzzy matching</b> in the project properties makes
-the Fuzzy Matches pane compare numbers by value:</p>
+<p><b>Number value equality</b> &mdash; active by
+default, behind the <b>Character equivalence...</b> button of the project
+properties &mdash; makes the Fuzzy Matches pane compare numbers by value:</p>
 <ul>
 <li>Number-only segments (dates, quantities, prices) match each other, with a
 small penalty.</li>
-<li>Equal value counts as equal across writing systems: XIV,
+<li>Equal value counts as equal across writing systems:
 &#21313;&#22235;, &#1633;&#1636; and the full-width &#65297;&#65300; all
-equal 14.</li>
+equal 14. Roman numerals written with Latin letters (XIV) join in through an
+opt-in sub-option.</li>
 <li>A tooltip shows how each score was computed and warns when the match's
 numbers differ from your segment's &mdash; no wrong number slips in
 unnoticed.</li>

--- a/src/main/java/org/omegat/core/Core.java
+++ b/src/main/java/org/omegat/core/Core.java
@@ -43,6 +43,7 @@ import org.omegat.core.data.EntryKey;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.NotLoadedProject;
 import org.omegat.core.machinetranslators.MachineTranslatorsManager;
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.spellchecker.ISpellChecker;
 import org.omegat.core.spellchecker.SpellCheckerManager;
@@ -263,6 +264,7 @@ public final class Core {
     static void initializeGUIimpl(IMainWindow me) throws Exception {
         MarkerController.init();
         LanguageToolWrapper.init();
+        MatchEquivalence.registerTeamSetting();
 
         CoreState coreState = CoreState.getInstance();
         coreState.setSegmenter(new Segmenter(Preferences.getSRX()));
@@ -295,6 +297,7 @@ public final class Core {
      */
     public static void initializeConsole() {
         CoreState coreState = CoreState.getInstance();
+        MatchEquivalence.registerTeamSetting();
         coreState.setTagValidation(new TagValidationTool());
         coreState.setProject(new NotLoadedProject());
         coreState.setMainWindow(new ConsoleWindow());

--- a/src/main/java/org/omegat/core/data/IProject.java
+++ b/src/main/java/org/omegat/core/data/IProject.java
@@ -29,6 +29,7 @@
 package org.omegat.core.data;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -106,6 +107,51 @@ public interface IProject {
      * @throws Exception if any error occurs during the commit process
      */
     void commitSourceFiles() throws Exception;
+
+    /**
+     * Sets a registered team project setting and commits the project
+     * settings file (omegat/project_settings.properties) to the team
+     * repository, so the whole team gets the value. The setting lives in
+     * its own file because older OmegaT versions reject unknown elements in
+     * omegat.project but ignore extra files. No operation for non-team
+     * projects. Must run through Core.executeExclusively, like saveProject.
+     *
+     * @param key
+     *            key of a setting registered in {@link TeamSettingsRegistry}
+     * @param value
+     *            raw value to distribute, null for the default
+     * @throws Exception
+     *             if writing or committing the file fails
+     */
+    default void publishProjectSetting(String key, @Nullable String value) throws Exception {
+    }
+
+    /**
+     * Sets a registered team project setting for this session and writes it
+     * to the local project settings file only: the next open of the team
+     * project supersedes it with the remote value again. No operation for
+     * non-team projects. Must run through Core.executeExclusively, like
+     * saveProject.
+     *
+     * @param key
+     *            key of a setting registered in {@link TeamSettingsRegistry}
+     * @param value
+     *            raw value to restore, null for the default
+     * @throws Exception
+     *             if writing the file fails
+     */
+    default void useLocalProjectSetting(String key, @Nullable String value) throws Exception {
+    }
+
+    /**
+     * The local raw values that the team values superseded during the last
+     * load of a team project, keyed by setting key; an entry with null value
+     * means the local side had the default. Empty when everything agreed,
+     * always empty for non-team projects.
+     */
+    default Map<String, @Nullable String> getSupersededLocalSettings() {
+        return Collections.emptyMap();
+    }
 
     /**
      * Get project properties.

--- a/src/main/java/org/omegat/core/data/ProjectProperties.java
+++ b/src/main/java/org/omegat/core/data/ProjectProperties.java
@@ -36,8 +36,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.core.segmentation.SRXManager;
 import org.omegat.filters2.master.FilterMaster;
@@ -104,7 +108,8 @@ public class ProjectProperties {
         setSentenceSegmentingEnabled(true);
         setSupportDefaultTranslations(true);
         setRemoveTags(false);
-        setMatchNumbersEnabled(false);
+        setMatchNumbersEnabled(true);
+        setMatchNumbersRomanEnabled(false);
 
         setSourceLanguage("AR-LB");
         setTargetLanguage("UK-UA");
@@ -420,7 +425,7 @@ public class ProjectProperties {
 
     /**
      * Returns whether fuzzy matching considers numbers by value for this
-     * project (feature request #465). Default, no.
+     * project (feature request #465). Default, yes.
      */
     public boolean isMatchNumbersEnabled() {
         return matchNumbersEnabled;
@@ -429,6 +434,42 @@ public class ProjectProperties {
     /** Sets whether fuzzy matching considers numbers by value for this project */
     public void setMatchNumbersEnabled(boolean matchNumbersEnabled) {
         this.matchNumbersEnabled = matchNumbersEnabled;
+    }
+
+    /**
+     * Returns whether number matching also reads Roman numerals written with
+     * Latin letters. Default, no: ordinary uppercase words ("I", "MIX") read
+     * as numbers too easily. Roman numerals written with the dedicated code
+     * points always count.
+     */
+    public boolean isMatchNumbersRomanEnabled() {
+        return matchNumbersRomanEnabled;
+    }
+
+    /** Sets whether number matching also reads Latin-letter Roman numerals. */
+    public void setMatchNumbersRomanEnabled(boolean matchNumbersRomanEnabled) {
+        this.matchNumbersRomanEnabled = matchNumbersRomanEnabled;
+    }
+
+    /**
+     * Character equivalence classes disabled for fuzzy matching in this
+     * project (feature request #1681). Default, none: every class active.
+     */
+    public Set<MatchEquivalence> getDisabledMatchEquivalences() {
+        return EnumSet.copyOf(disabledMatchEquivalences);
+    }
+
+    /** Sets character equivalence classes disabled for fuzzy matching. */
+    public void setDisabledMatchEquivalences(Collection<MatchEquivalence> disabled) {
+        disabledMatchEquivalences.clear();
+        disabledMatchEquivalences.addAll(disabled);
+    }
+
+    /** Character equivalence classes active for fuzzy matching. */
+    public Set<MatchEquivalence> getActiveMatchEquivalences() {
+        Set<MatchEquivalence> active = MatchEquivalence.all();
+        active.removeAll(disabledMatchEquivalences);
+        return active;
     }
 
     /**
@@ -688,6 +729,9 @@ public class ProjectProperties {
 
     private boolean sentenceSegmentingEnabled;
     private boolean matchNumbersEnabled;
+    private boolean matchNumbersRomanEnabled;
+    private final Set<MatchEquivalence> disabledMatchEquivalences = EnumSet
+            .noneOf(MatchEquivalence.class);
     private boolean supportDefaultTranslations;
     private boolean removeTags;
     private List<String> exportTmLevels;

--- a/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
+++ b/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
@@ -1,0 +1,168 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+import org.jspecify.annotations.Nullable;
+
+import org.omegat.util.Log;
+
+/**
+ * Storage of optional per-project settings in
+ * {@code omegat/project_settings.properties}. The settings live in their own
+ * file instead of {@code omegat.project} on purpose: the project file parser
+ * of released OmegaT versions rejects unknown elements, so a new element
+ * there would make the project unreadable for every team member on an older
+ * version, while an extra file in the {@code omegat} folder is ignored.
+ *
+ * The file is written deterministically (sorted keys, no timestamp comment),
+ * so distributing an unchanged file to a team repository stays recognisable
+ * as a byte-identical no-op.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class ProjectSettingsStorage {
+
+    public static final String FILE_PROJECT_SETTINGS = "project_settings.properties";
+
+    private ProjectSettingsStorage() {
+    }
+
+    /** The settings file of the given project. */
+    public static File getFile(ProjectProperties config) {
+        return new File(config.getProjectInternal(), FILE_PROJECT_SETTINGS);
+    }
+
+    /**
+     * The stored raw value of given key: null when the file or the key is
+     * absent or the file is unreadable, so callers can distinguish "not
+     * configured" from an explicit value.
+     */
+    public static @Nullable String load(ProjectProperties config, String key) {
+        File file = getFile(config);
+        if (!file.isFile()) {
+            return null;
+        }
+        Properties props = new Properties();
+        try (Reader in = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+            props.load(in);
+        } catch (IOException ex) {
+            Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+            return null;
+        }
+        String value = props.getProperty(key);
+        return value == null ? null : value.trim();
+    }
+
+    /**
+     * Store the raw value under given key (null removes the key), keeping
+     * any other keys of the file so settings can share it. Removing a key
+     * from an absent file is a no-op, so it never materialises the file.
+     */
+    public static void save(ProjectProperties config, String key, @Nullable String value)
+            throws IOException {
+        File file = getFile(config);
+        if (value == null && !file.isFile()) {
+            return;
+        }
+        Map<String, String> entries = new TreeMap<>();
+        if (file.isFile()) {
+            Properties existing = new Properties();
+            try (Reader in = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+                existing.load(in);
+            }
+            existing.stringPropertyNames().forEach(k -> entries.put(k, existing.getProperty(k)));
+        }
+        if (value == null) {
+            entries.remove(key);
+        } else {
+            entries.put(key, value);
+        }
+        File dir = file.getParentFile();
+        if (dir != null && !dir.isDirectory() && !dir.mkdirs()) {
+            throw new IOException("Cannot create " + dir);
+        }
+        try (Writer out = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+            for (Map.Entry<String, String> e : entries.entrySet()) {
+                out.write(escape(e.getKey(), true) + "=" + escape(e.getValue(), false) + "\n");
+            }
+        }
+    }
+
+    /**
+     * Escape a key or value the way {@code Properties.store} would, minus
+     * the Latin-1 escaping (the file is read and written as UTF-8), so
+     * foreign keys of other settings survive the load/save round trip
+     * unchanged.
+     */
+    private static String escape(String s, boolean isKey) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+            case '\\':
+                sb.append("\\\\");
+                break;
+            case '\t':
+                sb.append("\\t");
+                break;
+            case '\n':
+                sb.append("\\n");
+                break;
+            case '\r':
+                sb.append("\\r");
+                break;
+            case '\f':
+                sb.append("\\f");
+                break;
+            case '=':
+            case ':':
+            case '#':
+            case '!':
+                sb.append('\\').append(c);
+                break;
+            case ' ':
+                if (isKey || i == 0) {
+                    sb.append('\\');
+                }
+                sb.append(c);
+                break;
+            default:
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -252,11 +252,214 @@ public class RealProject implements IProject {
             FilterMaster.saveConfig(config.getProjectFilters(),
                     new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
             ProjectFileStorage.writeProjectFile(config);
+            persistSessionSettings(config, supersededLocalSettings.keySet());
         } finally {
             lockProject();
         }
         Preferences.setPreference(Preferences.SOURCE_LOCALE, config.getSourceLanguage().toString());
         Preferences.setPreference(Preferences.TARGET_LOCALE, config.getTargetLanguage().toString());
+    }
+
+    /**
+     * Persist the session values of all registered team settings to the
+     * sidecar file. Opt-in: only materialised once a setting was used, so
+     * default projects stay byte-identical to older OmegaT versions. While
+     * a superseded local value awaits the user's decision, the session runs
+     * on the team value but the file keeps the local one - persisting the
+     * session value here would silently turn a dismissed question into
+     * "take the team value". Static for testability.
+     */
+    static void persistSessionSettings(ProjectProperties config, Set<String> supersededKeys)
+            throws IOException {
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            String sessionValue = setting.read(config);
+            if (!supersededKeys.contains(setting.getKey())
+                    && (sessionValue != null || ProjectSettingsStorage.getFile(config).isFile())) {
+                ProjectSettingsStorage.save(config, setting.getKey(), sessionValue);
+            }
+        }
+    }
+
+    /**
+     * The local raw values that the just synced team values superseded
+     * during the load, keyed by setting key (null value = local default), or
+     * empty when everything agreed. Read by the question shown after a team
+     * project opened.
+     */
+    private volatile Map<String, @Nullable String> supersededLocalSettings = Collections.emptyMap();
+
+    @Override
+    public Map<String, @Nullable String> getSupersededLocalSettings() {
+        return supersededLocalSettings;
+    }
+
+    @Override
+    public void publishProjectSetting(String key, @Nullable String value) throws Exception {
+        if (!remoteRepositoryProvider.isManaged()) {
+            return;
+        }
+        TeamSetting setting = requireRegistered(key);
+        // The session and the local file keep the user's value even when the
+        // commit fails: the file then still diverges from the team and the
+        // next open asks again.
+        setting.apply(config, value);
+        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        // A checkout parked between teamSyncPrepare and teamSync must not be
+        // moved to latest behind the sync's back (same cleanup as
+        // saveProject).
+        tmxPrepared = null;
+        glossaryPrepared = null;
+        remoteRepositoryProvider.cleanPrepared();
+        commitProjectSettings(remoteRepositoryProvider, config);
+        clearSupersededLocalSetting(key);
+    }
+
+    @Override
+    public void useLocalProjectSetting(String key, @Nullable String value) throws Exception {
+        if (!remoteRepositoryProvider.isManaged()) {
+            return;
+        }
+        TeamSetting setting = requireRegistered(key);
+        setting.apply(config, value);
+        // Local write only: the next open of the team project syncs the
+        // remote file back in, notices a divergence and asks again.
+        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        clearSupersededLocalSetting(key);
+    }
+
+    private static TeamSetting requireRegistered(String key) {
+        TeamSetting setting = TeamSettingsRegistry.byKey(key);
+        if (setting == null) {
+            throw new IllegalArgumentException("Unknown team setting: " + key);
+        }
+        return setting;
+    }
+
+    private void clearSupersededLocalSetting(String key) {
+        if (supersededLocalSettings.containsKey(key)) {
+            Map<String, @Nullable String> remaining = new HashMap<>(supersededLocalSettings);
+            remaining.remove(key);
+            supersededLocalSettings = Collections.unmodifiableMap(remaining);
+        }
+    }
+
+    /**
+     * Commit the project settings file to the team repositories. Skips the
+     * commit when every repository copy is already byte-identical, because
+     * git reports the no-op commit of an unchanged file the same way as a
+     * rejected push. Static for testability.
+     */
+    static void commitProjectSettings(RemoteRepositoryProvider provider, ProjectProperties config)
+            throws Exception {
+        // The checkout may be stale, and a commit onto an old base would be
+        // rejected on push.
+        provider.switchAllToLatest();
+        String underRoot = config.getProjectInternalRelative()
+                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
+        if (!provider.isIdenticalInRepositoriesIgnoringEol(underRoot)) {
+            provider.copyFilesFromProjectToRepos(underRoot, null);
+            if (!provider.commitFilesChecked(underRoot, "Update the shared project settings")) {
+                throw new IOException(OStrings.getString("TEAM_SETTING_SHARE_ERROR"));
+            }
+        }
+    }
+
+    /**
+     * Apply the stored project settings to the session. For an online team
+     * project the team's state wins: the sync just overwrote a diverging
+     * local file with the remote one, and a purely local file (which the
+     * sync leaves alone, because it never existed remotely) does not count
+     * either - the team default stays active until the value is shared.
+     * Either way the superseded local values are kept for the question shown
+     * after the load, so every open asks again until the value is shared or
+     * dropped, as the share prompt promises.
+     *
+     * @param preSyncValues
+     *            the locally stored normalized values from before the team
+     *            sync, keyed by setting key
+     */
+    private void loadProjectSettings(Map<String, @Nullable String> preSyncValues) {
+        if (TeamSettingsRegistry.all().isEmpty()) {
+            supersededLocalSettings = Collections.emptyMap();
+            return;
+        }
+        boolean teamOnline = remoteRepositoryProvider.isManaged() && isOnlineMode;
+        boolean identical = false;
+        if (teamOnline) {
+            try {
+                // After the sync a settings file that exists remotely is
+                // byte-identical locally; a non-identical or absent file
+                // means the team does not carry the setting, so the local
+                // file is a local-only divergence.
+                identical = remoteRepositoryProvider.isIdenticalInRepositories(
+                        config.getProjectInternalRelative()
+                                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+            } catch (IOException ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                // fall back to trusting the local file
+                identical = true;
+            }
+        }
+        Map<String, @Nullable String> superseded = new HashMap<>();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            String preSync = preSyncValues.get(setting.getKey());
+            String postSync = setting.normalize(ProjectSettingsStorage.load(config, setting.getKey()));
+            SettingResolution state = resolveSetting(preSync, postSync, identical, teamOnline);
+            setting.apply(config, state.effective);
+            if (state.asks) {
+                superseded.put(setting.getKey(), state.supersededLocal);
+            }
+        }
+        supersededLocalSettings = Collections.unmodifiableMap(superseded);
+    }
+
+    /** Snapshot of the stored normalized values of all registered settings. */
+    private Map<String, @Nullable String> readStoredSettings() {
+        Map<String, @Nullable String> values = new HashMap<>();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            values.put(setting.getKey(),
+                    setting.normalize(ProjectSettingsStorage.load(config, setting.getKey())));
+        }
+        return values;
+    }
+
+    /** Resolution of one team setting after a load. */
+    static final class SettingResolution {
+        final @Nullable String effective;
+        final boolean asks;
+        final @Nullable String supersededLocal;
+
+        SettingResolution(@Nullable String effective, boolean asks, @Nullable String supersededLocal) {
+            this.effective = effective;
+            this.asks = asks;
+            this.supersededLocal = supersededLocal;
+        }
+    }
+
+    /**
+     * Decide which raw value a load activates and whether it superseded a
+     * diverging local value that the user should be asked about. Works on
+     * normalized values (default = null). Pure function for testability.
+     *
+     * @param preSyncStored
+     *            locally stored value from before the team sync, null when
+     *            file or key were absent
+     * @param postSyncStored
+     *            stored value after the team sync
+     * @param identicalInRepositories
+     *            whether the settings file is byte-identical in every team
+     *            repository (meaningless when teamOnline is false)
+     * @param teamOnline
+     *            whether this is a team project loaded in online mode
+     */
+    static SettingResolution resolveSetting(@Nullable String preSyncStored,
+            @Nullable String postSyncStored, boolean identicalInRepositories, boolean teamOnline) {
+        if (!teamOnline) {
+            return new SettingResolution(postSyncStored, false, null);
+        }
+        String team = identicalInRepositories ? postSyncStored : null;
+        boolean asks = !Objects.equals(preSyncStored, team);
+        return new SettingResolution(team, asks, asks ? preSyncStored : null);
     }
 
     /**
@@ -343,6 +546,7 @@ public class RealProject implements IProject {
 
             Core.getMainWindow().showStatusMessageRB("CT_LOADING_PROJECT");
 
+            Map<String, @Nullable String> preSyncSettings = readStoredSettings();
             if (remoteRepositoryProvider.isManaged()) {
                 try {
                     tmxPrepared = null;
@@ -360,6 +564,7 @@ public class RealProject implements IProject {
                 config.loadProjectFilters();
                 config.loadProjectSRX();
             }
+            loadProjectSettings(preSyncSettings);
 
             loadFilterSettings();
             loadSegmentationSettings();

--- a/src/main/java/org/omegat/core/data/TeamSetting.java
+++ b/src/main/java/org/omegat/core/data/TeamSetting.java
@@ -1,0 +1,146 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+import org.jspecify.annotations.Nullable;
+import org.openide.awt.Mnemonics;
+
+import org.omegat.util.OStrings;
+
+/**
+ * Descriptor of one per-project setting negotiated with team, stored in
+ * sidecar file handled by {@link ProjectSettingsStorage}. Feature code
+ * registers descriptor through {@link TeamSettingsRegistry}; core then
+ * loads, saves, distributes and questions the setting generically. Raw
+ * values are strings; null means "not configured", i.e. default.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSetting {
+
+    private final String key;
+    private final String nameKey;
+    private final Function<ProjectProperties, @Nullable String> reader;
+    private final BiConsumer<ProjectProperties, @Nullable String> applier;
+    private final Function<@Nullable String, String> valueDescriber;
+    private final UnaryOperator<@Nullable String> normalizer;
+
+    private TeamSetting(String key, String nameKey, Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+        this.key = key;
+        this.nameKey = nameKey;
+        this.reader = reader;
+        this.applier = applier;
+        this.valueDescriber = valueDescriber;
+        this.normalizer = normalizer;
+    }
+
+    /**
+     * Descriptor with fully custom behaviour, for non-boolean settings.
+     *
+     * @param key
+     *            key in project_settings.properties
+     * @param nameKey
+     *            resource key of localized display name
+     * @param reader
+     *            current session value as normalized raw string, null for
+     *            default
+     * @param applier
+     *            applies raw value (null = default) to session; must be an
+     *            idempotent setter, it also runs with unchanged values
+     * @param valueDescriber
+     *            localized description of raw value for dialogs
+     * @param normalizer
+     *            canonical form of raw value; must map default to null
+     */
+    public static TeamSetting of(String key, String nameKey,
+            Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+        return new TeamSetting(key, nameKey, reader, applier, valueDescriber, normalizer);
+    }
+
+    /**
+     * Boolean setting; absent key means given default, only the non-default
+     * value materialises in the file, so default projects stay byte-identical
+     * to projects of older OmegaT versions.
+     */
+    public static TeamSetting ofBoolean(String key, String nameKey, boolean defaultValue,
+            Predicate<ProjectProperties> getter, BiConsumer<ProjectProperties, Boolean> setter) {
+        UnaryOperator<@Nullable String> normalizer = raw -> {
+            boolean value = raw == null ? defaultValue : Boolean.parseBoolean(raw.trim());
+            return value == defaultValue ? null : Boolean.toString(value);
+        };
+        return new TeamSetting(key, nameKey,
+                config -> getter.test(config) == defaultValue ? null : Boolean.toString(!defaultValue),
+                (config, raw) -> setter.accept(config,
+                        raw == null ? defaultValue : Boolean.parseBoolean(raw.trim())),
+                raw -> OStrings.getString(
+                        (raw == null ? defaultValue : Boolean.parseBoolean(raw.trim()))
+                                ? "TEAM_SETTING_VALUE_ON"
+                                : "TEAM_SETTING_VALUE_OFF"),
+                normalizer);
+    }
+
+    /** Key in project_settings.properties. */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Localized display name for dialogs. Mnemonic markers are stripped, so
+     * existing menu or checkbox label keys work as name key.
+     */
+    public String getDisplayName() {
+        return Mnemonics.removeMnemonics(OStrings.getString(nameKey));
+    }
+
+    /** Current session value as normalized raw string, null for default. */
+    public @Nullable String read(ProjectProperties config) {
+        return normalize(reader.apply(config));
+    }
+
+    /** Applies raw value (null = default) to session. */
+    public void apply(ProjectProperties config, @Nullable String raw) {
+        applier.accept(config, normalize(raw));
+    }
+
+    /** Localized description of raw value for dialogs. */
+    public String describe(@Nullable String raw) {
+        return valueDescriber.apply(raw);
+    }
+
+    /** Canonical form of raw value; default maps to null. */
+    public @Nullable String normalize(@Nullable String raw) {
+        return normalizer.apply(raw);
+    }
+}

--- a/src/main/java/org/omegat/core/data/TeamSettingsRegistry.java
+++ b/src/main/java/org/omegat/core/data/TeamSettingsRegistry.java
@@ -1,0 +1,70 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Registry of team-negotiated project settings. Feature code registers its
+ * {@link TeamSetting} at plugin load; core iterates registered settings when
+ * loading, saving and distributing projects. Empty registry means every
+ * related code path stays no-op.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSettingsRegistry {
+
+    private static final List<TeamSetting> SETTINGS = new CopyOnWriteArrayList<>();
+
+    private TeamSettingsRegistry() {
+    }
+
+    /** Registers setting; rejects duplicate key. */
+    public static void register(TeamSetting setting) {
+        if (byKey(setting.getKey()) != null) {
+            throw new IllegalArgumentException("Team setting already registered: " + setting.getKey());
+        }
+        SETTINGS.add(setting);
+    }
+
+    /** Removes setting with given key, for plugin unload and tests. */
+    public static void unregister(String key) {
+        SETTINGS.removeIf(s -> s.getKey().equals(key));
+    }
+
+    /** All registered settings, in registration order. */
+    public static List<TeamSetting> all() {
+        return List.copyOf(SETTINGS);
+    }
+
+    /** Setting with given key, null when unknown. */
+    public static @Nullable TeamSetting byKey(String key) {
+        return SETTINGS.stream().filter(s -> s.getKey().equals(key)).findFirst().orElse(null);
+    }
+}

--- a/src/main/java/org/omegat/core/matching/MatchEquivalence.java
+++ b/src/main/java/org/omegat/core/matching/MatchEquivalence.java
@@ -1,0 +1,413 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.matching;
+
+import java.text.MessageFormat;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.ibm.icu.text.Normalizer2;
+import com.ibm.icu.text.UnicodeSet;
+
+import org.jspecify.annotations.Nullable;
+
+import org.omegat.core.data.TeamSetting;
+import org.omegat.core.data.TeamSettingsRegistry;
+import org.omegat.util.OStrings;
+
+/**
+ * Named equivalence classes of character variants that fuzzy matching can
+ * treat as equal (feature request #1681). Each class folds its members to one
+ * representative character, so segments differing only in such variants
+ * compare as equal. All classes are active by default; a project can disable
+ * individual classes.
+ * <p>
+ * Quotation marks fold in two separate groups, double-quote variants and
+ * single-quote variants, following the proposal in #1681: a straight double
+ * quote matches curly double quotes but not single quotes. Prime marks and
+ * other lookalikes that are not quotation marks stay untouched. The
+ * invisible-format class folds to the empty string, removing the characters
+ * from comparison entirely.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public enum MatchEquivalence {
+
+    /**
+     * Opening and closing quotation marks of all scripts plus apostrophe
+     * variants: apostrophes and single quotes share code points, so folding
+     * cannot separate the two roles and they form one class. Double variants
+     * fold to the straight double quote, single and apostrophe variants
+     * (including the modifier letter apostrophe) to the right single
+     * quotation mark. U+2019 is the representative because polished TM
+     * content already uses the typographic form: folding toward it keeps the
+     * historic verbatim tokenization of such content unchanged, and
+     * straight-typed text adopts that segmentation.
+     */
+    QUOTES("EQUIVALENCE_CLASS_QUOTES",
+            new Group(new UnicodeSet("[\"«»“”„‟⹂❝❞❠〝〞〟＂「」『』｢｣🙶🙷🙸]"), "\""),
+            new Group(new UnicodeSet("['‘’‚‛‹›❛❜❟＇ʼ]"), "’")),
+
+    /** Hyphen, dash and minus variants. */
+    DASHES("EQUIVALENCE_CLASS_DASHES",
+            new Group(new UnicodeSet("[\\-‐‑‒–—―−﹘﹣－]"), "-")),
+
+    /** Space variants: every Unicode space separator folds to plain space. */
+    SPACES("EQUIVALENCE_CLASS_SPACES",
+            new Group(new UnicodeSet("[[:Zs:]]"), " ")),
+
+    /**
+     * Invisible formatting characters removed from comparison: soft hyphen,
+     * bidi controls, zero-width space, word joiner, BOM. ZWNJ and ZWJ stay
+     * untouched: they are meaning-bearing in Persian and Indic scripts.
+     */
+    INVISIBLES("EQUIVALENCE_CLASS_INVISIBLES",
+            new Group(new UnicodeSet(
+                    "[\\u00AD\\u061C\\u200B\\u200E\\u200F\\u202A-\\u202E\\u2060\\u2066-\\u2069\\uFEFF]"),
+                    ""));
+
+    /** One folding group: a set of characters and their shared replacement. */
+    private static final class Group {
+        private final UnicodeSet chars;
+        private final String replacement;
+
+        Group(UnicodeSet chars, String replacement) {
+            this.chars = chars.freeze();
+            this.replacement = replacement;
+        }
+    }
+
+    private static final Normalizer2 NFC = Normalizer2.getNFCInstance();
+    private static final Normalizer2 NFD = Normalizer2.getNFDInstance();
+
+    private final String labelKey;
+    private final Group[] groups;
+
+    MatchEquivalence(String labelKey, Group... groups) {
+        this.labelKey = labelKey;
+        this.groups = groups;
+    }
+
+    /** Key of the team-negotiated setting in the project settings file. */
+    public static final String TEAM_SETTING_KEY = "match_equivalence_disabled";
+
+    /** Identifier used in the project settings file, stable across locales. */
+    public String getId() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    /** Localized display name of the class. */
+    public String getLocalizedName() {
+        return OStrings.getString(labelKey);
+    }
+
+    /**
+     * Code points of the class in display order, mapped to their replacement
+     * (empty string means removed). Insertion-ordered for the GUI listing.
+     */
+    public Map<Integer, String> getMembers() {
+        Map<Integer, String> members = new LinkedHashMap<>();
+        for (Group group : groups) {
+            for (UnicodeSet.EntryRange range : group.chars.ranges()) {
+                for (int cp = range.codepoint; cp <= range.codepointEnd; cp++) {
+                    members.put(cp, group.replacement);
+                }
+            }
+        }
+        return members;
+    }
+
+    /**
+     * Builds a code point replacement map for the given active classes.
+     */
+    public static Map<Integer, String> buildFoldMap(Set<MatchEquivalence> active) {
+        Map<Integer, String> map = new HashMap<>();
+        for (MatchEquivalence eq : active) {
+            for (Group group : eq.groups) {
+                for (UnicodeSet.EntryRange range : group.chars.ranges()) {
+                    for (int cp = range.codepoint; cp <= range.codepointEnd; cp++) {
+                        // Identity mappings (a representative onto itself)
+                        // would force a copy of nearly every string in fold.
+                        if (group.replacement.codePointCount(0, group.replacement.length()) == 1
+                                && group.replacement.codePointAt(0) == cp) {
+                            continue;
+                        }
+                        map.putIfAbsent(cp, group.replacement);
+                    }
+                }
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Folds text for comparison: canonical normalization (NFC) always, then
+     * replacement of every code point claimed by the fold map. Identity for
+     * text without variant characters.
+     */
+    public static String fold(String text, Map<Integer, String> foldMap) {
+        String normalized = NFC.normalize(text);
+        if (foldMap.isEmpty()) {
+            return normalized;
+        }
+        StringBuilder sb = null;
+        for (int i = 0; i < normalized.length();) {
+            int cp = normalized.codePointAt(i);
+            int len = Character.charCount(cp);
+            String replacement = foldMap.get(cp);
+            if (replacement != null && sb == null) {
+                sb = new StringBuilder(normalized.length());
+                sb.append(normalized, 0, i);
+            }
+            if (sb != null) {
+                if (replacement != null) {
+                    sb.append(replacement);
+                } else {
+                    sb.appendCodePoint(cp);
+                }
+            }
+            i += len;
+        }
+        return sb == null ? normalized : sb.toString();
+    }
+
+    /**
+     * Builds the subset of {@link #buildFoldMap(Set)} whose replacements keep
+     * UTF-16 length: single BMP character replaced by single BMP character.
+     * Safe to apply to a whole string before tokenization, so variant
+     * characters cannot shift word boundaries while token offsets stay valid
+     * for the original string. Removal (invisible formatting characters),
+     * canonical normalization and supplementary-plane members must fold in
+     * token text afterwards.
+     */
+    public static Map<Integer, String> buildSameLengthFoldMap(Set<MatchEquivalence> active) {
+        Map<Integer, String> map = new HashMap<>();
+        buildFoldMap(active).forEach((cp, replacement) -> {
+            if (cp <= Character.MAX_VALUE && replacement.length() == 1) {
+                map.put(cp, replacement);
+            }
+        });
+        return map;
+    }
+
+    /** Character-by-character fold with a same-length map; no normalization. */
+    public static String foldSameLength(String text, Map<Integer, String> sameLengthFoldMap) {
+        if (sameLengthFoldMap.isEmpty()) {
+            return text;
+        }
+        StringBuilder sb = null;
+        for (int i = 0; i < text.length(); i++) {
+            String replacement = sameLengthFoldMap.get((int) text.charAt(i));
+            if (replacement != null && sb == null) {
+                sb = new StringBuilder(text);
+            }
+            if (replacement != null) {
+                sb.setCharAt(i, replacement.charAt(0));
+            }
+        }
+        return sb == null ? text : sb.toString();
+    }
+
+    /**
+     * Builds a regular expression from a plain search text (with the search
+     * wildcards "*" and "?") that also matches every character variant
+     * equivalent under the active classes. Equivalence works on the pattern
+     * side: each variant character becomes a character class of its group,
+     * and with the invisibles class active, every gap between atoms tolerates
+     * invisible formatting characters in the searched text. The needle itself
+     * is normalized (NFC) and cleared of invisible formatting characters.
+     * Searched text and match offsets stay untouched.
+     */
+    public static String globToRegex(String text, Set<MatchEquivalence> active) {
+        Map<Integer, String> memberClasses = buildRegexClassMap(active);
+        UnicodeSet invisibles = active.contains(INVISIBLES) ? INVISIBLES.groups[0].chars : null;
+        String gap = invisibles == null ? ""
+                : characterClass(invisibles) + "*";
+        String nonSpaceRun = active.contains(SPACES) ? "[^\\s\\p{Zs}]" : "\\S";
+        String normalized = NFC.normalize(text);
+        StringBuilder sb = new StringBuilder(normalized.length() * 8);
+        boolean first = true;
+        for (int i = 0; i < normalized.length();) {
+            int cp = normalized.codePointAt(i);
+            i += Character.charCount(cp);
+            if (invisibles != null && invisibles.contains(cp)) {
+                continue;
+            }
+            String atom;
+            if (cp == '*') {
+                atom = nonSpaceRun + "*";
+            } else if (cp == '?') {
+                atom = nonSpaceRun;
+            } else {
+                atom = memberClasses.get(cp);
+                if (atom == null) {
+                    atom = literalAtom(cp);
+                }
+            }
+            if (!first) {
+                sb.append(gap);
+            }
+            sb.append(atom);
+            first = false;
+        }
+        if (sb.length() == 0 && !normalized.isEmpty()) {
+            // A needle consisting only of invisible formatting characters
+            // must not collapse to an empty pattern (which finds everything);
+            // search for it literally instead.
+            normalized.codePoints().forEach(cp -> sb.append(escapeLiteral(cp)));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Literal atom for one code point; when its canonical decomposition
+     * differs, both forms are alternated so decomposed text (frequent on
+     * macOS) is found as well.
+     */
+    private static String literalAtom(int cp) {
+        String composed = new String(Character.toChars(cp));
+        String decomposed = NFD.normalize(composed);
+        if (decomposed.equals(composed)) {
+            return escapeLiteral(cp);
+        }
+        StringBuilder alt = new StringBuilder("(?:").append(escapeLiteral(cp)).append('|');
+        decomposed.codePoints().forEach(dcp -> alt.append(escapeLiteral(dcp)));
+        return alt.append(')').toString();
+    }
+
+    /** Member code point to character class of its group, for active classes. */
+    private static Map<Integer, String> buildRegexClassMap(Set<MatchEquivalence> active) {
+        Map<Integer, String> map = new HashMap<>();
+        for (MatchEquivalence eq : active) {
+            if (eq == INVISIBLES) {
+                continue;
+            }
+            for (Group group : eq.groups) {
+                String characterClass = characterClass(group.chars);
+                for (UnicodeSet.EntryRange range : group.chars.ranges()) {
+                    for (int cp = range.codepoint; cp <= range.codepointEnd; cp++) {
+                        map.putIfAbsent(cp, characterClass);
+                    }
+                }
+            }
+        }
+        return map;
+    }
+
+    private static String characterClass(UnicodeSet chars) {
+        StringBuilder sb = new StringBuilder("[");
+        for (UnicodeSet.EntryRange range : chars.ranges()) {
+            sb.append(String.format(Locale.ROOT, "\\x{%X}", range.codepoint));
+            if (range.codepointEnd != range.codepoint) {
+                sb.append('-').append(String.format(Locale.ROOT, "\\x{%X}", range.codepointEnd));
+            }
+        }
+        return sb.append(']').toString();
+    }
+
+    /** Single code point as a regex literal; alphanumerics stay readable. */
+    private static String escapeLiteral(int cp) {
+        if (Character.isLetterOrDigit(cp) && cp < 0x80) {
+            return new String(Character.toChars(cp));
+        }
+        return String.format(Locale.ROOT, "\\x{%X}", cp);
+    }
+
+    /** All classes; the default state is every class active. */
+    public static Set<MatchEquivalence> all() {
+        return EnumSet.allOf(MatchEquivalence.class);
+    }
+
+    /**
+     * Comma-separated id list for storing in the settings file,
+     * alphabetically sorted so the canonical form survives classes inserted
+     * into the enum later.
+     */
+    public static String toIdList(Set<MatchEquivalence> classes) {
+        return classes.stream().map(MatchEquivalence::getId).sorted().collect(Collectors.joining(","));
+    }
+
+    /**
+     * Parses a comma-separated id list. Ids compare case-insensitively
+     * because the settings file is hand-editable; unknown ids are ignored so
+     * files written by newer versions with more classes still load.
+     */
+    public static Set<MatchEquivalence> fromIdList(String idList) {
+        Set<MatchEquivalence> result = EnumSet.noneOf(MatchEquivalence.class);
+        for (String id : idList.split(",")) {
+            for (MatchEquivalence eq : values()) {
+                if (eq.getId().equals(id.trim().toLowerCase(Locale.ROOT))) {
+                    result.add(eq);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Team-negotiated project setting: opt-out id list of disabled classes,
+     * absent key means every class active.
+     */
+    static TeamSetting teamSetting() {
+        return TeamSetting.of(TEAM_SETTING_KEY, "EQUIVALENCE_TEAM_SETTING_NAME", config -> {
+            Set<MatchEquivalence> disabled = config.getDisabledMatchEquivalences();
+            return disabled.isEmpty() ? null : toIdList(disabled);
+        }, (config, raw) -> config.setDisabledMatchEquivalences(
+                raw == null ? EnumSet.noneOf(MatchEquivalence.class) : fromIdList(raw)),
+                MatchEquivalence::describeDisabled, MatchEquivalence::normalizeIdList);
+    }
+
+    /** Registers the team setting; safe to call from every bootstrap. */
+    public static void registerTeamSetting() {
+        if (TeamSettingsRegistry.byKey(TEAM_SETTING_KEY) == null) {
+            TeamSettingsRegistry.register(teamSetting());
+        }
+    }
+
+    private static String describeDisabled(@Nullable String raw) {
+        Set<MatchEquivalence> disabled = raw == null ? EnumSet.noneOf(MatchEquivalence.class)
+                : fromIdList(raw);
+        if (disabled.isEmpty()) {
+            return OStrings.getString("EQUIVALENCE_TEAM_SETTING_ALL_ACTIVE");
+        }
+        return MessageFormat.format(OStrings.getString("EQUIVALENCE_TEAM_SETTING_DISABLED"),
+                disabled.stream().sorted().map(MatchEquivalence::getLocalizedName)
+                        .collect(Collectors.joining(", ")));
+    }
+
+    private static @Nullable String normalizeIdList(@Nullable String raw) {
+        if (raw == null) {
+            return null;
+        }
+        Set<MatchEquivalence> disabled = fromIdList(raw);
+        return disabled.isEmpty() ? null : toIdList(disabled);
+    }
+}

--- a/src/main/java/org/omegat/core/search/SearchExpression.java
+++ b/src/main/java/org/omegat/core/search/SearchExpression.java
@@ -31,7 +31,12 @@
 
 package org.omegat.core.search;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 import org.jspecify.annotations.Nullable;
+
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.util.OConsts;
 
 /**
@@ -75,7 +80,22 @@ public class SearchExpression {
     public boolean caseSensitive = false;
     public boolean wholeWordsOnly = false;
     public boolean widthInsensitive = true;
-    public boolean spaceMatchNbsp = false;
+    /**
+     * Character equivalence classes applied to exact and keyword searches
+     * (feature request #1681); empty means no folding. Regular-expression
+     * searches ignore the field: folding a pattern would corrupt its syntax.
+     */
+    public Set<MatchEquivalence> equivalences = EnumSet.noneOf(MatchEquivalence.class);
+
+    /**
+     * Match a number-only search term by its numeric value: the term finds
+     * every writing of the same value across the numeral systems. Applies to
+     * exact and keyword searches only.
+     */
+    public boolean matchNumbers;
+
+    /** Whether the value matching also reads Latin-letter Roman numerals. */
+    public boolean matchNumbersRoman;
     public boolean glossary = true;
     public boolean memory = true;
     public boolean tm = true;

--- a/src/main/java/org/omegat/core/search/Searcher.java
+++ b/src/main/java/org/omegat/core/search/Searcher.java
@@ -33,6 +33,7 @@
 package org.omegat.core.search;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,8 +45,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.VisibleForTesting;
@@ -64,6 +67,7 @@ import org.omegat.core.data.ProtectedPart;
 import org.omegat.core.data.SegmentProperties;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.TMXEntry;
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.core.threads.CancellationToken;
 import org.omegat.core.threads.LongProcessInterruptedException;
 import org.omegat.core.threads.LongProcessThread;
@@ -74,6 +78,7 @@ import org.omegat.filters2.master.FilterMaster;
 import org.omegat.gui.glossary.GlossaryEntry;
 import org.omegat.util.Language;
 import org.omegat.util.Log;
+import org.omegat.util.NumeralValueParser;
 import org.omegat.util.OStrings;
 import org.omegat.util.PatternConsts;
 import org.omegat.util.StaticUtils;
@@ -113,6 +118,12 @@ import org.omegat.util.StringUtil;
 public class Searcher {
 
     private final List<SearchResultEntry> searchResults = new ArrayList<>();
+
+    /**
+     * The trimmed search term while the number-value alternation is active,
+     * so literal hits can rank before value-equivalent ones; null otherwise.
+     */
+    private @Nullable String numberSearchTerm;
     private boolean preprocessResults;
     private final IProject project;
     /**
@@ -285,12 +296,36 @@ public class Searcher {
         // search string; otherwise, if keyword, break up the string into
         // separate words (= multiple search strings)
 
+        // A number-only search term matches by value: the whole (trimmed)
+        // term must read as one number - universally, or with the grouping
+        // and decimal separators of the project's source or target locale
+        // ("1.234" in a German project searches like 1234) - then the pattern
+        // becomes the alternation of every writing of that value.
+        String numberAlternation = null;
+        String term = textSearchExpression.trim();
+        if (searchExpression.matchNumbers
+                && searchExpression.searchExpressionType != SearchExpression.SearchExpressionType.REGEXP) {
+            numberAlternation = searchTermValue(term)
+                    .map(value -> Stream
+                            .of(Stream.of(term), localeWritings(value),
+                                    NumeralValueParser
+                                            .renderings(value, searchExpression.matchNumbersRoman)
+                                            .stream())
+                            .flatMap(writings -> writings).distinct().map(Pattern::quote)
+                            .collect(Collectors.joining("|", "(?:", ")")))
+                    .orElse(null);
+        }
+        // The same (possibly width-normalized) term the alternation leads
+        // with, so the literal-first ranking recognizes its own hits.
+        numberSearchTerm = numberAlternation != null ? term : null;
+
         switch (searchExpression.searchExpressionType) {
         case EXACT:
             // escape the search string, it's not supposed to be a regular
-            // expression
-            textSearchExpression = StaticUtils.globToRegex(textSearchExpression,
-                    searchExpression.spaceMatchNbsp);
+            // expression; variant characters match their whole equivalence
+            // group (#1681)
+            textSearchExpression = numberAlternation != null ? numberAlternation
+                    : MatchEquivalence.globToRegex(textSearchExpression, searchExpression.equivalences);
             if (searchExpression.wholeWordsOnly) {
                 textSearchExpression = anchorWholeWords(textSearchExpression);
             }
@@ -300,11 +335,22 @@ public class Searcher {
             break;
         case KEYWORD:
             // break the search string into keywords,
-            // each of which is a separate search string
+            // each of which is a separate search string; fold space variants
+            // first so no-break spaces also separate keywords
             final int flags = getPatternFlags();
-            Pattern.compile(" ").splitAsStream(textSearchExpression.trim()).filter(word -> !word.isEmpty())
+            if (numberAlternation != null) {
+                String glob = numberAlternation;
+                if (searchExpression.wholeWordsOnly) {
+                    glob = anchorWholeWords(glob);
+                }
+                matchers.add(Pattern.compile(glob, flags).matcher(""));
+                break;
+            }
+            String keywords = MatchEquivalence.foldSameLength(textSearchExpression,
+                    MatchEquivalence.buildSameLengthFoldMap(searchExpression.equivalences));
+            Pattern.compile(" ").splitAsStream(keywords.trim()).filter(word -> !word.isEmpty())
                     .map(word -> {
-                        String glob = StaticUtils.globToRegex(word, false);
+                        String glob = MatchEquivalence.globToRegex(word, searchExpression.equivalences);
                         if (searchExpression.wholeWordsOnly) {
                             glob = anchorWholeWords(glob);
                         }
@@ -312,12 +358,6 @@ public class Searcher {
                     }).forEach(matchers::add);
             break;
         case REGEXP:
-            // space match nbsp (\u00a0)
-            if (searchExpression.spaceMatchNbsp) {
-                textSearchExpression = textSearchExpression.replace(" ", "( |\u00A0)");
-                textSearchExpression = textSearchExpression.replace("\\\\s", "(\\\\s|\u00A0)");
-            }
-
             // create a matcher for the search string
             matchers.add(Pattern.compile(textSearchExpression, getPatternFlags()).matcher(""));
             break;
@@ -334,11 +374,43 @@ public class Searcher {
                 searchFiles();
             }
         } finally {
+            // A number-value search lists the literal hits first; the stable
+            // sort keeps the traversal order within each group.
+            if (numberSearchTerm != null) {
+                String literalTerm = numberSearchTerm;
+                searchResults.sort(java.util.Comparator
+                        .comparingInt(entry -> containsLiteralTerm(entry, literalTerm) ? 0 : 1));
+            }
             // Mark search as completed - provides happens-before edge for safe
             // result access
             // This ensures all search results are visible to other threads
             searchCompleted = true;
         }
+    }
+
+    /** Whether one of the entry's match regions is the search term itself. */
+    private boolean containsLiteralTerm(SearchResultEntry entry, String term) {
+        return matchesLiteral(entry.getSrcText(), entry.getSrcMatch(), term)
+                || matchesLiteral(entry.getTranslation(), entry.getTargetMatch(), term);
+    }
+
+    private boolean matchesLiteral(@Nullable String text, SearchMatch @Nullable [] matches, String term) {
+        if (text == null || matches == null) {
+            return false;
+        }
+        for (SearchMatch match : matches) {
+            int end = match.getStart() + match.getLength();
+            if (end > text.length()) {
+                continue;
+            }
+            String matched = text.substring(match.getStart(), end);
+            boolean equal = searchExpression.caseSensitive ? matched.equals(term)
+                    : matched.equalsIgnoreCase(term);
+            if (equal) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -369,6 +441,50 @@ public class Searcher {
     }
 
     /**
+     * The whole (trimmed) search term as one integer value: read universally
+     * first, then with the source and the target locale's separators. Only
+     * whole values take part, because the rendering alternation enumerates
+     * integer writings.
+     */
+    private Optional<BigInteger> searchTermValue(String term) {
+        Optional<BigInteger> universal = NumeralValueParser.parseTokenWhole(term,
+                searchExpression.matchNumbersRoman);
+        if (universal.isPresent()) {
+            return universal;
+        }
+        ProjectProperties props = project.getProjectProperties();
+        if (props == null) {
+            return Optional.empty();
+        }
+        for (Locale locale : new Locale[] { props.getSourceLanguage().getLocale(),
+                props.getTargetLanguage().getLocale() }) {
+            Optional<BigInteger> localized = NumeralValueParser
+                    .parseTokenValueLocalized(term, searchExpression.matchNumbersRoman, locale)
+                    .filter(v -> BigInteger.ONE.equals(v.denominator()))
+                    .map(NumeralValueParser.Rational::numerator);
+            if (localized.isPresent()) {
+                return localized;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * The value written with the project's source and target locale number
+     * formats, so "1234" also finds "1.234" in a German-English project.
+     */
+    private Stream<String> localeWritings(BigInteger value) {
+        ProjectProperties props = project.getProjectProperties();
+        if (props == null) {
+            return Stream.empty();
+        }
+        return Stream
+                .of(props.getSourceLanguage().getLocale(), props.getTargetLanguage().getLocale())
+                .flatMap(locale -> NumeralValueParser.localeRendering(value, locale).stream());
+    }
+
+
+    /**
      * Wrap the given regular expression so that it only matches whole words
      * (RFE#849). Lookaround on word characters is used instead of the word
      * boundary anchor so that search terms that start or end with a non-word
@@ -383,13 +499,16 @@ public class Searcher {
         return "(?<!\\w)(?:" + regex + ")(?!\\w)";
     }
 
+    /** Author matcher, created once per search (the pattern can be large). */
+    private @Nullable Matcher authorMatcher;
+
     /** create a matcher for the author search string. */
     private Matcher createAuthorSearchExpression() {
         String authorSearchExpression = searchExpression.author;
         int flags = searchExpression.caseSensitive ? 0 : Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
         if (searchExpression.searchExpressionType != SearchExpression.SearchExpressionType.REGEXP) {
-            authorSearchExpression = StaticUtils.globToRegex(authorSearchExpression,
-                    searchExpression.spaceMatchNbsp);
+            authorSearchExpression = MatchEquivalence.globToRegex(authorSearchExpression,
+                    searchExpression.equivalences);
         }
         return Pattern.compile(authorSearchExpression, flags).matcher("");
     }
@@ -1020,10 +1139,10 @@ public class Searcher {
      */
     boolean searchReplaceImpl(SearchExpression newSearchExpression, List<SearchMatch> foundMatchesList,
             Matcher matcher, int end, int start, Locale targetLocale) {
+        if ((end == start) && (start > 0)) {
+            return true;
+        }
         if (newSearchExpression.searchExpressionType == SearchExpression.SearchExpressionType.REGEXP) {
-            if ((end == start) && (start > 0)) {
-                return true;
-            }
             String repl = newSearchExpression.replacement;
             Matcher replaceMatcher = PatternConsts.REGEX_VARIABLE.matcher(repl);
             while (replaceMatcher.find()) {
@@ -1078,7 +1197,10 @@ public class Searcher {
      * @return True if the text string contains the search string
      */
     private boolean searchAuthor(@Nullable ITMXEntry te) {
-        Matcher author = createAuthorSearchExpression();
+        if (authorMatcher == null) {
+            authorMatcher = createAuthorSearchExpression();
+        }
+        Matcher author = authorMatcher;
         if (te == null) {
             return false;
         }

--- a/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -48,6 +49,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntPredicate;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.omegat.core.Core;
@@ -58,6 +60,7 @@ import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.matching.FuzzyMatcher;
 import org.omegat.core.matching.ISimilarityCalculator;
 import org.omegat.core.matching.LevenshteinDistance;
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.core.matching.NearString;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.statistics.FindMatches.StoppedException;
@@ -156,7 +159,7 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
         return null;
     }
 
-    private void appendText(String text) {
+    void appendText(String text) {
         textForLog.append(text);
         callback.appendTextData(text);
     }
@@ -245,6 +248,10 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
         if (outData) {
             String[][] table = result.calcTable(rowsTotal, i -> i != 1);
             String outText = TextUtil.showTextTable(header, table, align);
+            String note = matchEquivalenceNote();
+            if (!note.isEmpty()) {
+                outText = outText + "\n" + note + "\n";
+            }
             showText(outText);
             callback.setTable(header, table);
             String fn = project.getProjectProperties().getProjectInternal() + OConsts.STATS_MATCH_FILENAME;
@@ -253,6 +260,21 @@ public class CalcMatchStatistics extends CalcStandardStatistics implements ICalc
         }
 
         return result;
+    }
+
+    /**
+     * User-visible note naming the active character equivalence classes
+     * (#1681): folding changes match percentages, so the statistics say when
+     * it was in effect.
+     */
+    String matchEquivalenceNote() {
+        Set<MatchEquivalence> active = project.getProjectProperties().getActiveMatchEquivalences();
+        if (active.isEmpty()) {
+            return "";
+        }
+        String names = active.stream().map(MatchEquivalence::getLocalizedName)
+                .collect(Collectors.joining(", "));
+        return MessageFormat.format(OStrings.getString("CT_STATSMATCH_EQUIVALENCE_ACTIVE"), names);
     }
 
     void writeLog(String fn) {

--- a/src/main/java/org/omegat/core/statistics/CalcPerFileMatchStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/CalcPerFileMatchStatistics.java
@@ -94,6 +94,10 @@ public class CalcPerFileMatchStatistics extends CalcMatchStatistics implements I
         showTextTable(title, total, i -> i != 1, false);
         String fn = project.getProjectProperties().getProjectInternal()
                 + OConsts.STATS_MATCH_PER_FILE_FILENAME;
+        String note = matchEquivalenceNote();
+        if (!note.isEmpty()) {
+            appendText(note + "\n");
+        }
         writeLog(fn);
         callback.setDataFile(fn);
     }

--- a/src/main/java/org/omegat/core/statistics/FindMatches.java
+++ b/src/main/java/org/omegat/core/statistics/FindMatches.java
@@ -668,54 +668,18 @@ public class FindMatches {
         for (int i = 0; i < tokens.length; i++) {
             Token token = tokens[i];
             String text = token.getTextFromString(str);
-            BigInteger value = numeralValue(text);
+            // Roman numerals count here: a word misread as one only shifts the
+            // similarity a little, and reading them is the point of the option.
+            BigInteger value = NumeralValueParser.parseTokenWhole(text, true).orElse(null);
             String mappedText;
             if (value != null) {
-                mappedText = placeholder ? " #" : " #" + value;
+                mappedText = placeholder ? "\0#" : "\0#" + value;
             } else {
                 mappedText = text.toLowerCase(srcLocale);
             }
             mapped[i] = new Token(mappedText, token.getOffset(), token.getLength());
         }
         return mapped;
-    }
-
-    /**
-     * Matches a canonical uppercase Roman numeral; lowercase or non-canonical
-     * letter runs (like "mix" or "civil") stay ordinary words.
-     */
-    private static final Pattern CANONICAL_ROMAN = Pattern
-            .compile("M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})");
-    private static final Pattern ANY_ROMAN_DIGIT = Pattern.compile(".*[IVX].*");
-    /** Han numeral ideographs, the unambiguous CJK number tokens. */
-    private static final Pattern HAN_NUMERALS = Pattern.compile(
-            "[〇零一二三四五六七八九"
-                    + "十百千万萬億兆两兩]+");
-
-    /**
-     * The numeric value of a token, or null when the token must not be treated
-     * as a number. Tokens containing a decimal digit or letter numeral of any
-     * script always count; letter-only tokens count only in unambiguous forms
-     * (canonical uppercase Roman, Han numerals), so ordinary words are never
-     * misread as numerals.
-     */
-    private static BigInteger numeralValue(String text) {
-        boolean numeric = false;
-        for (int i = 0; i < text.length();) {
-            int cp = text.codePointAt(i);
-            int type = Character.getType(cp);
-            if (type == Character.DECIMAL_DIGIT_NUMBER || type == Character.LETTER_NUMBER) {
-                numeric = true;
-                break;
-            }
-            i += Character.charCount(cp);
-        }
-        if (!numeric
-                && !(CANONICAL_ROMAN.matcher(text).matches() && ANY_ROMAN_DIGIT.matcher(text).matches())
-                && !HAN_NUMERALS.matcher(text).matches()) {
-            return null;
-        }
-        return NumeralValueParser.parseWhole(text).orElse(null);
     }
 
     private void checkStopped(IStopped stop) throws StoppedException {

--- a/src/main/java/org/omegat/core/statistics/FindMatches.java
+++ b/src/main/java/org/omegat/core/statistics/FindMatches.java
@@ -49,10 +49,12 @@ import org.omegat.core.data.IProject;
 import org.omegat.core.data.ITMXEntry;
 import org.omegat.core.data.PrepareTMXEntry;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.data.StringData;
 import org.omegat.core.events.IStopped;
 import org.omegat.core.matching.FuzzyMatcher;
 import org.omegat.core.matching.ISimilarityCalculator;
 import org.omegat.core.matching.LevenshteinDistance;
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.core.matching.NearString;
 import org.omegat.core.segmentation.Rule;
 import org.omegat.core.segmentation.Segmenter;
@@ -143,6 +145,22 @@ public class FindMatches {
     /** Consider numbers by value during matching (project option, #465). */
     private final boolean matchNumbers;
 
+    /** Also read Latin-letter Roman numerals as numbers (project sub-option). */
+    private final boolean matchNumbersRoman;
+
+    /**
+     * Replacement map of the character equivalence classes active in this
+     * project (#1681); character variants fold together before comparison.
+     */
+    private final Map<Integer, String> equivalenceFoldMap;
+
+    /**
+     * Length-preserving subset of the fold map, applied to whole strings
+     * before tokenization so variant characters cannot shift word boundaries
+     * (straight and curly apostrophes segment differently).
+     */
+    private final Map<Integer, String> equivalenceSameLengthFoldMap;
+
     private final Segmenter segmenter;
 
     /**
@@ -194,6 +212,11 @@ public class FindMatches {
         this.searchExactlyTheSame = searchExactlyTheSame;
         this.fuzzyMatchThreshold = threshold;
         this.matchNumbers = project.getProjectProperties().isMatchNumbersEnabled();
+        this.matchNumbersRoman = project.getProjectProperties().isMatchNumbersRomanEnabled();
+        Set<MatchEquivalence> activeEquivalences = project.getProjectProperties()
+                .getActiveMatchEquivalences();
+        this.equivalenceFoldMap = MatchEquivalence.buildFoldMap(activeEquivalences);
+        this.equivalenceSameLengthFoldMap = MatchEquivalence.buildSameLengthFoldMap(activeEquivalences);
     }
 
     /**
@@ -407,7 +430,7 @@ public class FindMatches {
         // fill similarity data only for a result
         if (fillSimilarityData) {
             for (NearString near : result) {
-                near.attr = FuzzyMatcher.buildSimilarityData(strTokensAll, tokenizeAll(near.source));
+                near.attr = buildDisplaySimilarityData(near.source);
             }
         }
         return result;
@@ -601,6 +624,10 @@ public class FindMatches {
     Map<String, Token[]> tokenizeAllPlaceholderCache = new HashMap<>();
 
     Token[] tokenizeStem(String str) {
+        // Word-token passes compare token text only, so folding the whole
+        // string before tokenization is safe and also aligns token boundaries
+        // (an apostrophe variant can change word segmentation).
+        str = foldEquivalence(str);
         Token[] tokens = tokenizeStemCache.get(str);
         if (tokens == null) {
             if (Preferences.isPreference(Preferences.MATCHES_STEMMING_FULL)) {
@@ -616,7 +643,7 @@ public class FindMatches {
     Token[] tokenizeNoStem(String str) {
         // No-stemming token comparisons are intentionally case-insensitive
         // for matching purposes.
-        str = str.toLowerCase(srcLocale);
+        str = foldEquivalence(str.toLowerCase(srcLocale));
         Token[] tokens = tokenizeNoStemCache.get(str);
         if (tokens == null) {
             tokens = tok.tokenizeWords(str, ITokenizer.StemmingMode.NONE);
@@ -641,10 +668,69 @@ public class FindMatches {
         str = str.toLowerCase(srcLocale);
         Token[] tokens = tokenizeAllCache.get(str);
         if (tokens == null) {
-            tokens = tok.tokenizeVerbatim(str);
+            String folded = MatchEquivalence.foldSameLength(str, equivalenceSameLengthFoldMap);
+            tokens = foldTokens(tok.tokenizeVerbatim(folded), folded);
             tokenizeAllCache.put(str, tokens);
         }
         return tokens;
+    }
+
+    /**
+     * Similarity data for match-pane highlighting. The pane pairs the flags
+     * with a verbatim tokenization of the raw match source, while similarity
+     * is computed on the folded comparison tokens, whose boundaries can
+     * differ. The length-preserving fold keeps both tokenizations in the same
+     * string coordinates, so the folded flags project onto the raw tokens by
+     * offset overlap.
+     */
+    private byte[] buildDisplaySimilarityData(String matchSource) {
+        Token[] foldedTokens = tokenizeAll(matchSource);
+        byte[] foldedFlags = FuzzyMatcher.buildSimilarityData(strTokensAll, foldedTokens);
+        Token[] rawTokens = tok.tokenizeVerbatim(matchSource);
+        byte[] rawFlags = new byte[rawTokens.length];
+        for (int i = 0; i < rawTokens.length; i++) {
+            int rawStart = rawTokens[i].getOffset();
+            int rawEnd = rawStart + rawTokens[i].getLength();
+            byte flags = 0;
+            for (int j = 0; j < foldedTokens.length; j++) {
+                int foldedStart = foldedTokens[j].getOffset();
+                if (foldedStart < rawEnd && rawStart < foldedStart + foldedTokens[j].getLength()) {
+                    if ((foldedFlags[j] & StringData.UNIQ) != 0) {
+                        flags = StringData.UNIQ;
+                        break;
+                    }
+                    if ((foldedFlags[j] & StringData.PAIR) != 0) {
+                        flags = StringData.PAIR;
+                    }
+                }
+            }
+            rawFlags[i] = flags;
+        }
+        return rawFlags;
+    }
+
+    private String foldEquivalence(String str) {
+        return MatchEquivalence.fold(str, equivalenceFoldMap);
+    }
+
+    /**
+     * Verbatim tokens with equivalence folding applied to the token text;
+     * tokens folded to nothing (invisible formatting characters) are dropped.
+     * Offsets and lengths keep referring to the original string, so similarity
+     * data built from these tokens highlights the right characters.
+     */
+    private Token[] foldTokens(Token[] tokens, String str) {
+        List<Token> kept = new ArrayList<>(tokens.length);
+        for (Token token : tokens) {
+            String text = token.getTextFromString(str);
+            String folded = foldEquivalence(text);
+            if (folded.isEmpty()) {
+                continue;
+            }
+            kept.add(folded.equals(text) ? token
+                    : new Token(folded, token.getOffset(), token.getLength()));
+        }
+        return kept.toArray(new Token[0]);
     }
 
     Token[] tokenizeAllPlaceholder(String str) {
@@ -663,23 +749,27 @@ public class FindMatches {
      * equal). Other tokens are lowercased as in the plain verbatim pass.
      */
     private Token[] mapNumberTokens(String str, boolean placeholder) {
+        str = MatchEquivalence.foldSameLength(str, equivalenceSameLengthFoldMap);
         Token[] tokens = tok.tokenizeVerbatim(str);
-        Token[] mapped = new Token[tokens.length];
-        for (int i = 0; i < tokens.length; i++) {
-            Token token = tokens[i];
+        List<Token> mapped = new ArrayList<>(tokens.length);
+        for (Token token : tokens) {
             String text = token.getTextFromString(str);
-            // Roman numerals count here: a word misread as one only shifts the
-            // similarity a little, and reading them is the point of the option.
-            BigInteger value = NumeralValueParser.parseTokenWhole(text, true).orElse(null);
+            // Latin-letter Roman numerals only when the project opted in: a
+            // word misread as one only shifts the similarity a little, but the
+            // default keeps ordinary words out.
+            BigInteger value = NumeralValueParser.parseTokenWhole(text, matchNumbersRoman).orElse(null);
             String mappedText;
             if (value != null) {
                 mappedText = placeholder ? "\0#" : "\0#" + value;
             } else {
-                mappedText = text.toLowerCase(srcLocale);
+                mappedText = foldEquivalence(text.toLowerCase(srcLocale));
+                if (mappedText.isEmpty()) {
+                    continue;
+                }
             }
-            mapped[i] = new Token(mappedText, token.getOffset(), token.getLength());
+            mapped.add(new Token(mappedText, token.getOffset(), token.getLength()));
         }
-        return mapped;
+        return mapped.toArray(new Token[0]);
     }
 
     private void checkStopped(IStopped stop) throws StoppedException {

--- a/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -28,6 +28,7 @@ package org.omegat.core.team2;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -196,6 +197,60 @@ public class RemoteRepositoryProvider {
         return !getMappings(path).isEmpty();
     }
 
+    /**
+     * Whether every checked-out repository copy of the given project file is
+     * byte-identical to the file in the project directory, i.e. committing
+     * it would be a no-op. Only meaningful for files that are copied without
+     * EOL conversion, and after the repositories have been switched to a
+     * version.
+     */
+    public boolean isIdenticalInRepositories(String localPath) throws IOException {
+        File localFile = new File(projectRoot, localPath);
+        boolean found = false;
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile == null) {
+                continue;
+            }
+            if (!repoFile.exists() || !FileUtils.contentEquals(localFile, repoFile)) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
+    /**
+     * Like {@link #isIdenticalInRepositories}, but treating CRLF and LF line
+     * endings as equal: repository checkouts may re-line-end text files (git
+     * autocrlf on Windows), and that must not disguise an unchanged file as
+     * a change, whose empty commit then reports like a rejected push.
+     */
+    public boolean isIdenticalInRepositoriesIgnoringEol(String localPath) throws IOException {
+        File localFile = new File(projectRoot, localPath);
+        boolean found = false;
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile == null) {
+                continue;
+            }
+            if (!repoFile.exists() || !contentEqualsIgnoringEol(localFile, repoFile)) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
+    private static boolean contentEqualsIgnoringEol(File a, File b) throws IOException {
+        return normalizeEol(FileUtils.readFileToByteArray(a))
+                .equals(normalizeEol(FileUtils.readFileToByteArray(b)));
+    }
+
+    private static String normalizeEol(byte[] content) {
+        return new String(content, StandardCharsets.ISO_8859_1).replace("\r\n", "\n");
+    }
+
     public void cleanPrepared() throws IOException {
         FileUtils.deleteDirectory(new File(projectRoot, REPO_PREPARE_SUBDIR));
     }
@@ -297,6 +352,23 @@ public class RemoteRepositoryProvider {
         for (IRemoteRepository2 repo : repos.values()) {
             repo.commit(null, commentText);
         }
+    }
+
+    /**
+     * Same as commitFiles, but reports whether every affected repository
+     * accepted the commit: a rejected push (for example non-fast-forward)
+     * makes IRemoteRepository2.commit return null instead of throwing.
+     */
+    public boolean commitFilesChecked(String path, String commentText) throws Exception {
+        Map<String, IRemoteRepository2> repos = new TreeMap<>();
+        for (Mapping m : getMappings(path)) {
+            repos.put(m.repoDefinition.getUrl(), m.repo);
+        }
+        boolean accepted = true;
+        for (IRemoteRepository2 repo : repos.values()) {
+            accepted &= repo.commit(null, commentText) != null;
+        }
+        return accepted;
     }
 
     /**
@@ -509,6 +581,29 @@ public class RemoteRepositoryProvider {
          */
         public boolean matches() {
             return filterPrefix != null;
+        }
+
+        /**
+         * The file for the given project path inside this mapping's
+         * checked-out repository copy, or null when the path is outside the
+         * mapping.
+         */
+        @Nullable
+        File fileInRepository(String path) {
+            String p = withLeadingSlash(withoutTrailingSlash(path));
+            String local = withSlashes(repoMapping.getLocal());
+            String relative;
+            if (withTrailingSlash(p).equals(local)) {
+                // file mapping: the repository part is the file itself
+                relative = "";
+            } else if (p.startsWith(local)) {
+                relative = p.substring(local.length());
+            } else {
+                return null;
+            }
+            File base = new File(getRepositoryDir(repoDefinition),
+                    withoutLeadingSlash(repoMapping.getRepository()));
+            return new File(base, relative);
         }
 
         public void copyFromRepoToProject(final String postfix) throws IOException {

--- a/src/main/java/org/omegat/gui/dialogs/MatchEquivalenceDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/MatchEquivalenceDialog.java
@@ -1,0 +1,694 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.dialogs;
+
+import java.awt.BorderLayout;
+import java.awt.Dialog;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.datatransfer.StringSelection;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.Scrollable;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import org.jspecify.annotations.Nullable;
+import org.openide.awt.Mnemonics;
+
+import org.omegat.core.matching.MatchEquivalence;
+import org.omegat.util.NumeralValueParser;
+import org.omegat.util.OStrings;
+import org.omegat.util.gui.StaticUIUtils;
+
+/**
+ * Dialog listing the character equivalence classes used by fuzzy matching
+ * (feature request #1681). Every class shows a checkbox (all active by
+ * default) and its complete character inventory; a shared test area folds two
+ * sample texts with the currently checked classes and reports whether they
+ * compare as equal. The dialog also hosts the project option to compare
+ * numbers by value across the numeral systems.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+@SuppressWarnings("serial")
+public final class MatchEquivalenceDialog extends JDialog {
+
+    /**
+     * Prefill of the test area: the same mixed-language sentence in the
+     * typographic and the plain-keyboard writing, exercising every class
+     * (curly and CJK quotes, guillemets with narrow no-break space,
+     * apostrophes, dash, no-break space, soft hyphen).
+     */
+    static final String TEST_SAMPLE_TYPOGRAPHIC = "He said \u201cl\u2019\u00e9t\u00e9\u201d, "
+            + "\u00ab\u202foui\u202f\u00bb and \u300cはい\u300d \u2014 \u2019s morgens "
+            + "10\u00a0% dis\u00adcount on pages 3\u20134";
+    static final String TEST_SAMPLE_PLAIN = "He said \"l'\u00e9t\u00e9\", \" oui \" and \"はい\" - "
+            + "'s morgens 10 % discount on pages 3-4";
+
+    /**
+     * Prefill pairs of the test area, cycled by the example button: the
+     * classic sample plus consolidated multilingual pairs, together covering
+     * every character class and the number systems. The pure character pairs
+     * come first and fold equal even without the number option; the last
+     * pair uses Latin-letter Roman numerals and only compares equal with the
+     * Roman sub-option.
+     */
+    static final String[][] EXAMPLES = {
+            { TEST_SAMPLE_TYPOGRAPHIC, TEST_SAMPLE_PLAIN },
+            // French spacing, guillemets, German low quotes around Cyrillic,
+            // CJK corner brackets, em dash
+            { "Il a dit\u00a0: \u00ab\u202fbonjour\u202f\u00bb \u2014 \u201e\u0434\u0430\u201c und \u300cこんにちは\u300d",
+                    "Il a dit : \" bonjour \" - \"\u0434\u0430\" und \"こんにちは\"" },
+            // soft hyphens, narrow no-break space before the percent sign
+            { "co\u00ado\u00adp\u00e9ration 100\u202f% \u2014 \u00abfin\u00bb",
+                    "coop\u00e9ration 100 % - \"fin\"" },
+            // typographic quotes around fullwidth digits, guillemets around
+            // Persian digits
+            { "\u201c\uff11\uff12\uff13\uff14\uff15\u201d und \u00ab\u06f1\u06f2\u06f3\u00bb",
+                    "\"12345\" und \"123\"" },
+            // no-break space, Han numeral vs dedicated Roman code point, en
+            // dash inside a word, Arabic-Indic digits
+            { "Chapter\u00a0\u5341\u4e8c well\u2013known \u0664\u0662",
+                    "Chapter \u216b well-known 42" },
+            // soft hyphen inside a word, Thai digits, thin space, vulgar
+            // fraction vs decimal
+            { "dis\u00adcount \u0e57\u0e57\u0e57 Seite\u2009\u00bd",
+                    "discount 777 Seite 0.5" },
+            // Latin-letter Roman (needs the sub-option), em dash, Ethiopic ten
+            { "MMXXVI \u2014 \u1372", "2026 - 10" },
+    };
+
+    private final Map<MatchEquivalence, JCheckBox> checkboxes = new EnumMap<>(MatchEquivalence.class);
+    private final JCheckBox matchNumbersCheckBox = new JCheckBox();
+    private final JCheckBox matchNumbersRomanCheckBox = new JCheckBox();
+    private final JTextField testFieldA = new JTextField(30);
+    private final JTextField testFieldB = new JTextField(30);
+    private final JLabel testResult = new JLabel(" ");
+    private int exampleIndex;
+    private @Nullable Result result;
+    private @Nullable Set<MatchEquivalence> cachedActive;
+    private @Nullable Map<Integer, String> cachedFoldMap;
+
+
+    /**
+     * The two dynamically rendered pairs: long numbers with the grouping and
+     * decimal separators of the project's source (text A) and target (text
+     * B) locales.
+     */
+    static List<String[]> localeExamples(@Nullable Locale source, @Nullable Locale target) {
+        List<String[]> examples = new ArrayList<>();
+        if (source != null && target != null) {
+            NumberFormat src = NumberFormat.getIntegerInstance(source);
+            NumberFormat trg = NumberFormat.getIntegerInstance(target);
+            addWhenComparable(examples, source, target,
+                    new String[] { src.format(1234567890L), trg.format(1234567890L) });
+            NumberFormat srcDec = NumberFormat.getNumberInstance(source);
+            NumberFormat trgDec = NumberFormat.getNumberInstance(target);
+            srcDec.setMinimumFractionDigits(2);
+            trgDec.setMinimumFractionDigits(2);
+            addWhenComparable(examples, source, target,
+                    new String[] { srcDec.format(9876543.21), trgDec.format(9876543.21) });
+        }
+        return examples;
+    }
+
+    /**
+     * Guards the dynamic pairs: a locale whose number shape the comparator
+     * cannot resolve yet must not ship an example that reads "different".
+     */
+    private static void addWhenComparable(List<String[]> examples, Locale source, Locale target,
+            String[] pair) {
+        if (numbersCompareEqual(pair[0], pair[1], MatchEquivalence.all(), true, false, source, target)) {
+            examples.add(pair);
+        }
+    }
+
+    /** Every example pair: the shipped seven plus the two locale pairs. */
+    static List<String[]> allExamples(@Nullable Locale source, @Nullable Locale target) {
+        List<String[]> examples = new ArrayList<>(Arrays.asList(EXAMPLES));
+        examples.addAll(localeExamples(source, target));
+        return examples;
+    }
+
+    /** What the dialog was answered with: the disabled classes and the number options. */
+    public static final class Result {
+        private final Set<MatchEquivalence> disabled;
+        private final boolean matchNumbers;
+        private final boolean matchNumbersRoman;
+
+        Result(Set<MatchEquivalence> disabled, boolean matchNumbers, boolean matchNumbersRoman) {
+            EnumSet<MatchEquivalence> copy = EnumSet.noneOf(MatchEquivalence.class);
+            copy.addAll(disabled);
+            this.disabled = copy;
+            this.matchNumbers = matchNumbers;
+            this.matchNumbersRoman = matchNumbersRoman;
+        }
+
+        public Set<MatchEquivalence> getDisabled() {
+            return EnumSet.copyOf(disabled);
+        }
+
+        public boolean isMatchNumbers() {
+            return matchNumbers;
+        }
+
+        public boolean isMatchNumbersRoman() {
+            return matchNumbersRoman;
+        }
+    }
+
+    private final @Nullable Locale sourceLocale;
+    private final @Nullable Locale targetLocale;
+
+    private MatchEquivalenceDialog(Window parent, Set<MatchEquivalence> disabled, boolean matchNumbers,
+            boolean matchNumbersRoman, @Nullable Locale sourceLocale, @Nullable Locale targetLocale) {
+        super(parent, OStrings.getString("MATCH_EQUIVALENCE_DIALOG_TITLE"),
+                Dialog.ModalityType.APPLICATION_MODAL);
+        this.sourceLocale = sourceLocale;
+        this.targetLocale = targetLocale;
+        StaticUIUtils.setEscapeClosable(this);
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+
+        JPanel classesPanel = new WidthTrackingPanel();
+        classesPanel.setLayout(new BoxLayout(classesPanel, BoxLayout.Y_AXIS));
+        classesPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 0, 10));
+        JLabel nfcNote = new JLabel(OStrings.getString("MATCH_EQUIVALENCE_NFC_NOTE"));
+        nfcNote.setAlignmentX(LEFT_ALIGNMENT);
+        classesPanel.add(nfcNote);
+        for (MatchEquivalence eq : MatchEquivalence.values()) {
+            classesPanel.add(buildClassPanel(eq, disabled));
+        }
+        addNumberOptions(classesPanel, matchNumbers, matchNumbersRoman);
+
+        JPanel testPanel = new JPanel(new GridBagLayout());
+        testPanel.setBorder(BorderFactory.createTitledBorder(
+                OStrings.getString("MATCH_EQUIVALENCE_TEST_TITLE")));
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(2, 6, 2, 6);
+        gbc.anchor = GridBagConstraints.LINE_START;
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        testPanel.add(new JLabel(OStrings.getString("MATCH_EQUIVALENCE_TEST_TEXT_A")), gbc);
+        gbc.gridx = 1;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        testPanel.add(testFieldA, gbc);
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        gbc.weightx = 0;
+        gbc.fill = GridBagConstraints.NONE;
+        testPanel.add(new JLabel(OStrings.getString("MATCH_EQUIVALENCE_TEST_TEXT_B")), gbc);
+        gbc.gridx = 1;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        testPanel.add(testFieldB, gbc);
+        gbc.gridx = 2;
+        gbc.gridy = 0;
+        gbc.weightx = 0;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.gridheight = 2;
+        JButton exampleButton = new JButton();
+        Mnemonics.setLocalizedText(exampleButton, OStrings.getString("MATCH_EQUIVALENCE_EXAMPLE"));
+        exampleButton.setName("match_equivalence_example_button");
+        List<String[]> examples = allExamples(sourceLocale, targetLocale);
+        exampleButton.setToolTipText(
+                OStrings.getString("MATCH_EQUIVALENCE_EXAMPLE_TOOLTIP", examples.size()));
+        exampleButton.addActionListener(e -> {
+            exampleIndex = (exampleIndex + 1) % examples.size();
+            testFieldA.setText(examples.get(exampleIndex)[0]);
+            testFieldB.setText(examples.get(exampleIndex)[1]);
+        });
+        testPanel.add(exampleButton, gbc);
+        gbc.gridheight = 1;
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        gbc.gridwidth = 2;
+        testPanel.add(testResult, gbc);
+        DocumentListener testListener = new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateTestResult();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateTestResult();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                updateTestResult();
+            }
+        };
+        testFieldA.setText(TEST_SAMPLE_TYPOGRAPHIC);
+        testFieldB.setText(TEST_SAMPLE_PLAIN);
+        testFieldA.getDocument().addDocumentListener(testListener);
+        testFieldB.getDocument().addDocumentListener(testListener);
+
+        JButton okButton = new JButton();
+        Mnemonics.setLocalizedText(okButton, OStrings.getString("BUTTON_OK"));
+        okButton.setName("match_equivalence_ok_button");
+        okButton.addActionListener(e -> {
+            result = new Result(getDisabledFromCheckboxes(), matchNumbersCheckBox.isSelected(),
+                    matchNumbersRomanCheckBox.isSelected());
+            dispose();
+        });
+        JButton cancelButton = new JButton();
+        Mnemonics.setLocalizedText(cancelButton, OStrings.getString("BUTTON_CANCEL"));
+        cancelButton.setName("match_equivalence_cancel_button");
+        cancelButton.addActionListener(e -> dispose());
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.TRAILING));
+        buttonPanel.add(okButton);
+        buttonPanel.add(cancelButton);
+        getRootPane().setDefaultButton(okButton);
+
+        JPanel south = new JPanel();
+        south.setLayout(new BoxLayout(south, BoxLayout.Y_AXIS));
+        south.add(testPanel);
+        south.add(buttonPanel);
+
+        getContentPane().add(new JScrollPane(classesPanel), BorderLayout.CENTER);
+        getContentPane().add(south, BorderLayout.SOUTH);
+        classesPanel.add(Box.createVerticalGlue());
+        updateTestResult();
+        pack();
+        setSize(680, 490);
+        setLocationRelativeTo(parent);
+    }
+
+    /**
+     * Shows the dialog; returns the new set of disabled classes and the
+     * number options, or null when cancelled.
+     */
+    public static @Nullable Result show(Window parent, Set<MatchEquivalence> disabled,
+            boolean matchNumbers, boolean matchNumbersRoman, @Nullable Locale sourceLocale,
+            @Nullable Locale targetLocale) {
+        MatchEquivalenceDialog dialog = new MatchEquivalenceDialog(parent, disabled, matchNumbers,
+                matchNumbersRoman, sourceLocale, targetLocale);
+        dialog.setVisible(true);
+        return dialog.result;
+    }
+
+    private EnumSet<MatchEquivalence> getDisabledFromCheckboxes() {
+        EnumSet<MatchEquivalence> disabled = EnumSet.noneOf(MatchEquivalence.class);
+        checkboxes.forEach((eq, checkbox) -> {
+            if (!checkbox.isSelected()) {
+                disabled.add(eq);
+            }
+        });
+        return disabled;
+    }
+
+    /** Fold map of the given class set, rebuilt only when the set changes. */
+    private Map<Integer, String> foldMapFor(Set<MatchEquivalence> active) {
+        Map<Integer, String> foldMap = cachedFoldMap;
+        if (foldMap == null || !active.equals(cachedActive)) {
+            foldMap = MatchEquivalence.buildFoldMap(active);
+            cachedFoldMap = foldMap;
+            cachedActive = active.isEmpty() ? EnumSet.noneOf(MatchEquivalence.class)
+                    : EnumSet.copyOf(active);
+        }
+        return foldMap;
+    }
+
+    private void updateTestResult() {
+        Set<MatchEquivalence> active = EnumSet.complementOf(getDisabledFromCheckboxes());
+        boolean equal = numbersCompareEqual(testFieldA.getText(), testFieldB.getText(),
+                foldMapFor(active), matchNumbersCheckBox.isSelected(),
+                matchNumbersRomanCheckBox.isSelected(), sourceLocale, targetLocale);
+        testResult.setText(OStrings.getString(
+                equal ? "MATCH_EQUIVALENCE_TEST_EQUAL" : "MATCH_EQUIVALENCE_TEST_DIFFERENT"));
+    }
+
+    /**
+     * Comparison of the test area: both texts fold with the active classes,
+     * then compare token by token; with the numbers option, two tokens that
+     * read as numbers compare by value instead of by characters. Mirroring
+     * the tokenized matching, runs of plain whitespace compare as one
+     * separator.
+     */
+    static boolean numbersCompareEqual(String a, String b, Set<MatchEquivalence> active,
+            boolean numbers, boolean roman, @Nullable Locale sourceLocale,
+            @Nullable Locale targetLocale) {
+        return numbersCompareEqual(a, b, MatchEquivalence.buildFoldMap(active), numbers, roman,
+                sourceLocale, targetLocale);
+    }
+
+    static boolean numbersCompareEqual(String a, String b, Map<Integer, String> foldMap,
+            boolean numbers, boolean roman, @Nullable Locale sourceLocale,
+            @Nullable Locale targetLocale) {
+        String[] tokensA = MatchEquivalence.fold(a, foldMap).trim().split("\\s+");
+        String[] tokensB = MatchEquivalence.fold(b, foldMap).trim().split("\\s+");
+        if (tokensA.length != tokensB.length) {
+            return false;
+        }
+        for (int i = 0; i < tokensA.length; i++) {
+            if (tokensA[i].equals(tokensB[i])) {
+                continue;
+            }
+            if (!numbers) {
+                return false;
+            }
+            // Text A reads with the source locale's separators, text B with
+            // the target locale's, so "1.234,5" and "1,234.5" compare equal
+            // between a German source and an English target. When the whole
+            // tokens do not read as numbers, common folded affixes (quotes
+            // around a number) come off and the cores compare instead.
+            NumeralValueParser.Rational va = NumeralValueParser
+                    .parseTokenValueLocalized(tokensA[i], roman, sourceLocale).orElse(null);
+            NumeralValueParser.Rational vb = NumeralValueParser
+                    .parseTokenValueLocalized(tokensB[i], roman, targetLocale).orElse(null);
+            if (va == null || vb == null) {
+                String[] cores = trimCommonAffixes(tokensA[i], tokensB[i]);
+                va = NumeralValueParser.parseTokenValueLocalized(cores[0], roman, sourceLocale)
+                        .orElse(null);
+                vb = NumeralValueParser.parseTokenValueLocalized(cores[1], roman, targetLocale)
+                        .orElse(null);
+            }
+            if (va == null || vb == null || va.compareTo(vb) != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Strips the longest common prefix and suffix from both tokens, so a
+     * number wrapped in already-folded punctuation still reaches the value
+     * comparison as its bare core.
+     */
+    private static String[] trimCommonAffixes(String a, String b) {
+        int prefix = 0;
+        while (prefix < a.length() && prefix < b.length() && a.charAt(prefix) == b.charAt(prefix)) {
+            prefix++;
+        }
+        int endA = a.length();
+        int endB = b.length();
+        while (endA > prefix && endB > prefix && a.charAt(endA - 1) == b.charAt(endB - 1)) {
+            endA--;
+            endB--;
+        }
+        return new String[] { a.substring(prefix, endA), b.substring(prefix, endB) };
+    }
+
+    /**
+     * Scroll view that always takes the viewport's width, so wrapping text
+     * children re-wrap when the dialog is resized; vertical scrolling stays.
+     */
+    @SuppressWarnings("serial")
+    private static final class WidthTrackingPanel extends JPanel implements Scrollable {
+        @Override
+        public Dimension getPreferredScrollableViewportSize() {
+            return getPreferredSize();
+        }
+
+        @Override
+        public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction) {
+            return 16;
+        }
+
+        @Override
+        public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
+            return 64;
+        }
+
+        @Override
+        public boolean getScrollableTracksViewportWidth() {
+            return true;
+        }
+
+        @Override
+        public boolean getScrollableTracksViewportHeight() {
+            return false;
+        }
+    }
+
+    /**
+     * Context menu of a class label or group line: copies the selection (or
+     * the whole line) and, as the successor of the removed copy buttons, the
+     * complete replacement table of the class.
+     */
+    private static JPopupMenu replacementsCopyMenu(String[] memberLines, @Nullable JTextArea line) {
+        JPopupMenu menu = new JPopupMenu();
+        if (line != null) {
+            JMenuItem copyLine = new JMenuItem(OStrings.getString("CCP_COPY"));
+            copyLine.addActionListener(e -> Toolkit.getDefaultToolkit().getSystemClipboard()
+                    .setContents(new StringSelection(
+                            line.getSelectedText() != null ? line.getSelectedText() : line.getText()),
+                            null));
+            menu.add(copyLine);
+        }
+        JMenuItem copyAll = new JMenuItem(
+                OStrings.getString("MATCH_EQUIVALENCE_COPY_ALL", memberLines.length));
+        copyAll.addActionListener(e -> Toolkit.getDefaultToolkit().getSystemClipboard()
+                .setContents(new StringSelection(String.join("\n", memberLines)), null));
+        menu.add(copyAll);
+        return menu;
+    }
+
+    /**
+     * Checkbox and the per-group summary lines of one class. The full member
+     * inventory lives in the context menus (copy of the replacement table)
+     * and in the per-character tooltips of the summary lines, not in a table.
+     */
+    private JPanel buildClassPanel(MatchEquivalence eq, Set<MatchEquivalence> disabled) {
+        JCheckBox checkbox = new JCheckBox(eq.getLocalizedName(), !disabled.contains(eq));
+        checkbox.setName("match_equivalence_" + eq.getId() + "_cb");
+        checkbox.addActionListener(e -> updateTestResult());
+        checkboxes.put(eq, checkbox);
+
+        String[] memberLines = describeMembers(eq);
+        // The full replacement table travels through the context menu of the
+        // class label and of its group lines, not through a button.
+        checkbox.setComponentPopupMenu(replacementsCopyMenu(memberLines, null));
+
+        JPanel classPanel = new JPanel();
+        classPanel.setLayout(new BoxLayout(classPanel, BoxLayout.Y_AXIS));
+        checkbox.setAlignmentX(LEFT_ALIGNMENT);
+        classPanel.add(checkbox);
+        for (GroupLine group : describeGroupLines(eq)) {
+            JTextArea groupLine = new GroupLineArea(group, eq);
+            groupLine.setEditable(false);
+            groupLine.setOpaque(false);
+            groupLine.setFont(new Font(Font.MONOSPACED, Font.PLAIN, groupLine.getFont().getSize()));
+            groupLine.setBorder(BorderFactory.createEmptyBorder(0, 24, 2, 0));
+            groupLine.setAlignmentX(LEFT_ALIGNMENT);
+            groupLine.setFocusTraversalKeysEnabled(true);
+            groupLine.setComponentPopupMenu(replacementsCopyMenu(memberLines, groupLine));
+            classPanel.add(groupLine);
+        }
+        classPanel.setAlignmentX(LEFT_ALIGNMENT);
+        classPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 4, 0));
+        return classPanel;
+    }
+
+    /** One summary line with the member behind every space-separated token. */
+    static final class GroupLine {
+        private final String text;
+        private final List<Integer> memberCps;
+
+        GroupLine(String text, List<Integer> memberCps) {
+            this.text = text;
+            this.memberCps = memberCps;
+        }
+
+        String getText() {
+            return text;
+        }
+
+        List<Integer> getMemberCps() {
+            return memberCps;
+        }
+
+        /** The member code point of the token containing the text offset, or -1. */
+        int memberAt(int offset) {
+            if (offset < 0 || offset >= text.length()) {
+                return -1;
+            }
+            int token = 0;
+            for (int i = 0; i < offset; i++) {
+                if (text.charAt(i) == ' ') {
+                    token++;
+                }
+            }
+            return text.charAt(offset) == ' ' || token >= memberCps.size() ? -1 : memberCps.get(token);
+        }
+    }
+
+    /** Summary line whose characters answer with their own replacement tooltip. */
+    @SuppressWarnings("serial")
+    private static final class GroupLineArea extends JTextArea {
+        private final GroupLine group;
+        private final MatchEquivalence eq;
+
+        GroupLineArea(GroupLine group, MatchEquivalence eq) {
+            super(group.getText());
+            this.group = group;
+            this.eq = eq;
+            // Long lines (the invisibles list) wrap instead of being cut off
+            // by the width-tracking panel; model offsets keep the tooltips
+            // correct across wrapped rows.
+            setLineWrap(true);
+            setWrapStyleWord(true);
+            javax.swing.ToolTipManager.sharedInstance().registerComponent(this);
+        }
+
+        @Override
+        public @Nullable String getToolTipText(java.awt.event.MouseEvent event) {
+            int cp = group.memberAt(viewToModel2D(event.getPoint()));
+            if (cp < 0) {
+                return null;
+            }
+            String replacement = eq.getMembers().get(cp);
+            return replacement == null ? null : describeMember(cp, replacement);
+        }
+    }
+
+    /**
+     * The number options compare values instead of folding character lists,
+     * so they carry no inventory and do not take part in the character test
+     * area. The Roman sub-option only applies while number matching is on.
+     */
+    private void addNumberOptions(JPanel classesPanel, boolean matchNumbers, boolean matchNumbersRoman) {
+        Mnemonics.setLocalizedText(matchNumbersCheckBox,
+                OStrings.getString("MATCH_EQUIVALENCE_NUMBERS"));
+        // The explanation lives in the tooltip, wrapped by the html body
+        // width, keeping the window itself uncluttered.
+        matchNumbersCheckBox.setToolTipText("<html><body style='width: 380px'>"
+                + OStrings.getString("MATCH_EQUIVALENCE_NUMBERS_TOOLTIP") + "</body></html>");
+        matchNumbersCheckBox.setSelected(matchNumbers);
+        matchNumbersCheckBox.setName("match_equivalence_numbers_cb");
+        matchNumbersCheckBox.setAlignmentX(LEFT_ALIGNMENT);
+        classesPanel.add(matchNumbersCheckBox);
+
+        Mnemonics.setLocalizedText(matchNumbersRomanCheckBox,
+                OStrings.getString("MATCH_EQUIVALENCE_NUMBERS_ROMAN"));
+        matchNumbersRomanCheckBox.setSelected(matchNumbersRoman);
+        matchNumbersRomanCheckBox.setEnabled(matchNumbers);
+        matchNumbersRomanCheckBox.setName("match_equivalence_numbers_roman_cb");
+        matchNumbersRomanCheckBox.setAlignmentX(LEFT_ALIGNMENT);
+        matchNumbersRomanCheckBox.setBorder(BorderFactory.createEmptyBorder(0, 24, 0, 0));
+        classesPanel.add(matchNumbersRomanCheckBox);
+        matchNumbersCheckBox.addActionListener(e -> {
+            matchNumbersRomanCheckBox.setEnabled(matchNumbersCheckBox.isSelected());
+            updateTestResult();
+        });
+        matchNumbersRomanCheckBox.addActionListener(e -> updateTestResult());
+    }
+
+    /**
+     * One display line per member: glyph and code point, name, then the
+     * replacement target as glyph and code point(s) so the direction of the
+     * folding stays visible.
+     */
+    static String[] describeMembers(MatchEquivalence eq) {
+        return eq.getMembers().entrySet().stream()
+                .map(entry -> describeMember(entry.getKey(), entry.getValue()))
+                .toArray(String[]::new);
+    }
+
+    /** One member as glyph, code point, name and replacement target. */
+    static String describeMember(int cp, String replacement) {
+        String glyph = new String(Character.toChars(cp));
+        String name = Character.getName(cp);
+        if (name == null) {
+            name = "?";
+        }
+        String target = replacement.isEmpty() ? OStrings.getString("MATCH_EQUIVALENCE_REMOVED")
+                : replacement + "  " + codePointsOf(replacement);
+        return String.format(Locale.ROOT, "%s  U+%04X  %s  →  %s", glyph, cp, name, target);
+    }
+
+    /** "U+XXXX"-form of every code point of the given replacement string. */
+    private static String codePointsOf(String s) {
+        return s.codePoints().mapToObj(cp -> String.format(Locale.ROOT, "U+%04X", cp))
+                .collect(Collectors.joining(" "));
+    }
+
+    /**
+     * One line per group of inter-compatible members, e.g. {@code " “ ” „}
+     * and {@code ' ‘ ’} as two lines of the quotes class. Members without a
+     * visible glyph (spaces, invisible formatting) show their code point
+     * instead, so the space and invisible classes still carry information.
+     */
+    static List<String> describeGroups(MatchEquivalence eq) {
+        return describeGroupLines(eq).stream().map(GroupLine::getText).collect(Collectors.toList());
+    }
+
+    /** The group lines with the member behind every token, for the tooltips. */
+    static List<GroupLine> describeGroupLines(MatchEquivalence eq) {
+        Map<String, List<Integer>> groups = new LinkedHashMap<>();
+        eq.getMembers().forEach((cp, replacement) -> groups
+                .computeIfAbsent(replacement, k -> new ArrayList<>()).add(cp));
+        return groups.values().stream()
+                .map(cps -> new GroupLine(
+                        cps.stream().map(MatchEquivalenceDialog::visibleForm)
+                                .collect(Collectors.joining(" ")),
+                        cps))
+                .collect(Collectors.toList());
+    }
+
+    /** The glyph itself, or the code point for characters with no visible glyph. */
+    private static String visibleForm(int cp) {
+        if (Character.isWhitespace(cp) || Character.isSpaceChar(cp)
+                || Character.getType(cp) == Character.FORMAT) {
+            return String.format(Locale.ROOT, "U+%04X", cp);
+        }
+        return new String(Character.toChars(cp));
+    }
+
+}

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
@@ -407,13 +407,13 @@ public class ProjectPropertiesDialog extends JDialog {
         gbc.anchor = GridBagConstraints.LINE_START;
         optionsBox.add(removeTagsCheckBox, gbc);
 
-        // Numbers in fuzzy matching
-        Mnemonics.setLocalizedText(matchNumbersCheckBox, OStrings.getString("PP_MATCH_NUMBERS"));
-        matchNumbersCheckBox.setName(MATCH_NUMBERS_CB_NAME);
+        // Character and number equivalences in fuzzy matching
+        Mnemonics.setLocalizedText(matchEquivalenceButton, OStrings.getString("PP_MATCH_EQUIVALENCE"));
+        matchEquivalenceButton.setName(MATCH_EQUIVALENCE_BUTTON_NAME);
         gbc.gridx = 0;
         gbc.gridy = 3;
         gbc.anchor = GridBagConstraints.LINE_START;
-        optionsBox.add(matchNumbersCheckBox, gbc);
+        optionsBox.add(matchEquivalenceButton, gbc);
 
         return optionsBox;
     }
@@ -666,7 +666,7 @@ public class ProjectPropertiesDialog extends JDialog {
         sentenceSegmentingCheckBox.setEnabled(false);
         allowDefaultsCheckBox.setEnabled(false);
         removeTagsCheckBox.setEnabled(false);
-        matchNumbersCheckBox.setEnabled(false);
+        matchEquivalenceButton.setEnabled(false);
         externalCommandTextArea.setEnabled(false);
         insertButton.setEnabled(false);
         variablesList.setEnabled(false);
@@ -774,8 +774,8 @@ public class ProjectPropertiesDialog extends JDialog {
     // Remove Tags
     JCheckBox removeTagsCheckBox = new JCheckBox();
 
-    // Numbers in fuzzy matching
-    JCheckBox matchNumbersCheckBox = new JCheckBox();
+    // Character and number equivalences in fuzzy matching
+    JButton matchEquivalenceButton = new JButton();
     JButton exportTMBrowse = new JButton();
     JButton sentenceSegmentingButton = new JButton();
 
@@ -838,7 +838,7 @@ public class ProjectPropertiesDialog extends JDialog {
     public static final String SENTENCE_SEGMENTING_BUTTON_NAME = "project_properties_sentence_segmenting_button";
     public static final String ALLOW_DEFAULTS_CB_NAME = "project_properties_allow_defaults_cb";
     public static final String REMOVE_TAGS_CB_NAME = "project_properties_remove_tags_cb";
-    public static final String MATCH_NUMBERS_CB_NAME = "project_properties_match_numbers_cb";
+    public static final String MATCH_EQUIVALENCE_BUTTON_NAME = "project_properties_match_equivalence_button";
     public static final String EXPORT_TM_BROWSE_BUTTON_NAME = "project_properties_export_tm_browse_button";
     public static final String FILE_FILTER_BUTTON_NAME = "project_properties_file_filter_button";
     public static final String EXPORT_TM_ROOT_FIELD_NAME = "project_properties_export_tm_root_field";

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
@@ -37,7 +37,9 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.swing.AbstractAction;
 import javax.swing.JButton;
@@ -48,6 +50,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.externalfinder.ExternalFinder;
 import org.omegat.externalfinder.gui.ExternalFinderCustomizer;
@@ -74,6 +77,9 @@ public class ProjectPropertiesDialogController {
 
     /** Project SRX. */
     private SRX srx;
+    private Set<MatchEquivalence> disabledMatchEquivalences = EnumSet.noneOf(MatchEquivalence.class);
+    private boolean matchNumbersEnabled;
+    private boolean matchNumbersRomanEnabled;
 
     /** Project filters. */
     private Filters filters;
@@ -127,7 +133,9 @@ public class ProjectPropertiesDialogController {
         dialog.sentenceSegmentingCheckBox.setSelected(projectProperties.isSentenceSegmentingEnabled());
         dialog.allowDefaultsCheckBox.setSelected(projectProperties.isSupportDefaultTranslations());
         dialog.removeTagsCheckBox.setSelected(projectProperties.isRemoveTags());
-        dialog.matchNumbersCheckBox.setSelected(projectProperties.isMatchNumbersEnabled());
+        matchNumbersEnabled = projectProperties.isMatchNumbersEnabled();
+        matchNumbersRomanEnabled = projectProperties.isMatchNumbersRomanEnabled();
+        disabledMatchEquivalences = projectProperties.getDisabledMatchEquivalences();
 
         dialog.sourceLocaleField.setSelectedItem(projectProperties.getSourceLanguage());
         dialog.targetLocaleField.setSelectedItem(projectProperties.getTargetLanguage());
@@ -183,6 +191,17 @@ public class ProjectPropertiesDialogController {
             List<RepositoryDefinition> r = rmd.show(projectProperties.getRepositories());
             if (r != null) {
                 projectProperties.setRepositories(r);
+            }
+        });
+        dialog.matchEquivalenceButton.addActionListener(e -> {
+            MatchEquivalenceDialog.Result updated = MatchEquivalenceDialog.show(dialog,
+                    disabledMatchEquivalences, matchNumbersEnabled, matchNumbersRomanEnabled,
+                    projectProperties.getSourceLanguage().getLocale(),
+                    projectProperties.getTargetLanguage().getLocale());
+            if (updated != null) {
+                disabledMatchEquivalences = updated.getDisabled();
+                matchNumbersEnabled = updated.isMatchNumbers();
+                matchNumbersRomanEnabled = updated.isMatchNumbersRoman();
             }
         });
         dialog.externalFinderButton.addActionListener(e -> {
@@ -545,7 +564,9 @@ public class ProjectPropertiesDialogController {
         projectProperties.setSentenceSegmentingEnabled(dialog.sentenceSegmentingCheckBox.isSelected());
         projectProperties.setSupportDefaultTranslations(dialog.allowDefaultsCheckBox.isSelected());
         projectProperties.setRemoveTags(dialog.removeTagsCheckBox.isSelected());
-        projectProperties.setMatchNumbersEnabled(dialog.matchNumbersCheckBox.isSelected());
+        projectProperties.setMatchNumbersEnabled(matchNumbersEnabled);
+        projectProperties.setMatchNumbersRomanEnabled(matchNumbersRomanEnabled);
+        projectProperties.setDisabledMatchEquivalences(disabledMatchEquivalences);
         projectProperties.setExportTmLevels(dialog.exportTMOmegaTCheckBox.isSelected(),
                 dialog.exportTMLevel1CheckBox.isSelected(), dialog.exportTMLevel2CheckBox.isSelected());
         projectProperties.setExternalCommand(dialog.externalCommandTextArea.getText());

--- a/src/main/java/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/main/java/org/omegat/gui/main/ProjectUICommands.java
@@ -40,7 +40,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
@@ -58,9 +60,12 @@ import org.omegat.convert.ConvertProject;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.KnownException;
+import org.omegat.core.data.IProject;
 import org.omegat.core.data.ProjectFactory;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.RuntimePreferenceStore;
+import org.omegat.core.data.TeamSetting;
+import org.omegat.core.data.TeamSettingsRegistry;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.segmentation.SRXManager;
@@ -329,13 +334,104 @@ public final class ProjectUICommands {
             protected void done() {
                 try {
                     get();
-                    SwingUtilities.invokeLater(Core.getEditor()::requestFocus);
+                    SwingUtilities.invokeLater(() -> {
+                        Core.getEditor().requestFocus();
+                        promptForSupersededSettings();
+                    });
                 } catch (Exception ex) {
                     Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                     Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                 }
             }
         }.execute();
+    }
+
+    /**
+     * The team's project settings file of the just opened team project
+     * carried different values than this checkout, and the team values are
+     * now active. Asks the user per setting what to do with the local value:
+     * share it with the team, use the team's value, or restore it for this
+     * session only - the next open supersedes and asks again. Dismissing a
+     * dialog leaves the team's value active.
+     */
+    private static void promptForSupersededSettings() {
+        IProject project = Core.getProject();
+        if (!project.isProjectLoaded()) {
+            return;
+        }
+        for (Map.Entry<String, @Nullable String> entry : project.getSupersededLocalSettings().entrySet()) {
+            TeamSetting setting = TeamSettingsRegistry.byKey(entry.getKey());
+            if (setting == null) {
+                continue;
+            }
+            String localValue = entry.getValue();
+            String teamValue = setting.read(project.getProjectProperties());
+            String[] options = { OStrings.getString("TEAM_SETTING_SHARE"),
+                    OStrings.getString("TEAM_SETTING_TAKE_TEAM"),
+                    OStrings.getString("TEAM_SETTING_KEEP_THIS_TIME") };
+            int answer = JOptionPane.showOptionDialog(Core.getMainWindow().getApplicationFrame(),
+                    OStrings.getString("TEAM_SETTING_DIVERGED_MESSAGE", setting.getDisplayName(),
+                            setting.describe(localValue), setting.describe(teamValue)),
+                    OStrings.getString("TEAM_SETTING_DIVERGED_TITLE"), JOptionPane.DEFAULT_OPTION,
+                    JOptionPane.QUESTION_MESSAGE, null, options, options[1]);
+            if (answer != 0 && answer != 1 && answer != 2) {
+                // Dismissed: the team's value stays active for this session,
+                // the local file keeps the local value, and the next open
+                // asks again.
+                continue;
+            }
+            boolean share = answer == 0;
+            String value = answer == 1 ? teamValue : localValue;
+            // The repository work must stay off the EDT and must not run
+            // beside the auto-save thread. Taking the team's value persists
+            // it locally, so the divergence is settled instead of
+            // resurfacing on every open.
+            new SwingWorker<Void, Void>() {
+                @Override
+                protected Void doInBackground() throws Exception {
+                    Core.executeExclusively(true, () -> {
+                        try {
+                            if (share) {
+                                project.publishProjectSetting(entry.getKey(), value);
+                            } else {
+                                project.useLocalProjectSetting(entry.getKey(), value);
+                            }
+                        } catch (Exception ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    });
+                    return null;
+                }
+
+                @Override
+                protected void done() {
+                    try {
+                        get();
+                    } catch (Exception ex) {
+                        String key = share ? "TEAM_SETTING_SHARE_ERROR" : "TEAM_SETTING_APPLY_ERROR";
+                        Log.logErrorRB(ex, key);
+                        Core.getMainWindow().displayErrorRB(ex, key);
+                    }
+                }
+            }.execute();
+        }
+    }
+
+    /** Session values of all registered team settings, keyed by setting key. */
+    private static Map<String, @Nullable String> readSessionTeamSettings() {
+        Map<String, @Nullable String> values = new HashMap<>();
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            values.put(setting.getKey(), setting.read(props));
+        }
+        return values;
+    }
+
+    private static void applySessionTeamSettings(Map<String, @Nullable String> values) {
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            setting.apply(props, values.get(setting.getKey()));
+        }
     }
 
     private static @Nullable File selectProjectRootFolder(File projectDirectory) {
@@ -864,18 +960,64 @@ public final class ProjectUICommands {
         // commit the current entry first
         Core.getEditor().commitAndLeave();
 
+        // The dialog edits the live properties, so the current values have
+        // to be captured before it is shown.
+        final Map<String, @Nullable String> teamSettingsBefore = readSessionTeamSettings();
+
         // displaying the dialog to change paths and other properties
         final ProjectProperties newProps =
                 ProjectPropertiesDialogController.showDialog(frame, Core.getProject().getProjectProperties(),
                 Core.getProject().getProjectProperties().getProjectName(),
                 ProjectPropertiesDialog.Mode.EDIT_PROJECT);
         if (newProps == null) {
+            // The dialog edits the live properties even before a validation
+            // stops its OK, so cancelling must not leave flipped values.
+            applySessionTeamSettings(teamSettingsBefore);
             return;
         }
+
+        // Changing a team setting right here is the natural moment to offer
+        // its distribution; declining keeps it local, and the next open of
+        // the project asks again.
+        final Map<String, @Nullable String> changedTeamSettings = new HashMap<>();
+        if (Core.getProject().isRemoteProject()) {
+            for (TeamSetting setting : TeamSettingsRegistry.all()) {
+                String after = setting.read(newProps);
+                if (!Objects.equals(teamSettingsBefore.get(setting.getKey()), after)) {
+                    changedTeamSettings.put(setting.getKey(), after);
+                }
+            }
+        }
+        final Map<String, @Nullable String> settingsToShare = new HashMap<>();
+        changedTeamSettings.forEach((key, value) -> {
+            TeamSetting setting = TeamSettingsRegistry.byKey(key);
+            if (setting != null && promptToShareSettingChange(setting, value)) {
+                settingsToShare.put(key, value);
+            }
+        });
 
         int res = JOptionPane.showConfirmDialog(frame, OStrings.getString("MW_REOPEN_QUESTION"),
                 OStrings.getString("MW_REOPEN_TITLE"), JOptionPane.YES_NO_OPTION);
         if (res != JOptionPane.YES_OPTION) {
+            if (!settingsToShare.isEmpty()) {
+                new SwingWorker<Void, Void>() {
+                    @Override
+                    protected Void doInBackground() throws Exception {
+                        Core.executeExclusively(true, () -> publishSettingsLoggingErrors(settingsToShare));
+                        return null;
+                    }
+
+                    @Override
+                    protected void done() {
+                        try {
+                            get();
+                        } catch (Exception ex) {
+                            Log.logErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                            Core.getMainWindow().displayErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                        }
+                    }
+                }.execute();
+            }
             return;
         }
 
@@ -885,10 +1027,30 @@ public final class ProjectUICommands {
             @Override
             protected Void doInBackground() throws Exception {
                 Core.executeExclusively(true, () -> {
+                    if (!settingsToShare.isEmpty()) {
+                        // A failed share must not abort the reload; the
+                        // local file keeps the value, so the next open
+                        // offers the distribution again.
+                        publishSettingsLoggingErrors(settingsToShare);
+                    }
                     Core.getProject().saveProject(true);
                     ProjectFactory.closeProject();
 
                     ProjectFactory.loadProject(newProps, true);
+                    changedTeamSettings.forEach((key, value) -> {
+                        if (!settingsToShare.containsKey(key)) {
+                            // The share was declined, so the freshly chosen
+                            // value must stay local: without this, the
+                            // reload would classify it as local-only
+                            // divergence and fall back to the team default
+                            // without a word.
+                            try {
+                                Core.getProject().useLocalProjectSetting(key, value);
+                            } catch (Exception ex) {
+                                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                            }
+                        }
+                    });
                 });
                 return null;
             }
@@ -908,6 +1070,32 @@ public final class ProjectUICommands {
                 }
             }
         }.execute();
+    }
+
+    /**
+     * The properties dialog of a team project just changed a registered
+     * team setting; asks whether to distribute the change.
+     */
+    private static boolean promptToShareSettingChange(TeamSetting setting, @Nullable String value) {
+        String[] options = { OStrings.getString("TEAM_SETTING_SHARE"),
+                OStrings.getString("TEAM_SETTING_KEEP_FOR_NOW") };
+        return JOptionPane.showOptionDialog(Core.getMainWindow().getApplicationFrame(),
+                OStrings.getString("TEAM_SETTING_CHANGED_MESSAGE", setting.getDisplayName(),
+                        setting.describe(value)),
+                OStrings.getString("TEAM_SETTING_DIVERGED_TITLE"), JOptionPane.DEFAULT_OPTION,
+                JOptionPane.QUESTION_MESSAGE, null, options, options[0]) == 0;
+    }
+
+    private static void publishSettingsLoggingErrors(Map<String, @Nullable String> settings) {
+        settings.forEach((key, value) -> {
+            try {
+                Core.getProject().publishProjectSetting(key, value);
+            } catch (Exception ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                SwingUtilities.invokeLater(
+                        () -> Core.getMainWindow().displayErrorRB(ex, "TEAM_SETTING_SHARE_ERROR"));
+            }
+        });
     }
 
     public static void projectCompile() {

--- a/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
@@ -403,20 +403,50 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
      * Render the given source number in the digit script of the target token it
      * replaces, which is what makes a full-width target keep full-width digits
      * (feature request #1193). A target written in a system this code cannot
-     * write back, a Han numeral for one, receives plain digits instead: the right
-     * number in a foreign notation beats the wrong number in the right one.
+     * write back, a Tamil numeral for one, receives plain digits instead: the
+     * right number in a foreign notation beats the wrong number in the right
+     * one.
      */
     private static String renderLike(String number, String template) {
         int zero = digitZeroOf(template);
         if (zero < 0) {
+            // The target writes a numeral system, not digits: write the source
+            // value in that system, whatever system the source itself uses.
+            Optional<NumeralValueParser.Rational> sourceValue = NumeralValueParser.parseTokenValue(number,
+                    ALLOW_ROMAN);
+            if (sourceValue.isPresent()) {
+                if (BigInteger.ONE.equals(sourceValue.get().denominator())) {
+                    Optional<String> rendered = NumeralValueParser
+                            .renderInSystemOf(sourceValue.get().numerator(), template);
+                    if (rendered.isPresent()) {
+                        return rendered.get();
+                    }
+                } else {
+                    // A fraction value: a vulgar-fraction target receives the
+                    // matching precomposed glyph; a value without a glyph is
+                    // spelled out, because the right number in a foreign
+                    // notation beats the target's own, wrong one.
+                    Optional<String> glyph = NumeralValueParser
+                            .renderVulgarFractionOf(sourceValue.get(), template);
+                    return glyph.orElseGet(() -> sourceValue.get().numerator() + "/"
+                            + sourceValue.get().denominator());
+                }
+            }
             return StringUtil.normalizeWidth(number);
         }
         if (!hasDecimalDigit(number)) {
-            // The source number is written in an algorithmic system (a Han
-            // numeral) while the target writes digits: spell the value out.
-            Optional<BigInteger> value = NumeralValueParser.parseTokenWhole(number, ALLOW_ROMAN);
+            // The source number is written in a non-digit system (a Han
+            // numeral, a sign numeral such as cuneiform or Ethiopic) while
+            // the target writes digits: spell the whole value out.
+            Optional<NumeralValueParser.Rational> value = NumeralValueParser.parseTokenValue(number,
+                    ALLOW_ROMAN);
             if (value.isPresent()) {
-                return toDigitScript(value.get().toString(), zero);
+                if (BigInteger.ONE.equals(value.get().denominator())) {
+                    return toDigitScript(value.get().numerator().toString(), zero);
+                }
+                // A fractional sign value is spelled out as a digit fraction
+                // in the target's digit script.
+                return toDigitScript(value.get().numerator() + "/" + value.get().denominator(), zero);
             }
         }
         return toDigitScript(number, zero);

--- a/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
@@ -41,14 +41,15 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.io.File;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -78,6 +79,8 @@ import org.omegat.gui.preferences.PreferencesWindowController;
 import org.omegat.gui.preferences.view.TMMatchesPreferencesController;
 import org.omegat.gui.shortcuts.PropertiesShortcuts;
 import org.omegat.tokenizer.ITokenizer;
+import org.omegat.util.NumeralValueParser;
+import org.omegat.util.NumeralValueParser.Rational;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.Preferences;
@@ -329,29 +332,34 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
         List<String> sourceNumbers = Stream.of(sourceTok.tokenizeVerbatimToStrings(source))
                 .filter(MatchesTextArea::isNumber).collect(Collectors.toList());
 
-        // Compare and map numbers on their width-normalized form so that
-        // full-width (ASCII) digits (U+FF10-U+FF19, common in Japanese) are
-        // treated as equivalent to their half-width counterparts. See feature
-        // request #1193.
-        List<String> normSourceMatchNumbers = normalizeDigitWidth(sourceMatchNumbers);
-        List<String> normTargetMatchNumbers = normalizeDigitWidth(targetMatchNumbers);
+        // Compare and pair the numbers by their value, not by their spelling, so
+        // that the same number written differently counts as the same number:
+        // decimal digits of any script including full-width ones (feature
+        // request #1193) and Han numerals. What counts as one number is the
+        // tokenizer's decision, so a percentage or a dotted date, which arrive
+        // as a single token without a value, are out of reach here.
+        List<Rational> sourceMatchValues = values(sourceMatchNumbers);
+        List<Rational> targetMatchValues = values(targetMatchNumbers);
 
         if (sourceMatchNumbers.size() != sourceNumbers.size()
                 || sourceMatchNumbers.size() != targetMatchNumbers.size()
-                || !new HashSet<>(normSourceMatchNumbers).equals(new HashSet<>(normTargetMatchNumbers))) {
+                || !sameNumbers(sourceMatchValues, targetMatchValues)) {
             return targetMatch;
         }
 
-        Map<Integer, Integer> locationMap = mapIndices(normSourceMatchNumbers, normTargetMatchNumbers);
+        // Map each target number to the source number belonging there. Asking in
+        // that direction keeps the mapping correct for any permutation of the
+        // numbers, and complete for repeated numbers.
+        Map<Integer, Integer> locationMap = mapIndices(targetMatchValues, sourceMatchValues);
 
-        // Substitute new numbers in the target match. The inserted number
-        // adopts the digit width of the target token it replaces, so the
-        // target match's digit convention is preserved.
+        // Substitute new numbers in the target match. The inserted number adopts
+        // the notation of the target token it replaces, so the target match's own
+        // convention is preserved.
         StringBuilder result = new StringBuilder();
         int i = 0;
         for (String tok : targetTokens) {
             if (isNumber(tok)) {
-                result.append(toDigitWidthOf(sourceNumbers.get(locationMap.get(i)), tok));
+                result.append(renderLike(sourceNumbers.get(locationMap.get(i)), tok));
                 i++;
             } else {
                 result.append(tok);
@@ -361,67 +369,119 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
         return result.toString();
     }
 
-    /**
-     * Return a copy of the given number strings with every digit normalized to
-     * half-width, so that full-width and half-width digits compare equal.
-     * Feature request #1193.
-     */
-    private static List<String> normalizeDigitWidth(List<String> numbers) {
-        return numbers.stream().map(StringUtil::normalizeWidth).collect(Collectors.toList());
+    /** The values of number tokens that {@link #isNumber} accepted. */
+    private static List<Rational> values(List<String> numbers) {
+        return numbers.stream()
+                .map(n -> NumeralValueParser.parseTokenValue(n, ALLOW_ROMAN).orElseThrow())
+                .collect(Collectors.toList());
     }
 
     /**
-     * Render the given number with the digit width used by the template token:
-     * full-width when the template contains full-width digits, half-width
-     * otherwise. This makes a substituted number follow the target match's
-     * digit convention. Feature request #1193.
+     * Whether both lists hold the same numbers with the same multiplicities.
+     * Comparing as multisets rather than as sets keeps a repeated number from
+     * standing in for a missing one, which would leave a target number without a
+     * counterpart.
      */
-    private static String toDigitWidthOf(String number, String template) {
-        return hasFullwidthDigit(template) ? toFullwidthDigits(number)
-                : StringUtil.normalizeWidth(number);
+    private static boolean sameNumbers(List<Rational> first, List<Rational> second) {
+        Map<Rational, Integer> pending = new HashMap<>();
+        first.forEach(value -> pending.merge(value, 1, Integer::sum));
+        for (Rational value : second) {
+            Integer count = pending.get(value);
+            if (count == null) {
+                return false;
+            }
+            if (count == 1) {
+                pending.remove(value);
+            } else {
+                pending.put(value, count - 1);
+            }
+        }
+        return pending.isEmpty();
     }
 
-    private static boolean hasFullwidthDigit(String text) {
-        for (int i = 0; i < text.length(); i++) {
-            char c = text.charAt(i);
-            if (c >= '０' && c <= '９') {
+    /**
+     * Render the given source number in the digit script of the target token it
+     * replaces, which is what makes a full-width target keep full-width digits
+     * (feature request #1193). A target written in a system this code cannot
+     * write back, a Han numeral for one, receives plain digits instead: the right
+     * number in a foreign notation beats the wrong number in the right one.
+     */
+    private static String renderLike(String number, String template) {
+        int zero = digitZeroOf(template);
+        if (zero < 0) {
+            return StringUtil.normalizeWidth(number);
+        }
+        if (!hasDecimalDigit(number)) {
+            // The source number is written in an algorithmic system (a Han
+            // numeral) while the target writes digits: spell the value out.
+            Optional<BigInteger> value = NumeralValueParser.parseTokenWhole(number, ALLOW_ROMAN);
+            if (value.isPresent()) {
+                return toDigitScript(value.get().toString(), zero);
+            }
+        }
+        return toDigitScript(number, zero);
+    }
+
+    private static boolean hasDecimalDigit(String text) {
+        for (int i = 0; i < text.length();) {
+            int cp = text.codePointAt(i);
+            if (Character.digit(cp, 10) >= 0) {
                 return true;
             }
+            i += Character.charCount(cp);
         }
         return false;
     }
 
-    private static String toFullwidthDigits(String number) {
+    /**
+     * The code point of digit zero in the script of the template's first decimal
+     * digit, or -1 when the template holds no decimal digit.
+     */
+    private static int digitZeroOf(String template) {
+        for (int i = 0; i < template.length();) {
+            int cp = template.codePointAt(i);
+            int digit = Character.digit(cp, 10);
+            if (digit >= 0) {
+                return cp - digit;
+            }
+            i += Character.charCount(cp);
+        }
+        return -1;
+    }
+
+    /** The number with every decimal digit rewritten in the given digit script. */
+    private static String toDigitScript(String number, int zero) {
         StringBuilder sb = new StringBuilder(number.length());
-        for (int i = 0; i < number.length(); i++) {
-            char c = number.charAt(i);
-            sb.append(c >= '0' && c <= '9' ? (char) (c - '0' + 0xFF10) : c);
+        for (int i = 0; i < number.length();) {
+            int cp = number.codePointAt(i);
+            int digit = Character.digit(cp, 10);
+            sb.appendCodePoint(digit < 0 ? cp : zero + digit);
+            i += Character.charCount(cp);
         }
         return sb.toString();
     }
 
     /**
-     * Determine whether the given string is a number. Integers and simple
-     * doubles (not localized) are recognized.
+     * Whether a Roman numeral written with Latin letters counts as a number when
+     * inserting a match. It does not: "I", "V", "X", "MIX" and "DIV" are ordinary
+     * uppercase words at least as often as they are numbers, and here a false
+     * positive does not cost a few similarity points, it rewrites the text the
+     * translator is handed. Roman numerals written with the dedicated code points
+     * are unambiguous and remain numbers.
+     */
+    private static final boolean ALLOW_ROMAN = false;
+
+    /**
+     * Determine whether the given string is a number: a token that may be read
+     * as one and has an exact value. Decimal digits of every script, Han
+     * numerals, decimals and fractions are recognized; ordinary words are not.
      *
      * @param text
      *            A string
      * @return True if the string represents a number
      */
     private static boolean isNumber(String text) {
-        try {
-            Integer.parseInt(text);
-            return true;
-        } catch (NumberFormatException nfe) {
-            // Eat exception silently
-        }
-        try {
-            Double.parseDouble(text);
-            return true;
-        } catch (NumberFormatException nfe) {
-            // Eat exception silently
-        }
-        return false;
+        return NumeralValueParser.parseTokenValue(text, ALLOW_ROMAN).isPresent();
     }
 
     /**

--- a/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
@@ -65,6 +65,7 @@ import javax.swing.text.StyledDocument;
 
 import org.omegat.core.Core;
 import org.omegat.core.data.DataUtils;
+import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.SourceTextEntry;
 import org.omegat.core.data.StringData;
 import org.omegat.core.data.TMXEntry;
@@ -372,7 +373,7 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
     /** The values of number tokens that {@link #isNumber} accepted. */
     private static List<Rational> values(List<String> numbers) {
         return numbers.stream()
-                .map(n -> NumeralValueParser.parseTokenValue(n, ALLOW_ROMAN).orElseThrow())
+                .map(n -> NumeralValueParser.parseTokenValue(n, allowRoman()).orElseThrow())
                 .collect(Collectors.toList());
     }
 
@@ -413,7 +414,7 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
             // The target writes a numeral system, not digits: write the source
             // value in that system, whatever system the source itself uses.
             Optional<NumeralValueParser.Rational> sourceValue = NumeralValueParser.parseTokenValue(number,
-                    ALLOW_ROMAN);
+                    allowRoman());
             if (sourceValue.isPresent()) {
                 if (BigInteger.ONE.equals(sourceValue.get().denominator())) {
                     Optional<String> rendered = NumeralValueParser
@@ -439,7 +440,7 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
             // numeral, a sign numeral such as cuneiform or Ethiopic) while
             // the target writes digits: spell the whole value out.
             Optional<NumeralValueParser.Rational> value = NumeralValueParser.parseTokenValue(number,
-                    ALLOW_ROMAN);
+                    allowRoman());
             if (value.isPresent()) {
                 if (BigInteger.ONE.equals(value.get().denominator())) {
                     return toDigitScript(value.get().numerator().toString(), zero);
@@ -492,14 +493,23 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
     }
 
     /**
-     * Whether a Roman numeral written with Latin letters counts as a number when
-     * inserting a match. It does not: "I", "V", "X", "MIX" and "DIV" are ordinary
-     * uppercase words at least as often as they are numbers, and here a false
-     * positive does not cost a few similarity points, it rewrites the text the
-     * translator is handed. Roman numerals written with the dedicated code points
-     * are unambiguous and remain numbers.
+     * Whether a Roman numeral written with Latin letters counts as a number
+     * when inserting a match: only when the project opted in. By default it
+     * does not: "I", "V", "X", "MIX" and "DIV" are ordinary uppercase words at
+     * least as often as they are numbers, and here a false positive does not
+     * cost a few similarity points, it rewrites the text the translator is
+     * handed. Roman numerals written with the dedicated code points are
+     * unambiguous and always count.
      */
-    private static final boolean ALLOW_ROMAN = false;
+    private static boolean allowRoman() {
+        if (!Core.getProject().isProjectLoaded()) {
+            return false;
+        }
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        // The sub-option only applies while number matching itself is on; the
+        // stored checkbox state survives an off/on cycle of the main option.
+        return props != null && props.isMatchNumbersEnabled() && props.isMatchNumbersRomanEnabled();
+    }
 
     /**
      * Determine whether the given string is a number: a token that may be read
@@ -511,7 +521,7 @@ public class MatchesTextArea extends EntryInfoThreadPane<List<NearString>> imple
      * @return True if the string represents a number
      */
     private static boolean isNumber(String text) {
-        return NumeralValueParser.parseTokenValue(text, ALLOW_ROMAN).isPresent();
+        return NumeralValueParser.parseTokenValue(text, allowRoman()).isPresent();
     }
 
     /**

--- a/src/main/java/org/omegat/gui/search/SearchWindowController.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowController.java
@@ -37,6 +37,7 @@ package org.omegat.gui.search;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Font;
+import java.awt.GridLayout;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -52,16 +53,25 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.swing.AbstractAction;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
 import javax.swing.ButtonModel;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.InputMap;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JComponent;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SpinnerDateModel;
@@ -79,6 +89,7 @@ import org.openide.awt.Mnemonics;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.SourceTextEntry;
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.core.search.SearchExpression;
 import org.omegat.core.search.SearchMode;
 import org.omegat.core.search.Searcher;
@@ -120,6 +131,14 @@ import org.omegat.util.gui.UIThreadsUtil;
 public class SearchWindowController {
 
     private final SearchWindowForm form;
+    private final Map<MatchEquivalence, JCheckBox> searchEquivalenceCBs = new EnumMap<>(
+            MatchEquivalence.class);
+    private final Map<MatchEquivalence, JCheckBox> replaceEquivalenceCBs = new EnumMap<>(
+            MatchEquivalence.class);
+    private final JCheckBox searchNumbersCB = new JCheckBox();
+    private final JCheckBox searchNumbersRomanCB = new JCheckBox();
+    private final JCheckBox replaceNumbersCB = new JCheckBox();
+    private final JCheckBox replaceNumbersRomanCB = new JCheckBox();
     private final SearchMode mode;
     private final int initialEntry;
     private final CaretPosition initialCaret;
@@ -131,6 +150,7 @@ public class SearchWindowController {
     public SearchWindowController(SearchMode mode) {
         form = new SearchWindowForm();
         form.setJMenuBar(new SearchWindowMenu(this));
+        insertEquivalenceRows();
         Font f = Objects.requireNonNull(Core.getMainWindow()).getApplicationFont();
         setFont(f);
 
@@ -304,6 +324,8 @@ public class SearchWindowController {
         ActionListener searchFieldRequestFocus = e -> form.m_searchField.requestFocus();
 
         ActionListener wholeWordsStatusUpdate = e -> updateWholeWordsStatus();
+
+        wireReplaceEquivalenceStatus();
 
         form.m_searchExactSearchRB.addActionListener(searchFieldRequestFocus);
         form.m_searchExactSearchRB.addActionListener(wholeWordsStatusUpdate);
@@ -524,10 +546,6 @@ public class SearchWindowController {
         form.m_searchCase
                 .setSelected(Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_CASE_SENSITIVE, false));
 
-        // nbsp as space
-        form.m_searchSpaceMatchNbsp.setSelected(
-                Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_SPACE_MATCH_NBSP, false));
-
         // whole words only
         form.m_searchWholeWords.setSelected(
                 Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_WHOLE_WORDS, false));
@@ -558,10 +576,6 @@ public class SearchWindowController {
         // case sensitivity
         form.m_replaceCase.setSelected(
                 Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_CASE_SENSITIVE_REPLACE, false));
-
-        // nbsp as space
-        form.m_replaceSpaceMatchNbsp.setSelected(
-                Preferences.isPreferenceDefault(Preferences.SEARCHWINDOW_SPACE_MATCH_NBSP_REPLACE, false));
 
         // replace type
         SearchExpression.SearchExpressionType replaceType = Preferences.getPreferenceEnumDefault(
@@ -633,8 +647,6 @@ public class SearchWindowController {
 
         // search options
         Preferences.setPreference(Preferences.SEARCHWINDOW_CASE_SENSITIVE, form.m_searchCase.isSelected());
-        Preferences.setPreference(Preferences.SEARCHWINDOW_SPACE_MATCH_NBSP,
-                form.m_searchSpaceMatchNbsp.isSelected());
         Preferences.setPreference(Preferences.SEARCHWINDOW_WHOLE_WORDS,
                 form.m_searchWholeWords.isSelected());
 
@@ -656,8 +668,6 @@ public class SearchWindowController {
         // replace options
         Preferences.setPreference(Preferences.SEARCHWINDOW_CASE_SENSITIVE_REPLACE,
                 form.m_replaceCase.isSelected());
-        Preferences.setPreference(Preferences.SEARCHWINDOW_SPACE_MATCH_NBSP_REPLACE,
-                form.m_replaceSpaceMatchNbsp.isSelected());
         if (form.m_replaceExactSearchRB.isSelected()) {
             Preferences.setPreference(Preferences.SEARCHWINDOW_REPLACE_TYPE,
                     SearchExpression.SearchExpressionType.EXACT);
@@ -739,6 +749,7 @@ public class SearchWindowController {
 
         form.m_replaceSpaceMatchNbsp.setSelected(false);
         form.m_replaceExactSearchRB.setSelected(true);
+        resetEquivalenceOptions();
 
         form.m_replaceUntranslated.setSelected(true);
 
@@ -781,6 +792,144 @@ public class SearchWindowController {
      */
     private void updateWholeWordsStatus() {
         form.m_searchWholeWords.setEnabled(!form.m_searchRegexpSearchRB.isSelected());
+        // Folding a regular expression would corrupt its syntax, so character
+        // equivalence only applies to exact and keyword searches.
+        boolean plainSearch = !form.m_searchRegexpSearchRB.isSelected();
+        searchEquivalenceCBs.values().forEach(cb -> cb.setEnabled(plainSearch));
+        searchNumbersCB.setEnabled(plainSearch);
+        searchNumbersRomanCB.setEnabled(plainSearch && searchNumbersCB.isSelected());
+    }
+
+    private void wireReplaceEquivalenceStatus() {
+        form.m_replaceExactSearchRB.addActionListener(e -> updateReplaceEquivalenceStatus());
+        form.m_replaceRegexpSearchRB.addActionListener(e -> updateReplaceEquivalenceStatus());
+        updateReplaceEquivalenceStatus();
+    }
+
+    private void updateReplaceEquivalenceStatus() {
+        boolean plainSearch = !form.m_replaceRegexpSearchRB.isSelected();
+        replaceEquivalenceCBs.values().forEach(cb -> cb.setEnabled(plainSearch));
+        replaceNumbersCB.setEnabled(plainSearch);
+        replaceNumbersRomanCB.setEnabled(plainSearch && replaceNumbersCB.isSelected());
+    }
+
+    /**
+     * One row of character equivalence checkboxes per panel (#1681), inserted
+     * below the option row that held the retired "space matches nbsp" box.
+     * Prefilled from the classes active in the current project; toggling here
+     * only affects this window, never the project setting.
+     */
+    private void insertEquivalenceRows() {
+        form.m_searchSpaceMatchNbsp.setVisible(false);
+        form.m_replaceSpaceMatchNbsp.setVisible(false);
+        Set<MatchEquivalence> active = Core.getProject().isProjectLoaded()
+                ? Core.getProject().getProjectProperties().getActiveMatchEquivalences()
+                : MatchEquivalence.all();
+        insertRowAfter(form.m_searchSpaceMatchNbsp, buildNumbersRow(searchNumbersCB,
+                searchNumbersRomanCB, "SearchWindowForm.search_numbers"));
+        insertRowAfter(form.m_searchSpaceMatchNbsp, buildEquivalenceRow(searchEquivalenceCBs, active,
+                "SearchWindowForm.search_equivalence_"));
+        insertRowAfter(form.m_replaceSpaceMatchNbsp, buildNumbersRow(replaceNumbersCB,
+                replaceNumbersRomanCB, "SearchWindowForm.replace_numbers"));
+        insertRowAfter(form.m_replaceSpaceMatchNbsp, buildEquivalenceRow(replaceEquivalenceCBs, active,
+                "SearchWindowForm.replace_equivalence_"));
+    }
+
+    /**
+     * One row with the two number options (value equality across writing
+     * systems and the Latin-letter Roman sub-option), prefilled from the
+     * project like the equivalence classes. The sub-option follows the main
+     * checkbox like in the equivalence dialog.
+     */
+    private JPanel buildNumbersRow(JCheckBox numbersCB, JCheckBox romanCB, String namePrefix) {
+        boolean numbers = !Core.getProject().isProjectLoaded()
+                || Core.getProject().getProjectProperties().isMatchNumbersEnabled();
+        boolean roman = Core.getProject().isProjectLoaded()
+                && Core.getProject().getProjectProperties().isMatchNumbersRomanEnabled();
+        JPanel row = new JPanel();
+        row.setLayout(new BoxLayout(row, BoxLayout.LINE_AXIS));
+        row.add(new JLabel(OStrings.getString("SW_NUMBERS_LABEL")));
+        row.add(Box.createHorizontalStrut(10));
+        numbersCB.setText(OStrings.getString("SW_NUMBERS_BY_VALUE"));
+        numbersCB.setName(namePrefix + "_by_value");
+        numbersCB.setSelected(numbers);
+        numbersCB.setToolTipText(OStrings.getString("SW_NUMBERS_TOOLTIP"));
+        row.add(numbersCB);
+        row.add(Box.createHorizontalStrut(10));
+        romanCB.setText(OStrings.getString("SW_NUMBERS_ROMAN"));
+        romanCB.setName(namePrefix + "_roman");
+        romanCB.setSelected(roman);
+        romanCB.setEnabled(numbers);
+        row.add(romanCB);
+        numbersCB.addActionListener(e -> romanCB.setEnabled(numbersCB.isSelected() && numbersCB.isEnabled()));
+        row.add(Box.createHorizontalGlue());
+        return row;
+    }
+
+    private JPanel buildEquivalenceRow(Map<MatchEquivalence, JCheckBox> checkboxes,
+            Set<MatchEquivalence> active, String namePrefix) {
+        JPanel row = new JPanel();
+        row.setLayout(new BoxLayout(row, BoxLayout.LINE_AXIS));
+        row.add(new JLabel(OStrings.getString("SW_EQUIVALENCE_LABEL")));
+        for (MatchEquivalence eq : MatchEquivalence.values()) {
+            row.add(Box.createHorizontalStrut(10));
+            JCheckBox checkbox = new JCheckBox(OStrings.getString("SW_EQUIVALENCE_" + eq.name()),
+                    active.contains(eq));
+            checkbox.setName(namePrefix + eq.getId());
+            checkboxes.put(eq, checkbox);
+            row.add(checkbox);
+        }
+        row.add(Box.createHorizontalGlue());
+        return row;
+    }
+
+    private static void insertRowAfter(JComponent anchor, JPanel row) {
+        Container anchorRow = anchor.getParent();
+        Container parent = anchorRow.getParent();
+        if (parent.getLayout() instanceof GridLayout) {
+            // The option panels use a fixed-row GridLayout; without one more
+            // row, an added component opens a second column instead.
+            GridLayout grid = (GridLayout) parent.getLayout();
+            grid.setRows(grid.getRows() + 1);
+        }
+        for (int i = 0; i < parent.getComponentCount(); i++) {
+            if (parent.getComponent(i) == anchorRow) {
+                row.setAlignmentX(((JComponent) anchorRow).getAlignmentX());
+                parent.add(row, i + 1);
+                return;
+            }
+        }
+    }
+
+    /** Resets both equivalence rows to the classes active in the project. */
+    private void resetEquivalenceOptions() {
+        Set<MatchEquivalence> active = Core.getProject().isProjectLoaded()
+                ? Core.getProject().getProjectProperties().getActiveMatchEquivalences()
+                : MatchEquivalence.all();
+        searchEquivalenceCBs.forEach((eq, checkbox) -> checkbox.setSelected(active.contains(eq)));
+        replaceEquivalenceCBs.forEach((eq, checkbox) -> checkbox.setSelected(active.contains(eq)));
+        boolean numbers = !Core.getProject().isProjectLoaded()
+                || Core.getProject().getProjectProperties().isMatchNumbersEnabled();
+        boolean roman = Core.getProject().isProjectLoaded()
+                && Core.getProject().getProjectProperties().isMatchNumbersRomanEnabled();
+        searchNumbersCB.setSelected(numbers);
+        searchNumbersRomanCB.setSelected(roman);
+        replaceNumbersCB.setSelected(numbers);
+        replaceNumbersRomanCB.setSelected(roman);
+        // setSelected fires no listeners, so the dependent enabled states
+        // need an explicit refresh on both panels.
+        updateWholeWordsStatus();
+        updateReplaceEquivalenceStatus();
+    }
+
+    private static Set<MatchEquivalence> selectedEquivalences(Map<MatchEquivalence, JCheckBox> checkboxes) {
+        Set<MatchEquivalence> selected = EnumSet.noneOf(MatchEquivalence.class);
+        checkboxes.forEach((eq, checkbox) -> {
+            if (checkbox.isSelected()) {
+                selected.add(eq);
+            }
+        });
+        return selected;
     }
 
     // //////////////////////////////////////////////////////////////
@@ -1005,7 +1154,12 @@ public class SearchWindowController {
     private void applySearchModeOptions(SearchExpression expression) {
         expression.searchExpressionType = getSearchExpressionTypeForSearchMode();
         expression.caseSensitive = form.m_searchCase.isSelected();
-        expression.spaceMatchNbsp = form.m_searchSpaceMatchNbsp.isSelected();
+        expression.equivalences = getSearchExpressionTypeForSearchMode() == SearchExpression.SearchExpressionType.REGEXP
+                ? EnumSet.noneOf(MatchEquivalence.class)
+                : selectedEquivalences(searchEquivalenceCBs);
+        boolean searchRegexp = getSearchExpressionTypeForSearchMode() == SearchExpression.SearchExpressionType.REGEXP;
+        expression.matchNumbers = !searchRegexp && searchNumbersCB.isSelected();
+        expression.matchNumbersRoman = expression.matchNumbers && searchNumbersRomanCB.isSelected();
         expression.wholeWordsOnly = form.m_searchWholeWords.isSelected();
         expression.glossary = form.m_cbSearchInGlossaries.isSelected();
         expression.memory = form.m_cbSearchInMemory.isSelected();
@@ -1023,7 +1177,11 @@ public class SearchWindowController {
     private void applyReplaceModeOptions(SearchExpression expression) {
         expression.searchExpressionType = getSearchExpressionTypeForReplaceMode();
         expression.caseSensitive = form.m_replaceCase.isSelected();
-        expression.spaceMatchNbsp = form.m_replaceSpaceMatchNbsp.isSelected();
+        boolean replaceRegexp = getSearchExpressionTypeForReplaceMode() == SearchExpression.SearchExpressionType.REGEXP;
+        expression.equivalences = replaceRegexp ? EnumSet.noneOf(MatchEquivalence.class)
+                : selectedEquivalences(replaceEquivalenceCBs);
+        expression.matchNumbers = !replaceRegexp && replaceNumbersCB.isSelected();
+        expression.matchNumbersRoman = expression.matchNumbers && replaceNumbersRomanCB.isSelected();
         expression.glossary = false;
         expression.memory = true;
         expression.tm = false;

--- a/src/main/java/org/omegat/gui/stat/BaseMatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/BaseMatchStatisticsPanel.java
@@ -25,7 +25,19 @@
 
 package org.omegat.gui.stat;
 
+import java.text.MessageFormat;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.swing.JLabel;
+import javax.swing.border.EmptyBorder;
+
+import org.jspecify.annotations.Nullable;
+
+import org.omegat.core.Core;
+import org.omegat.core.matching.MatchEquivalence;
 import org.omegat.core.threads.Completion;
+import org.omegat.util.OStrings;
 
 /**
  *
@@ -50,5 +62,27 @@ public abstract class BaseMatchStatisticsPanel extends BaseStatisticsPanel {
     public void onComplete(Completion completion) {
         super.onComplete(completion);
         buffer.setLength(0);
+    }
+
+    /**
+     * Hint label naming the character equivalence classes active in the
+     * project (#1681): folding changes the numbers shown, so the window says
+     * when it is in effect. Null when no folding applies.
+     */
+    protected static @Nullable JLabel buildEquivalenceHint() {
+        if (!Core.getProject().isProjectLoaded()) {
+            return null;
+        }
+        Set<MatchEquivalence> active = Core.getProject().getProjectProperties()
+                .getActiveMatchEquivalences();
+        if (active.isEmpty()) {
+            return null;
+        }
+        String names = active.stream().map(MatchEquivalence::getLocalizedName)
+                .collect(Collectors.joining(", "));
+        JLabel hint = new JLabel(
+                MessageFormat.format(OStrings.getString("CT_STATSMATCH_EQUIVALENCE_ACTIVE"), names));
+        hint.setBorder(new EmptyBorder(4, 8, 4, 8));
+        return hint;
     }
 }

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
@@ -29,6 +29,7 @@ import org.omegat.core.statistics.IStatsConsumer;
 
 import java.awt.BorderLayout;
 
+import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
 /**
@@ -61,6 +62,10 @@ public class MatchStatisticsPanel extends BaseMatchStatisticsPanel implements IS
             // so have to remove first.
             removeAll();
             add(generateTableDisplay(null, headers, data));
+            JLabel hint = buildEquivalenceHint();
+            if (hint != null) {
+                add(hint, BorderLayout.PAGE_END);
+            }
         });
     }
 }

--- a/src/main/java/org/omegat/gui/stat/PerFileMatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/PerFileMatchStatisticsPanel.java
@@ -31,6 +31,7 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 
 import javax.swing.BoxLayout;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
@@ -60,6 +61,10 @@ public class PerFileMatchStatisticsPanel extends BaseMatchStatisticsPanel implem
         scrollPane.setBorder(new EmptyBorder(0, 0, 0, 0));
         scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         add(scrollPane);
+        JLabel hint = buildEquivalenceHint();
+        if (hint != null) {
+            add(hint, BorderLayout.PAGE_END);
+        }
     }
 
     @Override

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -29,12 +29,16 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParsePosition;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import com.ibm.icu.lang.UCharacter;
+import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.Normalizer2;
 import com.ibm.icu.text.RuleBasedNumberFormat;
 import com.ibm.icu.util.ULocale;
@@ -55,8 +59,7 @@ import com.ibm.icu.util.ULocale;
  *
  * A value is only returned when a candidate system consumes the WHOLE (trimmed)
  * string, so partial or ambiguous input is rejected and the caller can fall
- * back to plain text ordering. Kaktovik/Inuktitut numerals are not available in
- * the bundled ICU version and are therefore not recognized.
+ * back to plain text ordering.
  *
  * On top of the integer core, {@link #parseValue} and {@link #firstValue}
  * expose signed real numbers as an exact reduced {@link Rational}
@@ -71,13 +74,15 @@ import com.ibm.icu.util.ULocale;
  * irreducibly locale-ambiguous), so "1,000" and "1,5" contribute only their
  * leading integer. Division by zero yields no value.
  *
- * As a final step, a single code point that carries a Unicode numeric value but
- * is neither a decimal digit nor an algorithmic numeral is resolved from its
- * value: enclosed and parenthesized numbers and many
- * historic script numerals (Aegean, cuneiform, Aramaic, Greek acrophonic ...).
- * Only single, non-negative integer values are taken; multi-sign additive
- * sequences are not composed. Symbols without a numeric value (such as the emoji
- * for a hundred points or the keycap ten) are correctly ignored.
+ * As a final step, code points that carry a Unicode numeric value but are
+ * neither decimal digits nor algorithmic numerals are resolved from their
+ * values: enclosed and parenthesized numbers and many historic script numerals
+ * (Aegean, cuneiform, Aramaic, Greek acrophonic ...). A single sign is taken
+ * directly, including small exact fractions; a sequence of signs from one of
+ * the named numeral blocks reads positionally where the block is a digit block
+ * (Mayan and Kaktovik, base twenty) and as an additive largest-first sum
+ * otherwise. Symbols without a numeric value (such as the emoji for a hundred
+ * points or the keycap ten) are correctly ignored.
  *
  * The class is stateless from the caller's perspective; the (non-thread-safe)
  * ICU formatters are cached per thread.
@@ -164,6 +169,12 @@ public final class NumeralValueParser {
             return decimal;
         }
         if (!mayBeAlgorithmicNumeral(s)) {
+            return Optional.empty();
+        }
+        // No rule set reads the sign-block scripts, so their tokens would fail
+        // through every parser at real cost; the sign-value path reads them.
+        // (Number Forms come back here through their NFKC form, which is Latin.)
+        if (SIGN_BLOCKS.contains(Character.UnicodeBlock.of(s.codePointAt(0)))) {
             return Optional.empty();
         }
         for (RuleBasedNumberFormat parser : PARSERS.get()) {
@@ -618,19 +629,23 @@ public final class NumeralValueParser {
         if (algorithmic.isPresent()) {
             return algorithmic;
         }
-        // Last resort: a single Nl/No code point that carries a Unicode numeric
-        // value but is neither a decimal digit nor an algorithmic numeral -
-        // enclosed/parenthesized numbers and many historic script
-        // numerals (Aegean, cuneiform, Aramaic, Greek acrophonic ...). Only a
-        // single, non-negative integer value is taken; fractional forms and
-        // multi-sign additive sequences are left for a later, dedicated step.
-        return singleCodePointNumericValue(u);
+        // Last resort: sign numerals read through their Unicode numeric values -
+        // enclosed/parenthesized numbers and the historic script numerals
+        // (Aegean, cuneiform, Aramaic, Greek acrophonic ...). A single code
+        // point is taken directly; a sequence of signs from one block is read
+        // positionally where the block is a digit block, additively otherwise.
+        Optional<Rational> single = singleCodePointNumericValue(u);
+        if (single.isPresent()) {
+            return single;
+        }
+        return signSequenceValue(u);
     }
 
     /**
      * The value of a single Nl/No code point via its Unicode numeric value, if it
-     * is a non-negative integer. Symbols without a numeric value, the emoji for a
-     * hundred points or the keycap ten say, and fractional values yield empty.
+     * is non-negative. Small exact fractions (a cuneiform two-thirds, a North
+     * Indic quarter) resolve to their rational; symbols without a numeric value,
+     * the emoji for a hundred points or the keycap ten say, yield empty.
      */
     private static Optional<Rational> singleCodePointNumericValue(String u) {
         if (u.codePointCount(0, u.length()) != 1) {
@@ -642,10 +657,84 @@ public final class NumeralValueParser {
             return Optional.empty();
         }
         double v = UCharacter.getUnicodeNumericValue(cp);
-        if (v == UCharacter.NO_NUMERIC_VALUE || v < 0 || Double.isInfinite(v) || v != Math.floor(v)) {
+        if (v == UCharacter.NO_NUMERIC_VALUE || v < 0 || Double.isInfinite(v)) {
             return Optional.empty();
         }
-        return Optional.of(Rational.ofInteger(BigDecimal.valueOf(v).toBigIntegerExact()));
+        if (v == Math.floor(v)) {
+            return Optional.of(Rational.ofInteger(BigDecimal.valueOf(v).toBigIntegerExact()));
+        }
+        return rationalize(v);
+    }
+
+    /**
+     * The denominators Unicode numeric values of fractional numerals use; the
+     * largest (320) belongs to the Tamil and Malayalam fraction series.
+     */
+    private static final int[] FRACTION_DENOMINATORS = { 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16, 20, 32, 40,
+            64, 80, 160, 320 };
+
+    /** A small exact fraction for a Unicode numeric value, if one matches. */
+    private static Optional<Rational> rationalize(double v) {
+        for (int den : FRACTION_DENOMINATORS) {
+            double num = v * den;
+            if (Math.abs(num - Math.rint(num)) < 1e-9) {
+                return Optional.of(Rational.of(BigInteger.valueOf((long) Math.rint(num)),
+                        BigInteger.valueOf(den)));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * The value of a sequence of numeral signs from one Unicode block. A digit
+     * block (a contiguous zero-based run of sign values: Mayan and Kaktovik,
+     * base twenty) reads positionally; any other block reads as an additive
+     * sum, provided the signs come largest first (the canonical order of the
+     * additive systems) - an ascending pair rejects the token, so a
+     * multiplicative notation such as Tamil is never misread as a sum.
+     */
+    private static Optional<Rational> signSequenceValue(String u) {
+        int count = u.codePointCount(0, u.length());
+        if (count < 2 || count > MAX_COMPOSED_SIGNS) {
+            return Optional.empty();
+        }
+        Character.UnicodeBlock block = Character.UnicodeBlock.of(u.codePointAt(0));
+        if (block == null || !SIGN_BLOCKS.contains(block)) {
+            return Optional.empty();
+        }
+        List<BigInteger> sequence = new ArrayList<>();
+        for (int i = 0; i < u.length();) {
+            int cp = u.codePointAt(i);
+            int type = Character.getType(cp);
+            double v = UCharacter.getUnicodeNumericValue(cp);
+            if (!block.equals(Character.UnicodeBlock.of(cp))
+                    || (type != Character.LETTER_NUMBER && type != Character.OTHER_NUMBER)
+                    || (type == Character.OTHER_NUMBER && UCharacter.getIntPropertyValue(cp,
+                            UProperty.DECOMPOSITION_TYPE) != UCharacter.DecompositionType.NONE)
+                    || v == UCharacter.NO_NUMERIC_VALUE || v < 0 || v != Math.floor(v)) {
+                return Optional.empty();
+            }
+            sequence.add(BigDecimal.valueOf(v).toBigIntegerExact());
+            i += Character.charCount(cp);
+        }
+        Optional<BigInteger> base = positionalBase(blockSigns(u.codePointAt(0)));
+        if (base.isPresent()) {
+            BigInteger value = BigInteger.ZERO;
+            for (BigInteger digit : sequence) {
+                value = value.multiply(base.get()).add(digit);
+            }
+            return Optional.of(Rational.ofInteger(value));
+        }
+        BigInteger sum = BigInteger.ZERO;
+        BigInteger previous = null;
+        for (BigInteger sign : sequence) {
+            if (previous != null && sign.compareTo(previous) > 0) {
+                return Optional.empty();
+            }
+            sum = sum.add(sign);
+            previous = sign;
+        }
+        return Optional.of(Rational.ofInteger(sum));
     }
 
     private static boolean hasDecimalDigit(String s) {
@@ -777,9 +866,14 @@ public final class NumeralValueParser {
      *
      * Two boundaries are deliberate. A Roman form without I, V or X is rejected,
      * because "L", "C", "D" and "M" stand for a unit or an abbreviation far more
-     * often than for 50, 100, 500 and 1000. And a Number-Other code point is not
-     * a numeral token, which keeps a superscript exponent, a vulgar fraction and
-     * an enclosed number out of the number comparisons.
+     * often than for 50, 100, 500 and 1000. And a Number-Other code point counts
+     * only when it is a plain numeral or a precomposed vulgar fraction: the
+     * other presentation forms carrying a compatibility decomposition (a
+     * superscript exponent, an enclosed number) and the decoration-number
+     * symbol blocks (dingbat and negative circled digits, which carry no
+     * decomposition) stay out of the number comparisons, while the numeral
+     * systems encoded exclusively in that category (Ethiopic, Aegean, Mayan,
+     * Kaktovik, Meroitic and others) stay in.
      */
     private static boolean isNumeralToken(String text, boolean allowRoman) {
         if (text == null || text.isEmpty()) {
@@ -791,6 +885,13 @@ public final class NumeralValueParser {
             if (type == Character.DECIMAL_DIGIT_NUMBER || type == Character.LETTER_NUMBER) {
                 return true;
             }
+            if (type == Character.OTHER_NUMBER
+                    && (UCharacter.getIntPropertyValue(cp,
+                            UProperty.DECOMPOSITION_TYPE) == UCharacter.DecompositionType.NONE
+                            || VULGAR.containsKey(cp))
+                    && !SYMBOL_NUMBER_BLOCKS.contains(Character.UnicodeBlock.of(cp))) {
+                return true;
+            }
             i += Character.charCount(cp);
         }
         return allowRoman && CANONICAL_ROMAN.matcher(text).matches()
@@ -799,10 +900,266 @@ public final class NumeralValueParser {
     }
 
     /**
+     * Render a non-negative whole value in the numeral system the template
+     * numeral is written in, or empty when that system cannot be written.
+     *
+     * Two writers are tried. The algorithmic systems go through the same ICU
+     * rule sets that read them: whichever rule set consumes the template also
+     * formats the value (Ethiopic, Roman, Greek, Hebrew, Armenian, Tamil,
+     * Georgian, Cyrillic, Han). Sign systems are composed from the template's
+     * own Unicode block: a block whose signs form a contiguous digit run
+     * starting at zero is written positionally in that base (Mayan and
+     * Kaktovik, base twenty), any other block is written greedily as an
+     * additive sequence of its sign values, largest first (Aegean, Meroitic,
+     * cuneiform), and only an exact composition of reasonable length is
+     * returned.
+     */
+    public static Optional<String> renderInSystemOf(BigInteger value, String template) {
+        if (value == null || value.signum() < 0 || template == null || template.isEmpty()) {
+            return Optional.empty();
+        }
+        String trimmed = template.trim();
+        Optional<String> algorithmic = renderAlgorithmic(value, trimmed);
+        if (algorithmic.isPresent()) {
+            return algorithmic;
+        }
+        if (Character.UnicodeBlock.NUMBER_FORMS
+                .equals(Character.UnicodeBlock.of(trimmed.codePointAt(0)))) {
+            return renderRomanForms(value, trimmed);
+        }
+        return composeFromBlockOf(value, trimmed.codePointAt(0));
+    }
+
+    /** Write the value with the ICU rule set that owns the template's system, or empty. */
+    private static Optional<String> renderAlgorithmic(BigInteger value, String trimmed) {
+        for (RuleBasedNumberFormat parser : PARSERS.get()) {
+            ParsePosition pp = new ParsePosition(0);
+            Number read;
+            try {
+                read = parser.parse(trimmed, pp);
+            } catch (RuntimeException ex) {
+                continue;
+            }
+            if (read == null || pp.getIndex() != trimmed.length() || Double.isNaN(read.doubleValue())) {
+                continue;
+            }
+            // A NUMBERING_SYSTEM instance parses with every rule set it
+            // knows, not only its default: only the instance that writes
+            // the template back verbatim owns the template's system.
+            try {
+                if (!trimmed.equals(parser.format(read.longValue()))) {
+                    continue;
+                }
+            } catch (RuntimeException ex) {
+                continue;
+            }
+            try {
+                String written = parser.format(value.longValueExact());
+                // Out-of-range values make RBNF fall back to grouped decimal
+                // digits; that is not the template's system.
+                return hasDecimalDigit(written) ? Optional.empty() : Optional.of(written);
+            } catch (RuntimeException ex) {
+                // The owning system cannot write this value at all.
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** The single-letter Roman forms at U+2160/U+2170, index-aligned with {@link #ROMAN_DIGITS}. */
+    private static final String ROMAN_FORMS = "ⅠⅤⅩⅬⅭⅮⅯ"
+            + "ⅰⅴⅹⅼⅽⅾⅿ";
+
+    /**
+     * Write the value with the Number Forms Roman code points. Their greedy
+     * additive composition would be invalid notation (forty is not four
+     * twelves), so the block's letter numerals go through NFKC to ASCII
+     * Roman, the Roman rule sets write the value subtractively in the
+     * template's case, and the letters map back to the single-letter forms.
+     * The rest of the block (Claudian signs, turned digits) stays unwritable.
+     */
+    private static Optional<String> renderRomanForms(BigInteger value, String trimmed) {
+        String ascii = NFKC.normalize(trimmed);
+        Optional<String> written = ascii.equals(trimmed) ? Optional.empty()
+                : renderAlgorithmic(value, ascii);
+        if (written.isEmpty()) {
+            return Optional.empty();
+        }
+        String letters = written.get();
+        boolean lower = Character.isLowerCase(letters.charAt(0));
+        // One through twelve have precomposed forms; prefer those.
+        if (value.signum() > 0 && value.compareTo(BigInteger.valueOf(12)) <= 0) {
+            return Optional.of(String.valueOf((char) ((lower ? 'ⅰ' : 'Ⅰ') + value.intValueExact() - 1)));
+        }
+        StringBuilder mapped = new StringBuilder();
+        for (char letter : letters.toCharArray()) {
+            int index = ROMAN_DIGITS.indexOf(letter);
+            if (index < 0) {
+                return Optional.empty();
+            }
+            mapped.append(ROMAN_FORMS.charAt(index));
+        }
+        return Optional.of(mapped.toString());
+    }
+
+    /**
+     * Render an exact fraction as a precomposed vulgar-fraction glyph, when
+     * the template numeral is such a glyph itself and a glyph carrying
+     * exactly the value exists; empty otherwise. The counterpart of
+     * {@link #renderInSystemOf} for the non-integer values.
+     */
+    public static Optional<String> renderVulgarFractionOf(Rational value, String template) {
+        if (value == null || template == null || template.isEmpty()) {
+            return Optional.empty();
+        }
+        String trimmed = template.trim();
+        if (trimmed.codePointCount(0, trimmed.length()) != 1
+                || !VULGAR.containsKey(trimmed.codePointAt(0))) {
+            return Optional.empty();
+        }
+        return VULGAR.entrySet().stream().filter(e -> e.getValue().equals(value))
+                .map(e -> new String(Character.toChars(e.getKey()))).findFirst();
+    }
+
+    /** Longest sign sequence a block composition may produce or read. */
+    private static final int MAX_COMPOSED_SIGNS = 24;
+
+    /** Largest base a digit block may declare; Mayan and Kaktovik use twenty. */
+    private static final int MAX_POSITIONAL_BASE = 20;
+
+    /**
+     * The Unicode blocks whose signs compose to numbers, both when reading a
+     * sign sequence and when writing a value. An allowlist, because a block
+     * that merely happens to contain number-valued symbols (the dingbat
+     * circled digits, say) must never be read or written as a numeral system.
+     * Blocks a JDK does not know are skipped: their numerals simply stay
+     * single-sign.
+     */
+    private static final Set<Character.UnicodeBlock> SIGN_BLOCKS = namedBlocks("AEGEAN NUMBERS",
+            "CUNEIFORM NUMBERS AND PUNCTUATION", "MAYAN NUMERALS", "KAKTOVIK NUMERALS",
+            "MEROITIC CURSIVE", "COUNTING ROD NUMERALS", "ANCIENT GREEK NUMBERS",
+            "OTTOMAN SIYAQ NUMBERS", "INDIC SIYAQ NUMBERS", "MEDEFAIDRIN", "KHAROSHTHI", "PHOENICIAN",
+            "NUMBER FORMS");
+
+    /**
+     * Symbol blocks whose number-valued code points are decorations rather
+     * than numerals (list bullets, dingbats); they carry no compatibility
+     * decomposition, so they need naming.
+     */
+    private static final Set<Character.UnicodeBlock> SYMBOL_NUMBER_BLOCKS = namedBlocks(
+            "DINGBATS", "ENCLOSED ALPHANUMERICS", "ENCLOSED ALPHANUMERIC SUPPLEMENT",
+            "ENCLOSED CJK LETTERS AND MONTHS", "ENCLOSED IDEOGRAPHIC SUPPLEMENT");
+
+    private static Set<Character.UnicodeBlock> namedBlocks(String... names) {
+        Set<Character.UnicodeBlock> blocks = new HashSet<>();
+        for (String name : names) {
+            try {
+                blocks.add(Character.UnicodeBlock.forName(name));
+            } catch (IllegalArgumentException unknownInThisJdk) {
+                continue;
+            }
+        }
+        return Set.copyOf(blocks);
+    }
+
+    /** The numeral signs of the given code point's block, by integer value. */
+    private static TreeMap<BigInteger, Integer> blockSigns(int templateCp) {
+        TreeMap<BigInteger, Integer> signs = new TreeMap<>();
+        Character.UnicodeBlock block = Character.UnicodeBlock.of(templateCp);
+        if (block == null || !SIGN_BLOCKS.contains(block)) {
+            return signs;
+        }
+        for (int cp = Math.max(0, templateCp - 0x100); cp <= templateCp + 0x100; cp++) {
+            if (!block.equals(Character.UnicodeBlock.of(cp))) {
+                continue;
+            }
+            int type = Character.getType(cp);
+            if (type != Character.OTHER_NUMBER && type != Character.LETTER_NUMBER) {
+                continue;
+            }
+            // Presentation forms are filtered by their decomposition; letter
+            // numerals keep theirs (a Roman code point decomposes to letters
+            // and is a numeral all the same).
+            if (type == Character.OTHER_NUMBER && UCharacter.getIntPropertyValue(cp,
+                    UProperty.DECOMPOSITION_TYPE) != UCharacter.DecompositionType.NONE) {
+                continue;
+            }
+            double numeric = UCharacter.getUnicodeNumericValue(cp);
+            if (numeric == UCharacter.NO_NUMERIC_VALUE || numeric < 0 || numeric != Math.floor(numeric)) {
+                continue;
+            }
+            signs.putIfAbsent(BigDecimal.valueOf(numeric).toBigIntegerExact(), cp);
+        }
+        return signs;
+    }
+
+    /** The base of a contiguous zero-based digit block, or empty. */
+    private static Optional<BigInteger> positionalBase(TreeMap<BigInteger, Integer> signs) {
+        int base = signs.size();
+        if (base > 1 && base <= MAX_POSITIONAL_BASE && signs.firstKey().signum() == 0
+                && signs.lastKey().equals(BigInteger.valueOf(base - 1L))) {
+            return Optional.of(BigInteger.valueOf(base));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Blocks that are read but never composed: counting rods are positional
+     * above the tens and the Number Forms are subtractive Roman, so a greedy
+     * additive spelling of either would be invalid notation. (Roman gets its
+     * own writer; rod values fall back to plain digits.)
+     */
+    private static final Set<Character.UnicodeBlock> READ_ONLY_BLOCKS = Set
+            .of(Character.UnicodeBlock.NUMBER_FORMS, Character.UnicodeBlock.COUNTING_ROD_NUMERALS);
+
+    /** Write the value with the numeral signs of the given code point's block. */
+    private static Optional<String> composeFromBlockOf(BigInteger value, int templateCp) {
+        if (READ_ONLY_BLOCKS.contains(Character.UnicodeBlock.of(templateCp))) {
+            return Optional.empty();
+        }
+        TreeMap<BigInteger, Integer> signs = blockSigns(templateCp);
+        if (signs.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<BigInteger> base = positionalBase(signs);
+        if (base.isPresent()) {
+            StringBuilder digits = new StringBuilder();
+            BigInteger rest = value;
+            int count = 0;
+            do {
+                BigInteger[] div = rest.divideAndRemainder(base.get());
+                digits.insert(0, Character.toChars(signs.get(div[1])));
+                rest = div[0];
+                count++;
+            } while (rest.signum() > 0 && count < MAX_COMPOSED_SIGNS);
+            return rest.signum() == 0 ? Optional.of(digits.toString()) : Optional.empty();
+        }
+        // Otherwise compose additively, largest sign first.
+        if (value.signum() == 0) {
+            return Optional.empty();
+        }
+        StringBuilder out = new StringBuilder();
+        BigInteger rest = value;
+        int count = 0;
+        for (BigInteger sign : signs.descendingKeySet()) {
+            if (sign.signum() == 0) {
+                continue;
+            }
+            while (rest.compareTo(sign) >= 0 && count < MAX_COMPOSED_SIGNS) {
+                out.append(Character.toChars(signs.get(sign)));
+                rest = rest.subtract(sign);
+                count++;
+            }
+        }
+        return rest.signum() == 0 ? Optional.of(out.toString()) : Optional.empty();
+    }
+
+    /**
      * The integer value of a token that may be read as a number, or empty when
-     * the token is not one. The gated form of {@link #parseWhole}: safe to apply
-     * to every token of a segment, because ordinary words are rejected before
-     * they reach the numeral parsers.
+     * the token is not one. The gated form of {@link #parseWhole} plus the
+     * whole-valued sign numerals: safe to apply to every token of a segment,
+     * because ordinary words are rejected before they reach the numeral
+     * parsers.
      *
      * Every caller decides for itself whether Roman numerals written with Latin
      * letters count, because there is no telling "I", "V", "X", "MIX" or "DIV"
@@ -815,7 +1172,22 @@ public final class NumeralValueParser {
      *            whether a Latin-letter Roman numeral is a number here
      */
     public static Optional<BigInteger> parseTokenWhole(String token, boolean allowRoman) {
-        return isNumeralToken(token, allowRoman) ? parseWhole(token) : Optional.empty();
+        if (!isNumeralToken(token, allowRoman)) {
+            return Optional.empty();
+        }
+        Optional<BigInteger> whole = parseWhole(token);
+        if (whole.isPresent()) {
+            return whole;
+        }
+        // The sign numerals join the whole-number comparison through the same
+        // last resort parseValue uses, whole values only, so the match scorer
+        // pairs every numeral the insertion step can read.
+        String trimmed = token.trim();
+        if (hasDecimalDigit(trimmed)) {
+            return Optional.empty();
+        }
+        return singleCodePointNumericValue(trimmed).or(() -> signSequenceValue(trimmed))
+                .filter(value -> BigInteger.ONE.equals(value.denominator())).map(Rational::numerator);
     }
 
     /**

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.Normalizer2;
@@ -749,6 +750,86 @@ public final class NumeralValueParser {
             i += Character.charCount(cp);
         }
         return -1;
+    }
+
+    // ------------------------------------------------------------------------
+    // Number tokens of a segment
+    // ------------------------------------------------------------------------
+
+    /**
+     * Matches a canonical uppercase Roman numeral; lowercase or non-canonical
+     * letter runs (like "mix" or "civil") stay ordinary words.
+     */
+    private static final Pattern CANONICAL_ROMAN = Pattern
+            .compile("M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})");
+    private static final Pattern ANY_ROMAN_DIGIT = Pattern.compile(".*[IVX].*");
+    /** Han numeral ideographs, the unambiguous CJK number tokens. */
+    private static final Pattern HAN_NUMERALS = Pattern.compile(
+            "[〇零一二三四五六七八九"
+                    + "十百千万萬億兆两兩]+");
+
+    /**
+     * Whether a token taken from running text may be read as a number at all.
+     * Tokens containing a decimal digit or a letter numeral of any script always
+     * count; letter-only tokens count only in unambiguous forms (canonical
+     * uppercase Roman where the caller allows them, Han numerals), so ordinary
+     * words are never misread as numerals.
+     *
+     * Two boundaries are deliberate. A Roman form without I, V or X is rejected,
+     * because "L", "C", "D" and "M" stand for a unit or an abbreviation far more
+     * often than for 50, 100, 500 and 1000. And a Number-Other code point is not
+     * a numeral token, which keeps a superscript exponent, a vulgar fraction and
+     * an enclosed number out of the number comparisons.
+     */
+    private static boolean isNumeralToken(String text, boolean allowRoman) {
+        if (text == null || text.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < text.length();) {
+            int cp = text.codePointAt(i);
+            int type = Character.getType(cp);
+            if (type == Character.DECIMAL_DIGIT_NUMBER || type == Character.LETTER_NUMBER) {
+                return true;
+            }
+            i += Character.charCount(cp);
+        }
+        return allowRoman && CANONICAL_ROMAN.matcher(text).matches()
+                && ANY_ROMAN_DIGIT.matcher(text).matches()
+                || HAN_NUMERALS.matcher(text).matches();
+    }
+
+    /**
+     * The integer value of a token that may be read as a number, or empty when
+     * the token is not one. The gated form of {@link #parseWhole}: safe to apply
+     * to every token of a segment, because ordinary words are rejected before
+     * they reach the numeral parsers.
+     *
+     * Every caller decides for itself whether Roman numerals written with Latin
+     * letters count, because there is no telling "I", "V", "X", "MIX" or "DIV"
+     * apart from ordinary uppercase words. Where a false positive only shifts a
+     * similarity score it is worth reading them; where it rewrites text a
+     * translator is handed, it is not. Roman numerals written with the dedicated
+     * code points are letter numerals and count either way.
+     *
+     * @param allowRoman
+     *            whether a Latin-letter Roman numeral is a number here
+     */
+    public static Optional<BigInteger> parseTokenWhole(String token, boolean allowRoman) {
+        return isNumeralToken(token, allowRoman) ? parseWhole(token) : Optional.empty();
+    }
+
+    /**
+     * The exact value of a token that may be read as a number, or empty when the
+     * token is not one. The gated form of {@link #parseValue}, so decimals,
+     * fractions and the integer numeral systems are all recognized while
+     * ordinary words are not.
+     *
+     * @param allowRoman
+     *            whether a Latin-letter Roman numeral is a number here; see
+     *            {@link #parseTokenWhole(String, boolean)} for what that costs
+     */
+    public static Optional<Rational> parseTokenValue(String token, boolean allowRoman) {
+        return isNumeralToken(token, allowRoman) ? parseValue(token) : Optional.empty();
     }
 
     /**

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -30,13 +30,26 @@ import java.math.BigInteger;
 import java.text.ParsePosition;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.OptionalLong;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
+
+import org.jspecify.annotations.Nullable;
+
+import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.Normalizer2;
@@ -1219,5 +1232,227 @@ public final class NumeralValueParser {
         int type = Character.getType(cp);
         // Number-letter (Roman numeral code points) and number-other (vulgar fractions) belong here.
         return type != Character.LETTER_NUMBER && type != Character.OTHER_NUMBER;
+    }
+
+    /**
+     * The gated token value with locale knowledge on top: when the token does
+     * not read as a plain number, grouping and decimal separators of the given
+     * locale are resolved (the universal parsers refuse them as irreducibly
+     * ambiguous - with a locale they are not). "1.234.567,89" reads as
+     * 1234567.89 under a German locale and stays unreadable under an English
+     * one.
+     */
+    public static Optional<Rational> parseTokenValueLocalized(String token, boolean allowRoman,
+            @Nullable Locale locale) {
+        Optional<Rational> plain = parseTokenValue(token, allowRoman);
+        if (plain.isPresent() || locale == null) {
+            return plain;
+        }
+        String normalized = normalizeLocaleSeparators(token.trim(), locale);
+        return normalized == null ? Optional.empty() : parseTokenValue(normalized, allowRoman);
+    }
+
+    /**
+     * Strips the locale's grouping separators and turns its decimal separator
+     * into the point the universal parser reads, but only when the token
+     * matches the locale's number shape exactly (groups of three, at most one
+     * decimal part). Space-family grouping accepts the plain, no-break and
+     * narrow no-break space interchangeably. Returns null when the token does
+     * not have the locale's number shape.
+     */
+    /**
+     * Compiled number shape per locale; tokens arrive per keystroke and per
+     * search. JCache layer (Caffeine) bounds the cache by size and age
+     * (pattern of BaseCachedTranslate); values live by reference, a copying
+     * store would re-serialize the Pattern on every hit. Keys carry no
+     * project state, so no close listener is needed. Lazy holder keeps a
+     * JCache provider failure out of class init.
+     */
+    private static final class LocaleShapeCache {
+        private static final String NAME = "numeralValueLocaleShapes";
+        static final Cache<Locale, Pattern> CACHE = create();
+
+        private static Cache<Locale, Pattern> create() {
+            CacheManager manager = Caching.getCachingProvider().getCacheManager();
+            Cache<Locale, Pattern> cache = manager.getCache(NAME);
+            if (cache == null) {
+                CaffeineConfiguration<Locale, Pattern> config = new CaffeineConfiguration<>();
+                config.setExpiryPolicyFactory(() -> new CreatedExpiryPolicy(Duration.ONE_DAY));
+                config.setMaximumSize(OptionalLong.of(32));
+                config.setStoreByValue(false);
+                cache = manager.createCache(NAME, config);
+            }
+            return cache;
+        }
+    }
+
+    private static Pattern localeShape(Locale locale) {
+        Pattern cached = LocaleShapeCache.CACHE.get(locale);
+        if (cached != null) {
+            return cached;
+        }
+        Pattern built = buildLocaleShape(locale);
+        LocaleShapeCache.CACHE.put(locale, built);
+        return built;
+    }
+
+    private static Pattern buildLocaleShape(Locale loc) {
+        java.text.DecimalFormatSymbols symbols = java.text.DecimalFormatSymbols.getInstance(loc);
+        char group = symbols.getGroupingSeparator();
+        char decimal = symbols.getDecimalSeparator();
+        String groupClass = Character.isSpaceChar(group) ? "[\u0020\u00A0\u202F]"
+                : Pattern.quote(String.valueOf(group));
+        String decimalQuoted = Pattern.quote(String.valueOf(decimal));
+        String digit = "\\p{Nd}";
+        // The locale's grouping shape, including secondary grouping
+        // (Indian 12,34,567: last group of three, leading groups of two).
+        int primary = 3;
+        int secondary = 3;
+        com.ibm.icu.text.NumberFormat icuFormat = com.ibm.icu.text.NumberFormat
+                .getIntegerInstance(ULocale.forLocale(loc));
+        if (icuFormat instanceof com.ibm.icu.text.DecimalFormat) {
+            com.ibm.icu.text.DecimalFormat icu = (com.ibm.icu.text.DecimalFormat) icuFormat;
+            primary = Math.max(1, icu.getGroupingSize());
+            secondary = icu.getSecondaryGroupingSize() > 0 ? icu.getSecondaryGroupingSize()
+                    : primary;
+        }
+        String grouped = "[-+]?" + digit + "{1," + secondary + "}(?:" + groupClass + digit + "{"
+                + secondary + "})*" + groupClass + digit + "{" + primary + "}(?:" + decimalQuoted
+                + digit + "+)?";
+        String plainDecimal = "[-+]?" + digit + "+" + decimalQuoted + digit + "+";
+        return Pattern.compile(grouped + "|" + plainDecimal);
+    }
+
+    private static @Nullable String normalizeLocaleSeparators(String token, Locale locale) {
+        java.text.DecimalFormatSymbols symbols = java.text.DecimalFormatSymbols.getInstance(locale);
+        char group = symbols.getGroupingSeparator();
+        char decimal = symbols.getDecimalSeparator();
+        if (!localeShape(locale).matcher(token).matches()) {
+            return null;
+        }
+        StringBuilder out = new StringBuilder();
+        token.codePoints().forEach(cp -> {
+            if (cp == decimal) {
+                out.append('.');
+            } else if (cp != group && !(Character.isSpaceChar(group) && Character.isSpaceChar(cp))) {
+                // everything but the grouping separator survives
+                out.appendCodePoint(cp);
+            }
+        });
+        return out.toString();
+    }
+
+    /** Digit zero of every decimal digit script, computed once. */
+    private static volatile int @Nullable [] decimalZeros;
+
+    private static int[] decimalZeros() {
+        int[] zeros = decimalZeros;
+        if (zeros == null) {
+            zeros = IntStream.rangeClosed(0, Character.MAX_CODE_POINT)
+                    .filter(cp -> Character.getType(cp) == Character.DECIMAL_DIGIT_NUMBER
+                            && Character.digit(cp, 10) == 0)
+                    .toArray();
+            decimalZeros = zeros;
+        }
+        return zeros;
+    }
+
+    /**
+     * Every supported rendering of the value: ASCII, the positional digits of
+     * every decimal digit script, the algorithmic systems (Han, Ethiopic,
+     * Hebrew ...), the dedicated Roman numeral code points, and - only when
+     * allowed - Latin-letter Roman numerals. Lets a search match a number by
+     * its value: the alternation of these strings finds every writing the
+     * parser would read back as the same number.
+     */
+    /**
+     * Rendering lists per value: searches repeat the same terms. JCache layer
+     * (Caffeine) bounds the cache by size and age (pattern of
+     * BaseCachedTranslate); values are immutable lists held by reference.
+     * Keys carry no project state, so no close listener is needed. Lazy
+     * holder keeps a JCache provider failure out of class init.
+     */
+    private static final class RenderingsCache {
+        private static final String NAME = "numeralValueRenderings";
+        static final Cache<String, List<String>> CACHE = create();
+
+        private static Cache<String, List<String>> create() {
+            CacheManager manager = Caching.getCachingProvider().getCacheManager();
+            Cache<String, List<String>> cache = manager.getCache(NAME);
+            if (cache == null) {
+                CaffeineConfiguration<String, List<String>> config = new CaffeineConfiguration<>();
+                config.setExpiryPolicyFactory(() -> new CreatedExpiryPolicy(Duration.ONE_DAY));
+                config.setMaximumSize(OptionalLong.of(64));
+                config.setStoreByValue(false);
+                cache = manager.createCache(NAME, config);
+            }
+            return cache;
+        }
+    }
+
+    public static List<String> renderings(BigInteger value, boolean allowRoman) {
+        String key = value + ":" + allowRoman;
+        List<String> cached = RenderingsCache.CACHE.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        List<String> built = List.copyOf(computeRenderings(value, allowRoman));
+        RenderingsCache.CACHE.put(key, built);
+        return built;
+    }
+
+    /**
+     * The value written with the given locale's number format (grouping
+     * separators included), so a search can also find locale-formatted
+     * writings like "1.234" for 1234 under a German locale.
+     */
+    public static Optional<String> localeRendering(BigInteger value, Locale locale) {
+        if (value.bitLength() >= 63) {
+            return Optional.empty();
+        }
+        return Optional.of(java.text.NumberFormat.getIntegerInstance(locale)
+                .format(value.longValueExact()));
+    }
+
+    private static List<String> computeRenderings(BigInteger value, boolean allowRoman) {
+        Set<String> out = new LinkedHashSet<>();
+        String ascii = value.toString();
+        out.add(ascii);
+        if (value.signum() >= 0) {
+            for (int zero : decimalZeros()) {
+                StringBuilder sb = new StringBuilder();
+                ascii.chars().forEach(c -> sb.appendCodePoint(zero + (c - '0')));
+                out.add(sb.toString());
+            }
+            if (value.signum() > 0 && value.compareTo(BigInteger.valueOf(12)) <= 0) {
+                // The dedicated Roman numeral code points cover one to twelve.
+                int v = value.intValueExact();
+                out.add(String.valueOf((char) (0x2160 + v - 1)));
+                out.add(String.valueOf((char) (0x2170 + v - 1)));
+            }
+        }
+        if (value.bitLength() < 63) {
+            long v = value.longValueExact();
+            for (RuleSpec spec : SPECS) {
+                boolean roman = spec.ruleSet().startsWith("%roman");
+                if (roman && !allowRoman) {
+                    continue;
+                }
+                try {
+                    RuleBasedNumberFormat format = new RuleBasedNumberFormat(spec.locale(), spec.type());
+                    format.setDefaultRuleSet(spec.ruleSet());
+                    String rendered = format.format(v);
+                    // Only renderings the parser reads back as the same value
+                    // belong in the alternation; some rule sets fall back to
+                    // digits or produce unparseable text outside their range.
+                    if (parseTokenWhole(rendered, roman).filter(value::equals).isPresent()) {
+                        out.add(rendered);
+                    }
+                } catch (RuntimeException ignore) {
+                    // Rule set not available in this ICU build; skip it.
+                }
+            }
+        }
+        return new ArrayList<>(out);
     }
 }

--- a/src/main/java/org/omegat/util/Preferences.java
+++ b/src/main/java/org/omegat/util/Preferences.java
@@ -148,9 +148,13 @@ public final class Preferences {
     public static final String SEARCHWINDOW_SEARCH_TYPE = "search_window_search_type";
     public static final String SEARCHWINDOW_REPLACE_TYPE = "search_window_replace_type";
     public static final String SEARCHWINDOW_CASE_SENSITIVE = "search_window_case_sensitive";
+    /** @deprecated superseded by the per-window character equivalence options (#1681). */
+    @Deprecated
     public static final String SEARCHWINDOW_SPACE_MATCH_NBSP = "search_window_space_match_nbsp";
     public static final String SEARCHWINDOW_WHOLE_WORDS = "search_window_whole_words";
     public static final String SEARCHWINDOW_CASE_SENSITIVE_REPLACE = "search_window_case_sensitive_replace";
+    /** @deprecated superseded by the per-window character equivalence options (#1681). */
+    @Deprecated
     public static final String SEARCHWINDOW_SPACE_MATCH_NBSP_REPLACE = "search_window_space_match_nbsp_replace";
     public static final String SEARCHWINDOW_REPLACE_UNTRANSLATED = "search_window_replace_untranslated";
     public static final String SEARCHWINDOW_SEARCH_SOURCE = "search_window_search_source";

--- a/src/main/java/org/omegat/util/ProjectFileStorage.java
+++ b/src/main/java/org/omegat/util/ProjectFileStorage.java
@@ -223,6 +223,9 @@ public final class ProjectFileStorage {
         if (om.getProject().isMatchNumbers() != null) {
             result.setMatchNumbersEnabled(om.getProject().isMatchNumbers());
         }
+        if (om.getProject().isMatchNumbersRoman() != null) {
+            result.setMatchNumbersRomanEnabled(om.getProject().isMatchNumbersRoman());
+        }
         if (om.getProject().getExternalCommand() != null) {
             result.setExternalCommand(om.getProject().getExternalCommand());
         }
@@ -278,10 +281,14 @@ public final class ProjectFileStorage {
         om.getProject().setSentenceSeg(props.isSentenceSegmentingEnabled());
         om.getProject().setSupportDefaultTranslations(props.isSupportDefaultTranslations());
         om.getProject().setRemoveTags(props.isRemoveTags());
-        // Opt-in flag: only written when set, so default project files stay
-        // identical to the ones older OmegaT versions write.
-        if (props.isMatchNumbersEnabled()) {
-            om.getProject().setMatchNumbers(true);
+        // Number matching defaults to on; only the opt-out is written, so
+        // default project files stay free of the element. Roman numerals stay
+        // opt-in and only the enabled state is written.
+        if (!props.isMatchNumbersEnabled()) {
+            om.getProject().setMatchNumbers(false);
+        }
+        if (props.isMatchNumbersRomanEnabled()) {
+            om.getProject().setMatchNumbersRoman(true);
         }
         om.getProject().setExternalCommand(props.getExternalCommand());
 

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -2318,6 +2318,18 @@ TEAM_HTTP_UNAUTHORIZED=Authentication error when trying to access {0}.
 TEAM_HTTP_NOT_FOUND=No content found at {0}.
 TEAM_HTTP_OTHER_ERRORS=HTTP connection {1} responded with code: {2}.
 
+TEAM_SETTING_DIVERGED_TITLE=Team Project Setting
+TEAM_SETTING_DIVERGED_MESSAGE=The project setting "{0}" is {1} on this computer but {2} in the team project. The team version is now active.\nWhat do you want to do with the local version?
+TEAM_SETTING_SHARE=Share with the team
+TEAM_SETTING_TAKE_TEAM=Use the team version
+TEAM_SETTING_KEEP_THIS_TIME=Use the local version this time
+TEAM_SETTING_CHANGED_MESSAGE=You changed the project setting "{0}" to {1}. Share the change with the team? Without sharing it stays local, and the next open of the project asks again.
+TEAM_SETTING_KEEP_FOR_NOW=Keep it local for now
+TEAM_SETTING_VALUE_ON=enabled
+TEAM_SETTING_VALUE_OFF=disabled
+TEAM_SETTING_SHARE_ERROR=The setting could not be committed to the team project.
+TEAM_SETTING_APPLY_ERROR=The local setting could not be applied.
+
 # Save options
 SAVE_DIALOG_TITLE=Saving and Output Options
 PREFS_TITLE_SAVING_AND_OUTPUT=Saving and Output

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -400,15 +400,12 @@ TF_MENU_HELP_CHECK_FOR_UPDATES=&Check for Updates...
 
 # PREFERENCES
 
-
-
 PREFS_AUTOCOMPLETE_SHOW_AUTOMATICALLY=&Show relevant suggestions automatically
 PREFS_AUTOCOMPLETE_SWITCH_VIEWS_LR=Switch views with {0} and {1}
 PREFS_TITLE_AUTOCOMPLETER=Auto-Completion
 PREFS_AUTOCOMPLETE_HISTORY_COMPLETION_ENABLED=&Enable history completion
 PREFS_AUTOCOMPLETE_HISTORY_PREDICTION_ENABLED=Enable history &prediction
 PREFS_TITLE_AUTOCOMPLETE_HISTORY=History
-
 
 MW_OPTIONMENU_APPEARANCE_MENUSTYLE_LABEL=UI Style
 MW_OPTIONMENU_APPEARANCE_THEME_LABEL=Theme
@@ -564,7 +561,6 @@ GUI_PROJECT_TOTAL_SEGMENTS=Total number of segments
 GUI_PROJECT_UNIQUE_SEGMENTS=Number of unique segments
 
 GUI_PROJECT_TRANSLATED=Translated unique segments
-
 
 # immortalize the BeOS 404 messages (some modified a bit for context)
 HF_HAIKU_1=Exciting help page\nGossamer threads hold you back\n404 not found
@@ -785,7 +781,60 @@ PP_LOC_TOK=Target language tokenizer:
 PP_ALLOW_DEFAULTS=&Auto-propagation of translations
 
 PP_REMOVE_TAGS=Remove ta&gs
-PP_MATCH_NUMBERS=Consider &numbers in fuzzy matching
+
+PP_MATCH_EQUIVALENCE=Character e&quivalence...
+
+EQUIVALENCE_TEAM_SETTING_NAME=Character equivalence classes
+
+EQUIVALENCE_TEAM_SETTING_ALL_ACTIVE=all classes active
+
+EQUIVALENCE_TEAM_SETTING_DISABLED=disabled: {0}
+
+MATCH_EQUIVALENCE_DIALOG_TITLE=Character Equivalence in Fuzzy Matching
+
+MATCH_EQUIVALENCE_NFC_NOTE=Unicode canonical normalization (NFC) always applies, independent of these classes.
+
+MATCH_EQUIVALENCE_NUMBERS=&Number value equality
+
+MATCH_EQUIVALENCE_NUMBERS_TOOLTIP=More than character folding: number values read in the source text are recognized in the target text whatever the two numeral systems are \u2014 fullwidth digits, cuneiform, Persian-Indic digits or Han numerals \u2014 including decimal points and fractions. Also applied in fuzzy matching and when inserting matches.
+
+MATCH_EQUIVALENCE_NUMBERS_ROMAN=&Roman numerals written with Latin letters
+
+MATCH_EQUIVALENCE_COPY_ALL=Copy {0} character replacement details
+
+MATCH_EQUIVALENCE_EXAMPLE=E&xample
+
+MATCH_EQUIVALENCE_EXAMPLE_TOOLTIP=Cycles through {0} example pairs
+
+SW_NUMBERS_LABEL=Numbers:
+
+SW_NUMBERS_BY_VALUE=Equal by value across writing systems
+
+SW_NUMBERS_ROMAN=Including Latin-letter Roman numerals
+
+SW_NUMBERS_TOOLTIP=A search term that is one number finds every writing of the same value.
+
+MATCH_EQUIVALENCE_TEST_TITLE=Test
+
+MATCH_EQUIVALENCE_TEST_TEXT_A=Text A:
+
+MATCH_EQUIVALENCE_TEST_TEXT_B=Text B:
+
+MATCH_EQUIVALENCE_TEST_EQUAL=Texts compare as equal.
+
+MATCH_EQUIVALENCE_TEST_DIFFERENT=Texts compare as different.
+
+MATCH_EQUIVALENCE_REMOVED=(removed)
+
+EQUIVALENCE_CLASS_QUOTES=Quotation marks and apostrophes
+
+EQUIVALENCE_CLASS_DASHES=Hyphens and dashes
+
+EQUIVALENCE_CLASS_SPACES=Spaces
+
+EQUIVALENCE_CLASS_INVISIBLES=Invisible formatting characters
+
+CT_STATSMATCH_EQUIVALENCE_ACTIVE=Character equivalence classes active: {0}
 
 PP_EXTERNAL_COMMAND=Local post-processing commands
 
@@ -944,6 +993,16 @@ SW_CASE_SENSITIVE=C&ase sensitive
 SW_FULLHALFWIDTH_INSENSITIVE=Full/half-&width char insensitive
 
 SW_SEARCH_SPACE_MATCH_NBSP=S&pace matches nbsp
+
+SW_EQUIVALENCE_LABEL=Character equivalence:
+
+SW_EQUIVALENCE_QUOTES=Quotes
+
+SW_EQUIVALENCE_DASHES=Dashes
+
+SW_EQUIVALENCE_SPACES=Spaces
+
+SW_EQUIVALENCE_INVISIBLES=Invisibles
 
 SW_WHOLE_WORDS=&Whole words only
 
@@ -1467,7 +1526,6 @@ FLASH_FILTER_NAME=Flash XML Export
 
 WORDPRESS_FILTER_NAME=Wordpress XML export
 
-
 # AboutDialog.java
 
 # 0: OmegaT Brand
@@ -1895,7 +1953,6 @@ DOCKING_HINT_SETTINGS=Actions & Settings
 
 DOCKING_FIRST_STEPS_TITLE=First Steps
 
-
 # StaticUtils
 
 SU_USERHOME_PROP_ACCESS_ERROR=OmegaT was refused access to the system property containing\n\
@@ -2064,7 +2121,6 @@ GUI_DICTIONARY_INSTALLER_TEXT_NOTHING=No new languages available at the remote s
 
 GUI_DICTIONARY_INSTALLER_INSTALL=Install
 
-
 GUI_DICTIONARY_INSTALLER_AVAILABLE=Available languages:
 
 # org.omegat.gui.dialogs.PluginInstallerDialog
@@ -2182,7 +2238,6 @@ SCW_MENU_SAVE_SET=Save Current Set...
 SCW_SAVE_SET_MSG=Enter the name of this set:
 SCW_MENU_HELP=&Help
 SCW_MENU_JAVADOC=OmegaT Javadoc...
-
 
 # PO-Filter
 POFILTER_TRANSLATOR_COMMENTS=Translator comments:
@@ -2460,7 +2515,6 @@ STM_METADATA_FILE=File
 STM_METADATA_NEXT=Next
 STM_METADATA_PREV=Previous
 STM_REPORT_FORMAT=Added: {1}, Deleted: {2}, Modified: {3} (Conflicts: {0})
-
 
 # Filename patterns editor dialog
 FILENAMEPATTERNS_TITLE=Exclusion Patterns

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -2187,6 +2187,18 @@ TEAM_HTTP_UNAUTHORIZED=Authentifizierungsfehler beim Zugriff auf {0}.
 TEAM_HTTP_NOT_FOUND=Kein Inhalt gefunden bei {0}.
 TEAM_HTTP_OTHER_ERRORS=HTTP-Verbindung {1} antwortet mit Code: {2}.
 
+TEAM_SETTING_DIVERGED_TITLE=Team-Projekteinstellung
+TEAM_SETTING_DIVERGED_MESSAGE=Die Projekteinstellung "{0}" ist auf diesem Rechner {1}, im Teamprojekt {2}. Die Team-Fassung ist jetzt aktiv.\nWas soll mit der lokalen Fassung geschehen?
+TEAM_SETTING_SHARE=Ans Team verteilen
+TEAM_SETTING_TAKE_TEAM=Team-Fassung \u00FCbernehmen
+TEAM_SETTING_KEEP_THIS_TIME=Diesmal die lokale Fassung verwenden
+TEAM_SETTING_CHANGED_MESSAGE=Die Projekteinstellung "{0}" wurde auf {1} ge\u00E4ndert. Soll die \u00C4nderung ans Team verteilt werden? Ohne Verteilung bleibt sie lokal, und das n\u00E4chste \u00D6ffnen des Projekts fragt erneut.
+TEAM_SETTING_KEEP_FOR_NOW=Vorerst lokal belassen
+TEAM_SETTING_VALUE_ON=aktiviert
+TEAM_SETTING_VALUE_OFF=deaktiviert
+TEAM_SETTING_SHARE_ERROR=Die Einstellung konnte nicht ins Teamprojekt \u00FCbertragen werden.
+TEAM_SETTING_APPLY_ERROR=Die lokale Einstellung konnte nicht angewendet werden.
+
 # Save options
 SAVE_DIALOG_TITLE=Speichern und Ausgabe
 PREFS_TITLE_SAVING_AND_OUTPUT=Speichern und Ausgabe

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -380,15 +380,12 @@ TF_MENU_HELP_CHECK_FOR_UPDATES=&Nach Updates suchen...
 
 # PREFERENCES
 
-
-
 PREFS_AUTOCOMPLETE_SHOW_AUTOMATICALLY=Relevante Vorschl\u00E4ge automati&sch anzeigen
 PREFS_AUTOCOMPLETE_SWITCH_VIEWS_LR=Ansichten mit {0} und {1} wechseln
 PREFS_TITLE_AUTOCOMPLETER=Autovervollst\u00E4ndigung
 PREFS_AUTOCOMPLETE_HISTORY_COMPLETION_ENABLED=V&erlaufsvervollst\u00E4ndigung aktivieren
 PREFS_AUTOCOMPLETE_HISTORY_PREDICTION_ENABLED=Ver&laufsvorhersage aktivieren
 PREFS_TITLE_AUTOCOMPLETE_HISTORY=Verlauf
-
 
 MW_OPTIONMENU_APPEARANCE_MENUSTYLE_LABEL=UI-Stil
 MW_OPTIONMENU_APPEARANCE_THEME_LABEL=Design
@@ -530,7 +527,6 @@ GUI_PROJECT_TOTAL_SEGMENTS=Gesamtzahl der Segmente
 GUI_PROJECT_UNIQUE_SEGMENTS=Anzahl einmaliger Segmente
 
 GUI_PROJECT_TRANSLATED=\u00DCbersetzte einmalige Segmente
-
 
 # immortalize the BeOS 404 messages (some modified a bit for context)
 HF_HAIKU_1=Exciting help page\nGossamer threads hold you back\n404 not found
@@ -751,7 +747,60 @@ PP_LOC_TOK=Tokenizer der Zielsprache:
 PP_ALLOW_DEFAULTS=&Auto-Propagation von \u00DCbersetzungen
 
 PP_REMOVE_TAGS=Ta&gs entfernen
-PP_MATCH_NUMBERS=Zahle&n bei unscharfen Treffern ber\u00FCcksichtigen
+
+PP_MATCH_EQUIVALENCE=Zeichen-\u00C4&quivalenz...
+
+EQUIVALENCE_TEAM_SETTING_NAME=Zeichen-\u00C4quivalenzklassen
+
+EQUIVALENCE_TEAM_SETTING_ALL_ACTIVE=alle Klassen aktiv
+
+EQUIVALENCE_TEAM_SETTING_DISABLED=abgeschaltet: {0}
+
+MATCH_EQUIVALENCE_DIALOG_TITLE=Zeichen-\u00C4quivalenz bei unscharfen Treffern
+
+MATCH_EQUIVALENCE_NFC_NOTE=Kanonische Unicode-Normalisierung (NFC) gilt immer, unabh\u00E4ngig von diesen Klassen.
+
+MATCH_EQUIVALENCE_NUMBERS=Zahle&n-Wertgleichheit
+
+MATCH_EQUIVALENCE_NUMBERS_TOOLTIP=Mehr als Zeichenersetzung: Im Ausgangstext gelesene Zahlenwerte werden im Zieltext wiedererkannt, egal welche Zahlsysteme beide verwenden \u2014 Vollbreite-Ziffern, Keilschrift, persisch-indische Ziffern oder Han-Zahlzeichen \u2014 einschlie\u00DFlich Dezimalpunkten und Br\u00FCchen. Wird auch beim Fuzzy-Matching und beim Einf\u00FCgen von Treffern angewendet.
+
+MATCH_EQUIVALENCE_NUMBERS_ROMAN=&R\u00F6mische Zahlen aus lateinischen Buchstaben
+
+MATCH_EQUIVALENCE_COPY_ALL={0} Zeichen-Ersetzungs-Informationen kopieren
+
+MATCH_EQUIVALENCE_EXAMPLE=&Beispiel
+
+MATCH_EQUIVALENCE_EXAMPLE_TOOLTIP=Wechselt durch {0} Beispielpaare
+
+SW_NUMBERS_LABEL=Zahlen:
+
+SW_NUMBERS_BY_VALUE=Nach Wert \u00FCber Schriftsysteme gleich
+
+SW_NUMBERS_ROMAN=Auch r\u00F6mische Zahlen aus lateinischen Buchstaben
+
+SW_NUMBERS_TOOLTIP=Ein Suchbegriff, der eine einzelne Zahl ist, findet jede Schreibung desselben Werts.
+
+MATCH_EQUIVALENCE_TEST_TITLE=Test
+
+MATCH_EQUIVALENCE_TEST_TEXT_A=Text A:
+
+MATCH_EQUIVALENCE_TEST_TEXT_B=Text B:
+
+MATCH_EQUIVALENCE_TEST_EQUAL=Texte gelten als gleich.
+
+MATCH_EQUIVALENCE_TEST_DIFFERENT=Texte gelten als verschieden.
+
+MATCH_EQUIVALENCE_REMOVED=(entfernt)
+
+EQUIVALENCE_CLASS_QUOTES=Anf\u00FChrungszeichen und Apostrophe
+
+EQUIVALENCE_CLASS_DASHES=Binde- und Gedankenstriche
+
+EQUIVALENCE_CLASS_SPACES=Leerzeichen
+
+EQUIVALENCE_CLASS_INVISIBLES=Unsichtbare Formatierungszeichen
+
+CT_STATSMATCH_EQUIVALENCE_ACTIVE=Aktive Zeichen-\u00C4quivalenzklassen: {0}
 
 PP_EXTERNAL_COMMAND=Lokale Nachbearbeitungsbefehle
 
@@ -907,6 +956,16 @@ SW_CASE_SENSITIVE=Gro\u00DF-/&Kleinschreibung beachten
 SW_FULLHALFWIDTH_INSENSITIVE=Zeichen unabh\u00E4ngig von voller/halber Breite
 
 SW_SEARCH_SPACE_MATCH_NBSP=Leerzeichen findet nbs&p
+
+SW_EQUIVALENCE_LABEL=Zeichen-\u00C4quivalenz:
+
+SW_EQUIVALENCE_QUOTES=Anf\u00FChrungszeichen
+
+SW_EQUIVALENCE_DASHES=Striche
+
+SW_EQUIVALENCE_SPACES=Leerzeichen
+
+SW_EQUIVALENCE_INVISIBLES=Unsichtbare
 
 SW_WHOLE_WORDS=Nur ganze W\u00F6rter
 
@@ -1400,7 +1459,6 @@ FLASH_FILTER_NAME=Flash XML Export
 
 WORDPRESS_FILTER_NAME=Wordpress XML export
 
-
 # AboutDialog.java
 
 # 0: OmegaT Brand
@@ -1801,7 +1859,6 @@ DOCKING_HINT_SETTINGS=Aktionen & Einstellungen
 
 DOCKING_FIRST_STEPS_TITLE=Erste Schritte
 
-
 # StaticUtils
 
 SU_USERHOME_PROP_ACCESS_ERROR=OmegaT hatte keine Zugriffsrechte auf Systemeigenschaften, die\nden Namen Ihres Betriebssystems und/oder Ihres Benutzerordners\nenthalten. Aus diesem Grund kann der Speicherort des\nKonfigurationsordners von OmegaT nicht zuverl\u00E4ssig ermittelt\nwerden. Stattdessen wird der aktuelle Ordner verwendet. Dies wird\nalle Einstellungen auf ihre Standardwerte zur\u00FCcksetzen. Es kann\ndaher zu unerwartetem, aber korrektem Verhalten kommen.
@@ -1955,7 +2012,6 @@ GUI_DICTIONARY_INSTALLER_TEXT_NOTHING=Keine neuen Sprachen auf dem Remote-Server
 
 GUI_DICTIONARY_INSTALLER_INSTALL=Installieren
 
-
 GUI_DICTIONARY_INSTALLER_AVAILABLE=Verf\u00FCgbare Sprachen:
 
 # org.omegat.gui.dialogs.PluginInstallerDialog
@@ -2073,7 +2129,6 @@ SCW_MENU_SAVE_SET=Aktuelles Set speichern...
 SCW_SAVE_SET_MSG=Geben Sie den Namen dieses Sets ein:
 SCW_MENU_HELP=&Hilfe
 SCW_MENU_JAVADOC=OmegaT-Javadoc...
-
 
 # PO-Filter
 POFILTER_TRANSLATOR_COMMENTS=Kommentare des \u00DCbersetzers:
@@ -2325,7 +2380,6 @@ STM_METADATA_FILE=Datei
 STM_METADATA_NEXT=Weiter
 STM_METADATA_PREV=Zur\u00FCck
 STM_REPORT_FORMAT=Hinzugef\u00FCgt: {1}, Gel\u00F6scht: {2}, Ver\u00E4ndert: {3} (Konflikte: {0})
-
 
 # Filename patterns editor dialog
 FILENAMEPATTERNS_TITLE=Ausnahmemuster

--- a/src/main/resources/schemas/project_properties.xsd
+++ b/src/main/resources/schemas/project_properties.xsd
@@ -30,6 +30,7 @@
 				<xs:element name="support_default_translations" type="xs:boolean" minOccurs="0"/>
 				<xs:element name="remove_tags" type="xs:boolean" minOccurs="0"/>
 				<xs:element name="match_numbers" type="xs:boolean" minOccurs="0"/>
+				<xs:element name="match_numbers_roman" type="xs:boolean" minOccurs="0"/>
 				<xs:element name="external_command" type="xs:string" minOccurs="0"/>
                 <xs:element name="repositories" minOccurs="0">
                     <xs:complexType>

--- a/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
@@ -1,0 +1,274 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.team2.RemoteRepositoryProvider;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that sharing a team project setting commits the sidecar settings
+ * file and leaves omegat.project untouched, so team members on older OmegaT
+ * versions can still open the project.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectSettingsPublishTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "README").toPath(), "team project\n",
+                StandardCharsets.UTF_8);
+        commitAll("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    @Test
+    public void testPublishDeliversTheSettingsFileToTheTeam() throws Exception {
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("the team must receive the value", "true", loadDeliveredValue("member2"));
+        assertFalse("omegat.project must stay untouched for older versions",
+                new File(projectDir, OConsts.FILE_PROJECT).exists());
+    }
+
+    @Test
+    public void testPublishCanAlsoOverwriteAValue() throws Exception {
+        Files.createDirectories(new File(remoteDir, OConsts.DEFAULT_INTERNAL).toPath());
+        Files.writeString(remoteSettingsFile().toPath(), KEY + "=true\n", StandardCharsets.UTF_8);
+        commitAll("team with the option");
+
+        ProjectSettingsStorage.save(config, KEY, "false");
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("the team must receive the new value", "false", loadDeliveredValue("member2"));
+    }
+
+    @Test
+    public void testPublishingAnAlreadySharedValueIsNotAnError() throws Exception {
+        // Another team member shared the same value in the meantime: the git
+        // commit would be a no-op, which reports the same way as a rejected
+        // push - so publishing must recognise the identical file and skip.
+        Files.createDirectories(new File(remoteDir, OConsts.DEFAULT_INTERNAL).toPath());
+        Files.writeString(remoteSettingsFile().toPath(), KEY + "=true\n", StandardCharsets.UTF_8);
+        commitAll("team already carries the value");
+
+        ProjectSettingsStorage.save(config, KEY, "true");
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("true", loadDeliveredValue("member2"));
+    }
+
+    @Test
+    public void testStorageRoundTripAndDefaults() throws Exception {
+        assertNull("unconfigured project reads as null", ProjectSettingsStorage.load(config, KEY));
+        // removing an unset key must not materialise the file
+        ProjectSettingsStorage.save(config, KEY, null);
+        assertFalse("removing from an absent file must stay a no-op",
+                ProjectSettingsStorage.getFile(config).isFile());
+        ProjectSettingsStorage.save(config, KEY, "true");
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+        // deterministic content, so team no-op detection can compare bytes
+        assertEquals(KEY + "=true\n",
+                Files.readString(ProjectSettingsStorage.getFile(config).toPath(), StandardCharsets.UTF_8));
+        ProjectSettingsStorage.save(config, KEY, "false");
+        assertEquals("false", ProjectSettingsStorage.load(config, KEY));
+        // null removes the key but keeps the file and foreign keys
+        Files.writeString(ProjectSettingsStorage.getFile(config).toPath(),
+                "future_setting=x\n" + KEY + "=false\n", StandardCharsets.UTF_8);
+        ProjectSettingsStorage.save(config, KEY, null);
+        assertNull(ProjectSettingsStorage.load(config, KEY));
+        assertTrue(Files.readString(ProjectSettingsStorage.getFile(config).toPath(),
+                StandardCharsets.UTF_8).contains("future_setting=x"));
+    }
+
+    @Test
+    public void testResolveSettingTruthTable() {
+        // non-team / offline: the local file rules, never a question
+        assertResolved(null, null, RealProject.resolveSetting(null, null, false, false));
+        assertResolved("true", null, RealProject.resolveSetting(null, "true", false, false));
+        // team: remote delivered a value over an absent local file - first
+        // arrival activates and asks once
+        assertAsks("true", null, RealProject.resolveSetting(null, "true", true, true));
+        // team: remote delivered a differing value - team wins, asks
+        assertAsks("false", "true", RealProject.resolveSetting("true", "false", true, true));
+        // team: local-only survivor - team default stays active, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", "true", false, true));
+        // team: both agree (shared value) - quiet
+        assertResolved("true", null, RealProject.resolveSetting("true", "true", true, true));
+        // team: nothing anywhere - quiet
+        assertResolved(null, null, RealProject.resolveSetting(null, null, false, true));
+        // team: remote carries only foreign future keys - like absent, quiet
+        assertResolved(null, null, RealProject.resolveSetting(null, null, true, true));
+        // team: the sync deleted the key - team default wins, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", null, true, true));
+        // team: diverged and not identical - local-only, team default, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", "false", false, true));
+    }
+
+    private static void assertResolved(String effective, String superseded,
+            RealProject.SettingResolution state) {
+        assertEquals(effective, state.effective);
+        assertFalse("expected quiet resolution", state.asks);
+        assertEquals(superseded, state.supersededLocal);
+    }
+
+    private static void assertAsks(String effective, String superseded,
+            RealProject.SettingResolution state) {
+        assertEquals(effective, state.effective);
+        assertTrue("expected a question", state.asks);
+        assertEquals(superseded, state.supersededLocal);
+    }
+
+    @Test
+    public void testPersistSessionSettingsSkipsSupersededAndDefaults() throws Exception {
+        AtomicBoolean first = new AtomicBoolean(true);
+        AtomicBoolean second = new AtomicBoolean(true);
+        TeamSettingsRegistry.register(TeamSetting.ofBoolean("first_option",
+                "TEAM_SETTING_DIVERGED_TITLE", false, p -> first.get(), (p, v) -> first.set(v)));
+        TeamSettingsRegistry.register(TeamSetting.ofBoolean("second_option",
+                "TEAM_SETTING_DIVERGED_TITLE", false, p -> second.get(), (p, v) -> second.set(v)));
+        try {
+            // superseded key keeps the file untouched for its setting, the
+            // other one still persists
+            RealProject.persistSessionSettings(config, Collections.singleton("first_option"));
+            assertNull(ProjectSettingsStorage.load(config, "first_option"));
+            assertEquals("true", ProjectSettingsStorage.load(config, "second_option"));
+
+            // default values stay unmaterialised unless the file exists
+            Files.delete(ProjectSettingsStorage.getFile(config).toPath());
+            first.set(false);
+            second.set(false);
+            RealProject.persistSessionSettings(config, Collections.emptySet());
+            assertFalse("defaults must not materialise the file",
+                    ProjectSettingsStorage.getFile(config).isFile());
+        } finally {
+            TeamSettingsRegistry.unregister("first_option");
+            TeamSettingsRegistry.unregister("second_option");
+        }
+    }
+
+    @Test
+    public void testEscapingWriterRoundTripsForeignKeys() throws Exception {
+        Files.createDirectories(ProjectSettingsStorage.getFile(config).getParentFile().toPath());
+        Files.writeString(ProjectSettingsStorage.getFile(config).toPath(),
+                "future\\ key\\=x=va\\\\lue\\=1\n" + KEY + "=false\n", StandardCharsets.UTF_8);
+        Properties before = loadRaw();
+        ProjectSettingsStorage.save(config, KEY, "true");
+        Properties after = loadRaw();
+        assertEquals("foreign key must survive the rewrite unchanged", before.getProperty("future key=x"),
+                after.getProperty("future key=x"));
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    private Properties loadRaw() throws Exception {
+        Properties p = new Properties();
+        try (java.io.Reader in = Files.newBufferedReader(
+                ProjectSettingsStorage.getFile(config).toPath(), StandardCharsets.UTF_8)) {
+            p.load(in);
+        }
+        return p;
+    }
+
+    private File remoteSettingsFile() {
+        return new File(remoteDir,
+                OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+    }
+
+    private void commitAll(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    /** Fetch the settings file the way a second member's open does. */
+    private String loadDeliveredValue(String memberDirName) throws Exception {
+        File memberDir = folder.newFolder(memberDirName);
+        RemoteRepositoryProvider member = newProvider(memberDir, remoteDir);
+        member.switchAllToLatest();
+        member.copyFilesFromReposToProject("");
+        return ProjectSettingsStorage.load(new ProjectProperties(memberDir), KEY);
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}

--- a/src/test/java/org/omegat/core/data/TeamSettingTest.java
+++ b/src/test/java/org/omegat/core/data/TeamSettingTest.java
@@ -1,0 +1,122 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Contract of the boolean team setting descriptor and the registry: absent
+ * key means default, only the non-default value materialises, normalization
+ * folds explicit default values back to null so divergence detection never
+ * confuses "explicitly default" with "not configured".
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class TeamSettingTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @After
+    public final void tearDown() {
+        TeamSettingsRegistry.unregister(KEY);
+    }
+
+    @Test
+    public void testOptInBooleanContract() throws Exception {
+        AtomicBoolean holder = new AtomicBoolean(false);
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false,
+                config -> holder.get(), (config, value) -> holder.set(value));
+        ProjectProperties config = new ProjectProperties(folder.newFolder("p"));
+
+        assertNull("default reads as not configured", setting.read(config));
+        holder.set(true);
+        assertEquals("only the non-default value materialises", "true", setting.read(config));
+
+        setting.apply(config, null);
+        assertEquals("null applies the default", false, holder.get());
+        setting.apply(config, "true");
+        assertTrue(holder.get());
+
+        assertNull("explicit default folds back to null", setting.normalize("false"));
+        assertEquals("true", setting.normalize("true"));
+        assertNull(setting.normalize(null));
+    }
+
+    @Test
+    public void testOptOutBooleanContract() throws Exception {
+        AtomicBoolean holder = new AtomicBoolean(true);
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", true,
+                config -> holder.get(), (config, value) -> holder.set(value));
+        ProjectProperties config = new ProjectProperties(folder.newFolder("p"));
+
+        assertNull("default reads as not configured", setting.read(config));
+        holder.set(false);
+        assertEquals("false", setting.read(config));
+
+        setting.apply(config, null);
+        assertTrue("null applies the default", holder.get());
+        assertNull("explicit default folds back to null", setting.normalize("true"));
+        assertEquals("false", setting.normalize("false"));
+    }
+
+    @Test
+    public void testDisplayNameStripsMnemonicMarker() {
+        // existing label keys carry mnemonic markers; dialogs must not show them
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "PP_REMOVE_TAGS", false,
+                config -> false, (config, value) -> {
+                });
+        assertFalse("marker key must resolve to a non-empty name", setting.getDisplayName().isEmpty());
+        assertEquals("mnemonic marker must be stripped", -1, setting.getDisplayName().indexOf('&'));
+    }
+
+    @Test
+    public void testRegistryRejectsDuplicatesAndUnregisters() {
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false,
+                config -> false, (config, value) -> {
+                });
+        TeamSettingsRegistry.register(setting);
+        assertNotNull(TeamSettingsRegistry.byKey(KEY));
+        assertThrows(IllegalArgumentException.class, () -> TeamSettingsRegistry.register(setting));
+        TeamSettingsRegistry.unregister(KEY);
+        assertNull(TeamSettingsRegistry.byKey(KEY));
+        assertTrue(TeamSettingsRegistry.all().stream().noneMatch(s -> s.getKey().equals(KEY)));
+    }
+}

--- a/src/test/java/org/omegat/core/matching/MatchEquivalenceTeamSettingTest.java
+++ b/src/test/java/org/omegat/core/matching/MatchEquivalenceTeamSettingTest.java
@@ -1,0 +1,142 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.matching;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.EnumSet;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectSettingsStorage;
+import org.omegat.core.data.TeamSetting;
+import org.omegat.core.data.TeamSettingsRegistry;
+import org.omegat.util.OStrings;
+
+/**
+ * The disabled equivalence classes ride the generic team settings sidecar
+ * (SF #1681): absent value means every class active, the normalizer folds
+ * the default to null and drops unknown ids, and a default project writes
+ * no file.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class MatchEquivalenceTeamSettingTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private ProjectProperties props;
+    private TeamSetting setting;
+
+    @Before
+    public void setUp() throws Exception {
+        props = new ProjectProperties(folder.getRoot());
+        setting = MatchEquivalence.teamSetting();
+    }
+
+    @After
+    public void tearDown() {
+        TeamSettingsRegistry.unregister(MatchEquivalence.TEAM_SETTING_KEY);
+    }
+
+    @Test
+    public void defaultReadsAsNull() {
+        assertNull(setting.read(props));
+        assertNull(setting.normalize(""));
+        assertNull(setting.normalize(null));
+    }
+
+    @Test
+    public void normalizerCanonicalizesAndDropsUnknownIds() {
+        assertEquals("dashes", setting.normalize("dashes,ligatures"));
+        assertEquals("quotes,spaces", setting.normalize(" spaces , quotes "));
+        assertEquals("quotes", setting.normalize("QUOTES"));
+        assertNull(setting.normalize("ligatures"));
+    }
+
+    @Test
+    public void describerNamesDisabledClasses() {
+        assertEquals(OStrings.getString("EQUIVALENCE_TEAM_SETTING_ALL_ACTIVE"), setting.describe(null));
+        String described = setting.describe("dashes");
+        assertTrue(described, described.contains(MatchEquivalence.DASHES.getLocalizedName()));
+    }
+
+    @Test
+    public void applyAndReadRoundTrip() {
+        setting.apply(props, "quotes,invisibles");
+        assertEquals(EnumSet.of(MatchEquivalence.QUOTES, MatchEquivalence.INVISIBLES),
+                props.getDisabledMatchEquivalences());
+        assertEquals("invisibles,quotes", setting.read(props));
+        // The applier is an idempotent setter: a repeated value is a no-op.
+        setting.apply(props, "invisibles,quotes");
+        assertEquals("invisibles,quotes", setting.read(props));
+        // A value of only unknown ids applies as the default.
+        setting.apply(props, "ligatures");
+        assertTrue(props.getDisabledMatchEquivalences().isEmpty());
+        setting.apply(props, null);
+        assertTrue(props.getDisabledMatchEquivalences().isEmpty());
+        assertNull(setting.read(props));
+    }
+
+    @Test
+    public void storageRoundTripAndDefaultWritesNoFile() throws Exception {
+        // Mirror of the persist guard in RealProject: save runs only for a
+        // configured value or an already existing file, so default projects
+        // stay sidecar-free.
+        persistLikeRealProject();
+        assertFalse("default project must stay sidecar-free",
+                ProjectSettingsStorage.getFile(props).isFile());
+
+        setting.apply(props, "dashes");
+        persistLikeRealProject();
+        assertEquals("dashes",
+                setting.normalize(ProjectSettingsStorage.load(props, MatchEquivalence.TEAM_SETTING_KEY)));
+    }
+
+    private void persistLikeRealProject() throws Exception {
+        String sessionValue = setting.read(props);
+        if (sessionValue != null || ProjectSettingsStorage.getFile(props).isFile()) {
+            ProjectSettingsStorage.save(props, MatchEquivalence.TEAM_SETTING_KEY, sessionValue);
+        }
+    }
+
+    @Test
+    public void registrationIsIdempotent() {
+        MatchEquivalence.registerTeamSetting();
+        MatchEquivalence.registerTeamSetting();
+        assertEquals(1, TeamSettingsRegistry.all().stream()
+                .filter(s -> MatchEquivalence.TEAM_SETTING_KEY.equals(s.getKey())).count());
+    }
+}

--- a/src/test/java/org/omegat/core/matching/MatchEquivalenceTest.java
+++ b/src/test/java/org/omegat/core/matching/MatchEquivalenceTest.java
@@ -1,0 +1,217 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.matching;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+/**
+ * Folding behavior of the character equivalence classes (feature request
+ * #1681).
+ *
+ * @author Stephan Pakebusch
+ */
+public class MatchEquivalenceTest {
+
+    private static String foldAll(String text) {
+        return MatchEquivalence.fold(text, MatchEquivalence.buildFoldMap(MatchEquivalence.all()));
+    }
+
+    private static String fold(String text, Set<MatchEquivalence> active) {
+        return MatchEquivalence.fold(text, MatchEquivalence.buildFoldMap(active));
+    }
+
+    @Test
+    public void doubleQuoteVariantsFoldTogether() {
+        String expected = foldAll("Select \"Save\" from the menu.");
+        assertEquals(expected, foldAll("Select “Save” from the menu."));
+        assertEquals(expected, foldAll("Select „Save“ from the menu."));
+        assertEquals(expected, foldAll("Select «Save» from the menu."));
+        assertEquals(expected, foldAll("Select 「Save」 from the menu."));
+    }
+
+    @Test
+    public void singleQuoteVariantsFoldTogether() {
+        String expected = foldAll("a 'word' here");
+        assertEquals(expected, foldAll("a ‘word’ here"));
+        assertEquals(expected, foldAll("a ‹word› here"));
+    }
+
+    /** #1681 asks for two groups: single quotes never match double quotes. */
+    @Test
+    public void singleAndDoubleQuotesStaySeparate() {
+        assertNotEquals(foldAll("a \"word\" here"), foldAll("a 'word' here"));
+    }
+
+    /** Primes are measurement marks, not quotation marks; they stay as is. */
+    @Test
+    public void primesAreNotQuotes() {
+        assertNotEquals(foldAll("5′10″"), foldAll("5'10\""));
+    }
+
+    @Test
+    public void apostropheVariantsFoldInsideWords() {
+        Set<MatchEquivalence> only = EnumSet.of(MatchEquivalence.QUOTES);
+        assertEquals(fold("l'ananas", only), fold("l’ananas", only));
+        assertEquals(fold("l'ananas", only), fold("lʼananas", only));
+    }
+
+    @Test
+    public void dashVariantsFoldTogether() {
+        String expected = foldAll("pages 3-4");
+        assertEquals(expected, foldAll("pages 3–4"));
+        assertEquals(expected, foldAll("pages 3—4"));
+        assertEquals(expected, foldAll("pages 3−4"));
+    }
+
+    @Test
+    public void spaceVariantsFoldTogether() {
+        String expected = foldAll("10 %");
+        assertEquals(expected, foldAll("10\u00A0%"));
+        assertEquals(expected, foldAll("10\u202F%"));
+        assertEquals(expected, foldAll("10\u3000%"));
+    }
+
+    @Test
+    public void invisibleFormattingCharactersAreRemoved() {
+        assertEquals(foldAll("information"), foldAll("infor\u00ADmation"));
+        assertEquals(foldAll("ab"), foldAll("a\u200Eb"));
+        assertEquals(foldAll("ab"), foldAll("a\u200Bb"));
+        // ZWNJ and ZWJ are meaning-bearing in Persian and Indic scripts and
+        // are not folded away.
+        assertNotEquals(foldAll("ab"), foldAll("a\u200Cb"));
+        assertNotEquals(foldAll("ab"), foldAll("a\u200Db"));
+    }
+
+    /** Canonical normalization applies even with every class disabled. */
+    @Test
+    public void canonicalNormalizationIsUnconditional() {
+        Set<MatchEquivalence> none = EnumSet.noneOf(MatchEquivalence.class);
+        assertEquals(fold("caf\u00E9", none), fold("cafe\u0301", none));
+    }
+
+    @Test
+    public void disabledClassKeepsVariantsApart() {
+        Set<MatchEquivalence> withoutQuotes = EnumSet.complementOf(EnumSet.of(MatchEquivalence.QUOTES));
+        assertNotEquals(fold("a \"word\"", withoutQuotes), fold("a “word”", withoutQuotes));
+    }
+
+    @Test
+    public void idListRoundTrip() {
+        Set<MatchEquivalence> classes = EnumSet.of(MatchEquivalence.QUOTES, MatchEquivalence.SPACES);
+        assertEquals(classes, MatchEquivalence.fromIdList(MatchEquivalence.toIdList(classes)));
+        // Unknown ids from newer versions are ignored instead of failing.
+        assertEquals(EnumSet.of(MatchEquivalence.DASHES),
+                MatchEquivalence.fromIdList("dashes,ligatures"));
+    }
+
+    /** Apostrophe variants belong to the quotes class (shared code points). */
+    @Test
+    public void apostrophesBelongToQuotes() {
+        Map<Integer, String> map = MatchEquivalence.buildFoldMap(EnumSet.of(MatchEquivalence.QUOTES));
+        assertEquals("’", map.get((int) '\''));
+        assertEquals("’", map.get((int) 'ʼ'));
+    }
+
+    private static boolean regexFinds(String needle, String haystack, Set<MatchEquivalence> active) {
+        return java.util.regex.Pattern.compile(MatchEquivalence.globToRegex(needle, active))
+                .matcher(haystack).find();
+    }
+
+    /** Search patterns match every variant of the active classes (#1681). */
+    @Test
+    public void searchRegexMatchesVariants() {
+        Set<MatchEquivalence> all = MatchEquivalence.all();
+        assertTrue(regexFinds("\"Save\"", "W\u00e4hlen Sie \u201eSave\u201c im Men\u00fc.", all));
+        assertTrue(regexFinds("3-4", "pages 3\u20134", all));
+        assertTrue(regexFinds("10 %", "Rabatt 10\u00a0%", all));
+        // invisible formatting characters tolerated in the searched text
+        assertTrue(regexFinds("information", "infor\u00admation", all));
+        // and dropped from the needle
+        assertTrue(regexFinds("infor\u00admation", "information", all));
+        assertFalse(regexFinds("'Save'", "\u201eSave\u201c", all));
+    }
+
+    @Test
+    public void searchRegexEscapesMetacharacters() {
+        Set<MatchEquivalence> all = MatchEquivalence.all();
+        assertFalse(regexFinds("a.b", "axb", all));
+        assertTrue(regexFinds("a.b", "a.b", all));
+        assertTrue(regexFinds("f*o", "fooo", all));
+        assertFalse(regexFinds("f*o", "f o", all));
+        assertTrue(regexFinds("t?p", "tip", all));
+    }
+
+    /**
+     * The needle is NFC-normalized, so literals with a differing canonical
+     * decomposition alternate both forms: composed and decomposed text is
+     * found either way, with any class configuration.
+     */
+    @Test
+    public void searchRegexMatchesBothNormalizationForms() {
+        Set<MatchEquivalence> none = EnumSet.noneOf(MatchEquivalence.class);
+        assertTrue(regexFinds("caf\u00E9", "caf\u00E9", none));
+        assertTrue(regexFinds("caf\u00E9", "cafe\u0301", none));
+        assertTrue(regexFinds("cafe\u0301", "caf\u00E9", none));
+        assertTrue(regexFinds("cafe\u0301", "cafe\u0301", none));
+    }
+
+    /**
+     * A needle of nothing but invisible formatting characters must not
+     * collapse to an empty pattern that finds (and in replace mode rewrites)
+     * everything; it is searched literally instead.
+     */
+    @Test
+    public void invisibleOnlyNeedleStaysLiteral() {
+        Set<MatchEquivalence> all = MatchEquivalence.all();
+        assertFalse(MatchEquivalence.globToRegex("\u00AD", all).isEmpty());
+        assertFalse(regexFinds("\u00AD", "plain text", all));
+        assertTrue(regexFinds("\u00AD", "soft\u00ADhyphen", all));
+    }
+
+    @Test
+    public void searchRegexWithoutClassesIsPlain() {
+        Set<MatchEquivalence> none = EnumSet.noneOf(MatchEquivalence.class);
+        assertFalse(regexFinds("\"Save\"", "\u201eSave\u201c", none));
+        assertTrue(regexFinds("\"Save\"", "\"Save\"", none));
+    }
+
+    @Test
+    public void membersListedForGui() {
+        for (MatchEquivalence eq : MatchEquivalence.values()) {
+            assertTrue(eq.getId(), eq.getMembers().size() >= 3);
+        }
+        assertTrue(MatchEquivalence.QUOTES.getMembers().containsKey(0x1F676));
+    }
+}

--- a/src/test/java/org/omegat/core/search/SearcherTest.java
+++ b/src/test/java/org/omegat/core/search/SearcherTest.java
@@ -483,6 +483,52 @@ public class SearcherTest {
         assertEquals("Duplicate entry", results.get(1).getSrcText());
     }
 
+    /**
+     * A number-only search term with the numbers option finds every writing
+     * of the same value; a differing value stays out.
+     */
+    @Test
+    public void numberValueSearchFindsOtherNumeralSystems() throws Exception {
+        addSTE(fi, "id1", "chapter \u5341\u4e8c of the book", null);
+        addSTE(fi, "id2", "chapter \u0661\u0662 again", null);
+        addSTE(fi, "id3", "chapter 13 differs", null);
+        SearchExpression s = createSearchExpression("12", SearchExpressionType.EXACT, false, false);
+        s.matchNumbers = true;
+        Searcher searcher = startSearcher(s);
+        assertEquals(2, searcher.getSearchResults().size());
+    }
+
+    /**
+     * A term that reads as a number only through the source locale's
+     * separators still finds its own literal writing (first) and the
+     * value-equivalent plain writing (after it).
+     */
+    @Test
+    public void numberValueSearchKeepsLiteralWritingAndRanksItFirst() throws Exception {
+        proj.getProjectProperties().setSourceLanguage("de");
+        proj.getProjectProperties().setTargetLanguage("en-US");
+        addSTE(fi, "id1", "counted 1234 pieces", null);
+        addSTE(fi, "id2", "literal 1.234 here", null);
+        SearchExpression s = createSearchExpression("1.234", SearchExpressionType.EXACT, false, false);
+        s.matchNumbers = true;
+        Searcher searcher = startSearcher(s);
+        List<SearchResultEntry> results = searcher.getSearchResults();
+        assertEquals(2, results.size());
+        assertTrue(results.get(0).getSrcText(), results.get(0).getSrcText().contains("1.234"));
+        assertTrue(results.get(1).getSrcText(), results.get(1).getSrcText().contains("1234"));
+    }
+
+    /** Without the numbers option the term stays a literal search string. */
+    @Test
+    public void numberValueSearchOffKeepsLiteralSemantics() throws Exception {
+        addSTE(fi, "id1", "counted 1234 pieces", null);
+        addSTE(fi, "id2", "literal 1.234 here", null);
+        SearchExpression s = createSearchExpression("1.234", SearchExpressionType.EXACT, false, false);
+        s.matchNumbers = false;
+        Searcher searcher = startSearcher(s);
+        assertEquals(1, searcher.getSearchResults().size());
+    }
+
     private static @NotNull SearchExpression createSearchExpression(String text, SearchExpressionType type,
                                                                     boolean caseSensitive, boolean widthInsensitive) {
         return createSearchExpression(text, type, caseSensitive, widthInsensitive, true);
@@ -501,7 +547,6 @@ public class SearcherTest {
         s.allResults = allResults;
         s.fileNames = true;
         s.caseSensitive = caseSensitive;
-        s.spaceMatchNbsp = false;
         s.searchSource = true;
         s.searchTarget = true;
         s.searchTranslated = true;

--- a/src/test/java/org/omegat/core/statistics/FindMatchesEquivalenceTest.java
+++ b/src/test/java/org/omegat/core/statistics/FindMatchesEquivalenceTest.java
@@ -1,0 +1,189 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.statistics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.IProject;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.events.IStopped;
+import org.omegat.core.matching.MatchEquivalence;
+import org.omegat.core.matching.NearString;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.tokenizer.DefaultTokenizer;
+import org.omegat.tokenizer.LuceneEnglishTokenizer;
+import org.omegat.util.OConsts;
+import org.omegat.util.Preferences;
+import org.omegat.util.TestPreferencesInitializer;
+
+/**
+ * Character equivalence classes in fuzzy matching (feature request #1681):
+ * segments differing only in quote, apostrophe, dash, space or invisible
+ * format variants match at 100% with the default class set, and keep their
+ * distance when the class is disabled.
+ *
+ * @author Stephan Pakebusch
+ */
+public class FindMatchesEquivalenceTest {
+
+    /** Resolved from the test classpath so tree reorganizations cannot break it. */
+    private static final File TMX_EQUIVALENCE = fixture("/data/tmx/test-equivalence-en-de.tmx");
+
+    private static File fixture(String resource) {
+        java.net.URL url = FindMatchesEquivalenceTest.class.getResource(resource);
+        if (url == null) {
+            throw new IllegalStateException("fixture missing on test classpath: " + resource);
+        }
+        try {
+            return new File(url.toURI());
+        } catch (java.net.URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Path tmpDir;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        tmpDir = Files.createTempDirectory("omegat");
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        Core.initializeConsole();
+        Core.registerTokenizerClass(DefaultTokenizer.class);
+        Core.registerTokenizerClass(LuceneEnglishTokenizer.class);
+        TestPreferencesInitializer.init();
+    }
+
+    private List<NearString> search(String srcText, Set<MatchEquivalence> disabled) {
+        ProjectProperties prop = new ProjectProperties(tmpDir.toFile());
+        prop.setSourceLanguage("en");
+        prop.setTargetLanguage("de");
+        prop.setSupportDefaultTranslations(true);
+        prop.setSentenceSegmentingEnabled(true);
+        prop.setDisabledMatchEquivalences(disabled);
+        Segmenter segmenter = new Segmenter(Preferences.getSRX());
+        IProject project = new FindMatchesTest.TestProject(prop, TMX_EQUIVALENCE, null,
+                new LuceneEnglishTokenizer(), new DefaultTokenizer(), segmenter);
+        IStopped iStopped = () -> false;
+        FindMatches finder = new FindMatches(project, segmenter, OConsts.MAX_NEAR_STRINGS, false, 30);
+        return finder.search(srcText, false, iStopped, false);
+    }
+
+    private NearString bestMatch(String srcText, Set<MatchEquivalence> disabled) {
+        List<NearString> result = search(srcText, disabled);
+        assertTrue("no match found for: " + srcText, !result.isEmpty());
+        return result.get(0);
+    }
+
+    private static final Set<MatchEquivalence> NONE_DISABLED = EnumSet.noneOf(MatchEquivalence.class);
+
+    private void assertScores(NearString near, int stem, int noStem, int adjusted) {
+        assertEquals(stem, near.scores[0].score);
+        assertEquals(noStem, near.scores[0].scoreNoStem);
+        assertEquals(adjusted, near.scores[0].adjustedScore);
+    }
+
+    /** Straight double quotes match the TM entry with curly quotes (#1681). */
+    @Test
+    public void straightQuotesMatchCurlyQuotes() {
+        NearString near = bestMatch("Select the \"Save\" command from the menu.", NONE_DISABLED);
+        assertEquals("Wählen Sie den Befehl „Speichern“ im Menü.", near.translation);
+        assertScores(near, 100, 100, 100);
+    }
+
+    /** With the quotes class disabled, the verbatim pass sees the difference. */
+    @Test
+    public void disabledQuotesClassKeepsDistance() {
+        NearString near = bestMatch("Select the \"Save\" command from the menu.",
+                EnumSet.of(MatchEquivalence.QUOTES));
+        assertEquals(100, near.scores[0].score);
+        assertTrue("adjusted score must drop below 100 with quotes class disabled",
+                near.scores[0].adjustedScore < 100);
+    }
+
+    /** Single quotes do not match the double-quoted TM entry (#1681). */
+    @Test
+    public void singleQuotesDoNotMatchDoubleQuotes() {
+        NearString near = bestMatch("Select the 'Save' command from the menu.", NONE_DISABLED);
+        assertEquals(100, near.scores[0].score);
+        assertTrue("single quotes must not fold onto double quotes",
+                near.scores[0].adjustedScore < 100);
+    }
+
+    /**
+     * The typewriter apostrophe matches the curly one, also in the word-token
+     * passes where the apostrophe sits inside the token.
+     */
+    @Test
+    public void straightApostropheMatchesCurlyApostrophe() {
+        NearString near = bestMatch("It's John's house near the river.", NONE_DISABLED);
+        assertScores(near, 100, 100, 100);
+    }
+
+    @Test
+    public void disabledQuotesClassKeepsApostropheDistance() {
+        // Apostrophe folding is part of the quotes class. The word-token
+        // passes still match: the Lucene analyzer normalizes possessives
+        // itself, so the distance shows in the verbatim pass.
+        NearString near = bestMatch("It's John's house near the river.",
+                EnumSet.of(MatchEquivalence.QUOTES));
+        assertTrue("adjusted score must drop with apostrophe folding disabled",
+                near.scores[0].adjustedScore < 100);
+    }
+
+    @Test
+    public void hyphenMatchesEnDash() {
+        NearString near = bestMatch("See pages 3-4 for details.", NONE_DISABLED);
+        assertScores(near, 100, 100, 100);
+    }
+
+    @Test
+    public void plainSpaceMatchesNoBreakSpace() {
+        NearString near = bestMatch("The discount is 10 % this week.", NONE_DISABLED);
+        assertScores(near, 100, 100, 100);
+    }
+
+    @Test
+    public void softHyphenIsIgnored() {
+        NearString near = bestMatch("More information is available online.", NONE_DISABLED);
+        assertScores(near, 100, 100, 100);
+    }
+}

--- a/src/test/java/org/omegat/core/statistics/FindMatchesNumbersTest.java
+++ b/src/test/java/org/omegat/core/statistics/FindMatchesNumbersTest.java
@@ -92,12 +92,17 @@ public class FindMatchesNumbersTest {
     }
 
     private List<NearString> search(String srcText, boolean matchNumbers) {
+        return search(srcText, matchNumbers, false);
+    }
+
+    private List<NearString> search(String srcText, boolean matchNumbers, boolean matchNumbersRoman) {
         ProjectProperties prop = new ProjectProperties(tmpDir.toFile());
         prop.setSourceLanguage("en");
         prop.setTargetLanguage("cs");
         prop.setSupportDefaultTranslations(true);
         prop.setSentenceSegmentingEnabled(true);
         prop.setMatchNumbersEnabled(matchNumbers);
+        prop.setMatchNumbersRomanEnabled(matchNumbersRoman);
         Segmenter segmenter = new Segmenter(Preferences.getSRX());
         IProject project = new FindMatchesTest.TestProject(prop, TMX_NUMBERS, null,
                 new LuceneEnglishTokenizer(), new DefaultTokenizer(), segmenter);
@@ -185,13 +190,18 @@ public class FindMatchesNumbersTest {
     }
 
     /**
-     * With the option on, the word passes still ignore numbers, but the
-     * verbatim pass now equates the value-identical Roman and Arabic
-     * renderings.
+     * Latin-letter Roman numerals stay ordinary words unless the Roman
+     * sub-option is also enabled; with both on, the verbatim pass equates the
+     * value-identical Roman and Arabic renderings.
      */
     @Test
     public void romanNumeralAgainstSameChapterWithOption() {
         List<NearString> result = search("Chapter 12", true);
+        assertEquals(1, result.size());
+        assertScores(result.get(0), 50, 50, 66);
+        assertEquals("Kapitola XII", result.get(0).translation);
+
+        result = search("Chapter 12", true, true);
         assertEquals(1, result.size());
         assertScores(result.get(0), 50, 50, 100);
         assertEquals("Kapitola XII", result.get(0).translation);

--- a/src/test/java/org/omegat/core/team2/ProjectSettingsTeamRoundTripTest.java
+++ b/src/test/java/org/omegat/core/team2/ProjectSettingsTeamRoundTripTest.java
@@ -1,0 +1,168 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectSettingsStorage;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that a per-project team setting survives the team project round
+ * trip in its sidecar file omegat/project_settings.properties: the routine
+ * full sync distributes and supersedes it like any other configuration file,
+ * a purely local file survives the sync and is recognisable as local-only
+ * divergence through the repository comparison.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectSettingsTeamRoundTripTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "readme.txt").toPath(), "team project",
+                StandardCharsets.UTF_8);
+        // the provider detects the repository type at construction time, so
+        // the remote must be a git repository before newProvider runs
+        commitRemote("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    @Test
+    public void testTeamOpenDeliversTheRemoteSettingsFile() throws Exception {
+        writeRemoteSettings(KEY + "=true\n");
+        commitRemote("team with the option");
+
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("the full sync must deliver the settings file", "true",
+                ProjectSettingsStorage.load(config, KEY));
+        assertTrue("a delivered file is identical to the repository copy",
+                provider.isIdenticalInRepositories(settingsPathUnderRoot()));
+    }
+
+    @Test
+    public void testRemoteFileSupersedesADivergingLocalFile() throws Exception {
+        writeRemoteSettings(KEY + "=false\n");
+        commitRemote("team without the option");
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        // the pre-sync snapshot is what the open uses to notice and report
+        // the superseded local value
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("on open, the team's file wins", "false", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    @Test
+    public void testLocalOnlyFileSurvivesTheSyncAndReadsAsDivergence() throws Exception {
+        commitRemote("team without a settings file");
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("a file the team never had survives the full sync", "true",
+                ProjectSettingsStorage.load(config, KEY));
+        assertFalse("the survivor is recognisable as local-only, so the open "
+                + "keeps the team default active and asks",
+                provider.isIdenticalInRepositories(settingsPathUnderRoot()));
+    }
+
+    private String settingsPathUnderRoot() {
+        return OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
+    }
+
+    private void writeRemoteSettings(String content) throws Exception {
+        File f = new File(remoteDir,
+                OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+        Files.createDirectories(f.getParentFile().toPath());
+        Files.writeString(f.toPath(), content, StandardCharsets.UTF_8);
+    }
+
+    private void commitRemote(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}

--- a/src/test/java/org/omegat/gui/dialogs/MatchEquivalenceDialogTest.java
+++ b/src/test/java/org/omegat/gui/dialogs/MatchEquivalenceDialogTest.java
@@ -1,0 +1,180 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.dialogs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.EnumSet;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.omegat.core.matching.MatchEquivalence;
+
+/**
+ * The shipped test-area prefill of the equivalence dialog: both sample
+ * variants fold onto each other with the default class set and stay apart
+ * without folding.
+ *
+ * @author Stephan Pakebusch
+ */
+public class MatchEquivalenceDialogTest {
+
+    @Test
+    public void sampleVariantsFoldEqualByDefault() {
+        Map<Integer, String> foldMap = MatchEquivalence.buildFoldMap(MatchEquivalence.all());
+        assertEquals(MatchEquivalence.fold(MatchEquivalenceDialog.TEST_SAMPLE_TYPOGRAPHIC, foldMap),
+                MatchEquivalence.fold(MatchEquivalenceDialog.TEST_SAMPLE_PLAIN, foldMap));
+    }
+
+    @Test
+    public void sampleVariantsDifferWithoutFolding() {
+        Map<Integer, String> empty = MatchEquivalence
+                .buildFoldMap(EnumSet.noneOf(MatchEquivalence.class));
+        assertNotEquals(MatchEquivalence.fold(MatchEquivalenceDialog.TEST_SAMPLE_TYPOGRAPHIC, empty),
+                MatchEquivalence.fold(MatchEquivalenceDialog.TEST_SAMPLE_PLAIN, empty));
+    }
+
+    /**
+     * Every member line names its own code point and shows the replacement
+     * target with the target's code points, so the direction of the folding
+     * is visible; removals name themselves without a target code point.
+     */
+    @Test
+    public void memberLinesShowSourceAndTargetCodePoints() {
+        for (MatchEquivalence eq : MatchEquivalence.values()) {
+            String[] lines = MatchEquivalenceDialog.describeMembers(eq);
+            assertEquals(eq.getMembers().size(), lines.length);
+            int i = 0;
+            for (Map.Entry<Integer, String> member : eq.getMembers().entrySet()) {
+                String line = lines[i++];
+                assertTrue(line, line.contains(String.format("U+%04X", member.getKey())));
+                assertTrue(line, line.contains("→"));
+                if (!member.getValue().isEmpty()) {
+                    int targetCp = member.getValue().codePointAt(0);
+                    assertTrue(line, line.contains(String.format("U+%04X", targetCp)));
+                }
+            }
+        }
+    }
+
+    /**
+     * One summary line per group of inter-compatible members above each
+     * inventory; the quotes class splits into its double-quote and apostrophe
+     * groups. Visible members appear as glyph, invisible ones as code point.
+     */
+    @Test
+    public void groupLinesJoinInterCompatibleMembers() {
+        for (MatchEquivalence eq : MatchEquivalence.values()) {
+            java.util.List<String> lines = MatchEquivalenceDialog.describeGroups(eq);
+            long targets = eq.getMembers().values().stream().distinct().count();
+            assertEquals(lines.toString(), targets, lines.size());
+            String joined = String.join(" ", lines);
+            eq.getMembers().keySet().forEach(cp -> assertTrue(joined,
+                    joined.contains(new String(Character.toChars(cp)))
+                            || joined.contains(String.format("U+%04X", cp))));
+        }
+    }
+
+    /**
+     * The pure character pairs (the first three) fold equal with the full
+     * class set and stay apart without folding.
+     */
+    @Test
+    public void shippedCharExamplesFoldEqual() {
+        Map<Integer, String> full = MatchEquivalence.buildFoldMap(MatchEquivalence.all());
+        Map<Integer, String> empty = MatchEquivalence
+                .buildFoldMap(EnumSet.noneOf(MatchEquivalence.class));
+        for (int i = 0; i < 3; i++) {
+            String[] pair = MatchEquivalenceDialog.EXAMPLES[i];
+            assertEquals(pair[0] + " | " + pair[1], MatchEquivalence.fold(pair[0], full),
+                    MatchEquivalence.fold(pair[1], full));
+            assertNotEquals(pair[0], MatchEquivalence.fold(pair[0], empty),
+                    MatchEquivalence.fold(pair[1], empty));
+        }
+    }
+
+    /**
+     * Group lines answer hover positions with the member behind the token, so
+     * the tooltip can show the character's own replacement line.
+     */
+    @Test
+    public void groupLineMapsOffsetsToMembers() {
+        for (MatchEquivalence eq : MatchEquivalence.values()) {
+            for (MatchEquivalenceDialog.GroupLine line : MatchEquivalenceDialog.describeGroupLines(eq)) {
+                String text = line.getText();
+                java.util.List<Integer> cps = line.getMemberCps();
+                int token = 0;
+                for (int i = 0; i < text.length(); i++) {
+                    if (text.charAt(i) == ' ') {
+                        token++;
+                        assertEquals(-1, line.memberAt(i));
+                    } else {
+                        // Every character of a token (both halves of an astral
+                        // surrogate pair included) maps to the token's member.
+                        assertEquals(text + "@" + i, (int) cps.get(token), line.memberAt(i));
+                    }
+                }
+                assertEquals(cps.size() - 1, token);
+                assertEquals(-1, line.memberAt(-1));
+                assertEquals(-1, line.memberAt(text.length()));
+            }
+        }
+    }
+
+    /**
+     * Every shipped example pair of the number test compares equal with the
+     * numbers option and the Roman sub-option on; the Latin-letter Roman pair
+     * is the only one that needs the sub-option.
+     */
+    @Test
+    public void shippedNumberExamplesCompareEqual() {
+        for (String[] pair : MatchEquivalenceDialog.EXAMPLES) {
+            assertTrue(pair[0] + " | " + pair[1], MatchEquivalenceDialog.numbersCompareEqual(
+                    pair[0], pair[1], MatchEquivalence.all(), true, true, null, null));
+        }
+        String[] roman = MatchEquivalenceDialog.EXAMPLES[MatchEquivalenceDialog.EXAMPLES.length - 1];
+        assertFalse(MatchEquivalenceDialog.numbersCompareEqual(roman[0], roman[1],
+                MatchEquivalence.all(), true, false, null, null));
+    }
+
+    /**
+     * The locale examples pair the same value in source- and target-locale
+     * formatting; the comparator resolves each side with its own locale.
+     */
+    @Test
+    public void localeNumberExamplesCompareEqual() {
+        java.util.Locale de = java.util.Locale.GERMANY;
+        java.util.Locale en = java.util.Locale.US;
+        for (String[] pair : MatchEquivalenceDialog.localeExamples(de, en)) {
+            assertTrue(pair[0] + " | " + pair[1], MatchEquivalenceDialog.numbersCompareEqual(
+                    pair[0], pair[1], MatchEquivalence.all(), true, true, de, en));
+        }
+    }
+}

--- a/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -173,24 +173,348 @@ public class MatchesTextAreaTest {
         assertEquals("p 9 q ８",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
 
-        // Documented limit: full-width DECIMALS are not recognized as numbers
-        // (Double.parseDouble is ASCII-only), so no substitution happens. This
-        // pins the current scope; extending to full-width decimals is a
-        // possible follow-up.
+        // Documented limit: a full-width DECIMAL is not a single number, because
+        // the full-width full stop is not read as a decimal separator, so no
+        // substitution happens. This pins the current scope; extending to
+        // full-width decimals is a possible follow-up.
         source = "x ５．５";
         srcMatch = "x １．１";
         trgMatch = "foo 1.1";
         assertEquals("foo 1.1", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
 
-        // Documented scope boundary: Arabic-Indic digits (U+0660-U+0669) and
-        // Extended Arabic-Indic digits (U+06F0-U+06F9) are recognized as
-        // numbers but are NOT width-normalized by #1193, so such a source
-        // number is inserted verbatim rather than converted. Cross
-        // numeral-system handling is intentionally out of scope here.
+        // Arabic-Indic digits (U+0660-U+0669) carry the same values as their
+        // ASCII counterparts, and the inserted number follows the digit script
+        // of the target token it replaces, so a Latin target receives ASCII
+        // digits.
         source = "x ٩";
         srcMatch = "x 8";
         trgMatch = "foo 8";
+        assertEquals("foo 9",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // ... and the other way round: an Arabic-Indic target keeps its script.
+        source = "x 9";
+        srcMatch = "x 8";
+        trgMatch = "foo ٨";
         assertEquals("foo ٩",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Numbers are compared and paired by value, so the same number written in a
+     * different numeral system counts as the same number. Roman numerals are the
+     * exception, and only where they are written with Latin letters: see
+     * {@link #testUppercaseRomanWordsAreNotNumbers()}.
+     */
+    @Test
+    public void testReplaceNumbersAcrossNumeralSystems() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // A Roman numeral written with the dedicated code points is unambiguous
+        // and counts, so the numbers pair up and the source number is inserted.
+        String source = "Kapitel 7";
+        String srcMatch = "Kapitel 4";
+        String trgMatch = "Chapter Ⅳ";
+        assertEquals("Chapter 7",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Written with Latin letters the same numeral is not a number here, so
+        // the counts disagree and the match is left alone.
+        trgMatch = "Chapter IV";
+        assertEquals("Chapter IV",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Han numerals are numbers as well, including multi-character ones.
+        source = "chapter 五";
+        srcMatch = "chapter 十二";
+        trgMatch = "Kapitel 12";
+        assertEquals("Kapitel 5",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Where a number begins and ends is the tokenizer's decision, not ours:
+        // the default tokenizer keeps a run of ideographs together, so the
+        // numeral inside the Han word below never becomes a token of its own and
+        // the segment holds no number at all.
+        source = "第五章";
+        srcMatch = "第八章";
+        trgMatch = "Chapter 8";
+        assertEquals("Chapter 8",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Ordinary words that look like numerals must not be touched: "mix" is
+        // not a lowercase Roman 1009, and "civil" is not 106. The segment
+        // carries a real number as well, so the assertion tells the two cases
+        // apart: were "mix" counted, the number counts would disagree and no
+        // substitution would happen at all.
+        source = "the mix of 3 civil laws";
+        srcMatch = "the mix of 5 civil laws";
+        trgMatch = "die Mischung aus 5 Zivilgesetzen";
+        assertEquals("die Mischung aus 3 Zivilgesetzen",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Values are exact and unbounded: numbers far beyond the range and the
+     * precision of a double are substituted digit for digit, and two numbers
+     * that differ only beyond that precision are recognized as different.
+     */
+    @Test
+    public void testReplaceNumbersArbitraryPrecision() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // A 40-digit integer is inserted verbatim, with no rounding and no
+        // exponent notation.
+        String big = "1234567890123456789012345678901234567890";
+        String source = "id " + big;
+        String srcMatch = "id 7";
+        String trgMatch = "Kennung 7";
+        assertEquals("Kennung " + big,
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Two 20-digit numbers that a double would round to the same value are
+        // different numbers, so the guard refuses the substitution.
+        source = "id 99999999999999999999";
+        srcMatch = "id 99999999999999999998";
+        trgMatch = "Kennung 99999999999999999997";
+        assertEquals("Kennung 99999999999999999997",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // The same for decimals: a difference in the twentieth decimal place is
+        // a real difference, and it is not lost.
+        source = "value 1.00000000000000000001";
+        srcMatch = "value 1.00000000000000000002";
+        trgMatch = "Wert 1.00000000000000000003";
+        assertEquals("Wert 1.00000000000000000003",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A long decimal that does match is carried over exactly.
+        source = "value 2.71828182845904523536028747135266249776";
+        srcMatch = "value 3.14159265358979323846264338327950288420";
+        trgMatch = "Wert 3.14159265358979323846264338327950288420";
+        assertEquals("Wert 2.71828182845904523536028747135266249776",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * The numbers of a match may appear in any order in its target, and they may
+     * repeat. Every target number must receive the source number that belongs to
+     * it, whatever the permutation.
+     */
+    @Test
+    public void testReplaceNumbersPermutations() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // A cyclic permutation: the target order 2, 3, 1 must pick up the source
+        // numbers that stand where those numbers stand in the match's source.
+        String source = "a 7 b 8 c 9";
+        String srcMatch = "a 1 b 2 c 3";
+        String trgMatch = "x 2 y 3 z 1";
+        assertEquals("x 8 y 9 z 7",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // The same numbers in different multiplicities are not the same set of
+        // numbers; refusing here also keeps every target number mapped.
+        source = "a 7 b 8 c 9";
+        srcMatch = "a 1 b 1 c 2";
+        trgMatch = "x 1 y 2 z 2";
+        assertEquals("x 1 y 2 z 2",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A repeated number is substituted in every place it occurs.
+        source = "a 7 b 7 c 9";
+        srcMatch = "a 1 b 1 c 2";
+        trgMatch = "x 2 y 1 z 1";
+        assertEquals("x 9 y 7 z 7",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A permutation that is not its own inverse. Reversing a pair or a
+        // triple hides a mapping that runs in the wrong direction, because
+        // those permutations equal their inverse; a four-element cycle does
+        // not, so this is the case that pins the direction of the mapping.
+        source = "a 10 b 20 c 30 d 40";
+        srcMatch = "a 1 b 2 c 3 d 4";
+        trgMatch = "w 2 x 3 y 4 z 1";
+        assertEquals("w 20 x 30 y 40 z 10",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * What counts as a number here is decided token by token, so a number glued
+     * to a symbol is only reached when the tokenizer happens to separate the
+     * two. The cases below pin today's reach. The ones marked as gaps are not
+     * intended behaviour: a percentage, a currency amount, a dotted date and an
+     * ordinal are all values the number conversion window already reads and
+     * writes locale by locale, and match insertion should end up using the same
+     * notion of a number rather than the bare token parser.
+     */
+    @Test
+    public void testReplaceNumbersReachOfTheTokenNotion() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Separated by a space, the amount is an ordinary number token and is
+        // substituted; the unit travels along untouched.
+        String source = "Preis 30 EUR für 4 Stück";
+        String srcMatch = "Preis 50 EUR für 6 Stück";
+        String trgMatch = "Price 50 EUR for 6 items";
+        assertEquals("Price 30 EUR for 4 items",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // GAP: glued to a percent or a currency sign it is one token with no
+        // value, so the match's own figure survives although the source
+        // disagrees - the translator is handed 50% where the segment says 30%.
+        source = "Rabatt 30% auf 4 Artikel";
+        srcMatch = "Rabatt 50% auf 6 Artikel";
+        trgMatch = "50% discount on 6 items";
+        assertEquals("50% discount on 4 items",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        source = "Preis $30 für 4";
+        srcMatch = "Preis $50 für 6";
+        trgMatch = "Price $50 for 4";
+        assertEquals("Price $50 for 4",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A date whose parts are separated becomes three numbers and is carried
+        // over part by part - including across a different date order in the
+        // target, which is exactly the case a mapping in the wrong direction
+        // would scramble.
+        source = "am 2024-03-07";
+        srcMatch = "am 2024-01-06";
+        trgMatch = "on 01/06/2024";
+        assertEquals("on 03/07/2024",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // GAP: a dotted date is a single token with no value, so the stale date
+        // of the match is left standing.
+        source = "am 07.03.2024";
+        srcMatch = "am 06.01.2024";
+        trgMatch = "on 06.01.2024";
+        assertEquals("on 06.01.2024",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A time separated by a colon is two numbers and is carried over.
+        source = "um 12:30 kamen 4";
+        srcMatch = "um 14:45 kamen 6";
+        trgMatch = "at 14:45 there were 6";
+        assertEquals("at 12:30 there were 4",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // GAP: an ordinal indicator makes the token unreadable as a number on
+        // the English side, so the counts disagree and nothing is substituted -
+        // although "3." and "3rd" are the same ordinal, and the conversion
+        // window already knows how to read and write both.
+        source = "der 4. Absatz";
+        srcMatch = "der 3. Absatz";
+        trgMatch = "the 3rd paragraph";
+        assertEquals("the 3rd paragraph",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Numbers keep their surroundings intact: inline tags, punctuation directly
+     * against a number, and a target that holds no number at all.
+     */
+    @Test
+    public void testReplaceNumbersLeavesSurroundingsAlone() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // OmegaT inline tags are ordinary text here and must come through byte
+        // for byte, including the digits inside the tag names.
+        String source = "<f1>Chapter 3</f1>";
+        String srcMatch = "<f1>Chapter 5</f1>";
+        String trgMatch = "<f1>Kapitel 5</f1>";
+        assertEquals("<f1>Kapitel 3</f1>",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        source = "Text <x0/> 3 items";
+        srcMatch = "Text <x0/> 5 items";
+        trgMatch = "Text <x0/> 5 Stück";
+        assertEquals("Text <x0/> 3 Stück",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // A number pressed against punctuation and a percent sign.
+        source = "50% of 3, no more.";
+        srcMatch = "50% of 5, no more.";
+        trgMatch = "50% von 5, nicht mehr.";
+        assertEquals("50% von 3, nicht mehr.",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Empty input is not a special case, it simply holds no number.
+        assertEquals("", MatchesTextArea.substituteNumbers("", "", "", tok, tok));
+    }
+
+    /**
+     * The digit script of the target token is followed for every decimal script,
+     * including one outside the basic multilingual plane. A target token written
+     * in an algorithmic system that this code cannot write back (Han) falls back
+     * to plain digits rather than to the wrong number.
+     */
+    @Test
+    public void testReplaceNumbersDigitScripts() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Osmanya digits (U+104A0..) are surrogate pairs; the substituted number
+        // is written in that script, not in ASCII.
+        String source = "n 7";
+        String srcMatch = "n 5";
+        String trgMatch = "n 𐒥";
+        assertEquals("n 𐒧",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // Documented limit: there is no writer for the Han system here, so a Han
+        // target receives the value spelled out in digits. The number is right,
+        // the notation is not preserved.
+        source = "chapter 7";
+        srcMatch = "chapter 12";
+        trgMatch = "第 十二 章";
+        assertEquals("第 7 章",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * Regression guard for the substitution side: a token made only of Roman
+     * letters is a numeral only in the fuzzy-matching score, where a false
+     * positive costs a little similarity. Here it rewrites text the translator
+     * gets handed, so an ordinary uppercase word must never be read as a number.
+     *
+     * These cases fail as long as the substitution side uses the same
+     * unrestricted Roman gate as the match scorer. Fix the production code, not
+     * the expectations.
+     */
+    @Test
+    public void testUppercaseRomanWordsAreNotNumbers() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // The English pronoun "I" is a canonical Roman 1. Were it counted, it
+        // would take part in the pairing and be rewritten as a numeral: the
+        // target would read "II saw 8 birds 2 hours later."
+        String source = "2 Stunden später sah ich 8 Vögel.";
+        String srcMatch = "1 Stunde später sah ich 3 Vögel.";
+        String trgMatch = "I saw 3 birds 1 hour later.";
+        assertEquals("I saw 8 birds 2 hour later.",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // "X" as a size or a multiplier, and "MIX" as a word, are not 10 and 1009.
+        source = "Größe 3";
+        srcMatch = "Größe 10";
+        trgMatch = "Size X";
+        assertEquals("Size X", MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // The same rule the other way round: a Roman-looking word in the source
+        // or in the match must not silently switch the whole feature off by
+        // making the number counts disagree.
+        source = "I have 3 apples";
+        srcMatch = "I have 5 apples";
+        trgMatch = "Ich habe 5 Äpfel";
+        assertEquals("Ich habe 3 Äpfel",
+                MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+        // "IV" reads as intravenous far more often than as 4, and "V" prefixes a
+        // version far more often than it counts five.
+        source = "Gabe von 3 ml";
+        srcMatch = "Gabe von 4 ml";
+        trgMatch = "IV administration of 4 ml";
+        assertEquals("IV administration of 3 ml",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
     }
 

--- a/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -211,11 +211,12 @@ public class MatchesTextAreaTest {
         ITokenizer tok = new DefaultTokenizer();
 
         // A Roman numeral written with the dedicated code points is unambiguous
-        // and counts, so the numbers pair up and the source number is inserted.
+        // and counts, so the numbers pair up and the source value is written
+        // back in the target's own notation.
         String source = "Kapitel 7";
         String srcMatch = "Kapitel 4";
         String trgMatch = "Chapter Ⅳ";
-        assertEquals("Chapter 7",
+        assertEquals("Chapter Ⅶ",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
 
         // Written with Latin letters the same numeral is not a number here, so
@@ -461,13 +462,12 @@ public class MatchesTextAreaTest {
         assertEquals("n 𐒧",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
 
-        // Documented limit: there is no writer for the Han system here, so a Han
-        // target receives the value spelled out in digits. The number is right,
-        // the notation is not preserved.
+        // A Han target keeps its notation: the source value is written through
+        // the same ICU rule set that read the target number.
         source = "chapter 7";
         srcMatch = "chapter 12";
         trgMatch = "第 十二 章";
-        assertEquals("第 7 章",
+        assertEquals("第 七 章",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
     }
 
@@ -534,5 +534,153 @@ public class MatchesTextAreaTest {
         String trgMatch = "This is a sample sentence 8";
         assertEquals("This is a sample sentence 9",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, jaTok, enTok));
+    }
+
+    /**
+     * Sign numerals of the Number-Other category (Mayan and Kaktovik digits,
+     * Ethiopic composites, cuneiform and others) pair by value and are
+     * spelled out as digits in a digit-writing target.
+     */
+    @Test
+    public void testSubstituteSignNumerals() {
+        ITokenizer tok = new DefaultTokenizer();
+        String mayanNineteen = new String(Character.toChars(0x1D2F3));
+        String mayanEleven = new String(Character.toChars(0x1D2EB));
+        assertEquals("day 19 dawns",
+                MatchesTextArea.substituteNumbers("day " + mayanNineteen + " dawns",
+                        "day " + mayanEleven + " dawns", "day 11 dawns", tok, tok));
+
+        String ethiopic1976 = "፲፱፻፸፮";
+        String ethiopic1974 = "፲፱፻፸፬";
+        assertEquals("year 1976 begins",
+                MatchesTextArea.substituteNumbers("year " + ethiopic1976 + " begins",
+                        "year " + ethiopic1974 + " begins", "year 1974 begins", tok, tok));
+
+        String cuneiformLarge = new String(Character.toChars(0x12433));
+        String cuneiformHalf = new String(Character.toChars(0x12432));
+        assertEquals("tally 432000 sila",
+                MatchesTextArea.substituteNumbers("tally " + cuneiformLarge + " sila",
+                        "tally " + cuneiformHalf + " sila", "tally 216000 sila", tok, tok));
+    }
+
+    /**
+     * When the target match writes its number in a numeral system rather than
+     * digits, the source value is written in that same system: composed
+     * additively for sign systems, positionally for the base-twenty digit
+     * blocks, and through the ICU rule sets for the algorithmic systems.
+     */
+    @Test
+    public void testSubstituteAcrossNumeralSystems() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Ethiopic source value 840, Aegean target: composed as 800 plus 40
+        String aegean600 = new String(Character.toChars(0x1011E));
+        String aegean840 = new String(Character.toChars(0x10120)) + new String(Character.toChars(0x10113));
+        assertEquals("toll " + aegean840 + " due",
+                MatchesTextArea.substituteNumbers("toll ፰፻፵ due", "toll ፮፻ due",
+                        "toll " + aegean600 + " due", tok, tok));
+
+        // Ethiopic source value 40, Mayan digit target: positional base twenty
+        String mayanNine = new String(Character.toChars(0x1D2E9));
+        String mayanForty = new String(Character.toChars(0x1D2E2)) + new String(Character.toChars(0x1D2E0));
+        assertEquals("count " + mayanForty + " tuns",
+                MatchesTextArea.substituteNumbers("count ፵ tuns", "count ፱ tuns",
+                        "count " + mayanNine + " tuns", tok, tok));
+
+        // Meroitic source value 900000, Ethiopic target: the rule set that
+        // writes the template back verbatim also writes the value - and no
+        // other, so a Roman or grouped-digit rendition would fail here.
+        String meroiticLarge = new String(Character.toChars(0x109F5));
+        String meroiticThousand = new String(Character.toChars(0x109DB));
+        assertEquals("stock ፺፼ kept",
+                MatchesTextArea.substituteNumbers("stock " + meroiticLarge + " kept",
+                        "stock " + meroiticThousand + " kept", "stock ፲፻ kept", tok, tok));
+    }
+
+    /**
+     * A sequence of numeral signs from one block reads as one number: additive
+     * sums for the historic systems, positional base twenty for the Mayan
+     * digit block - so those numbers pair and substitute like any other.
+     */
+    @Test
+    public void testSignSequencesReadAsOneNumber() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        // Aegean 1984 written additively (1000, 900, 80, 4) in the source
+        String aegean1984 = new String(Character.toChars(0x10122)) + new String(Character.toChars(0x10121))
+                + new String(Character.toChars(0x10117)) + new String(Character.toChars(0x1010A));
+        assertEquals("anno 1984 scripta",
+                MatchesTextArea.substituteNumbers("year " + aegean1984 + " written", "year 1291 written",
+                        "anno 1291 scripta", tok, tok));
+
+        // Mayan two-digit positional source value: 1;0 in base twenty is 20
+        String mayanTwenty = new String(Character.toChars(0x1D2E1)) + new String(Character.toChars(0x1D2E0));
+        assertEquals("cycle 20 closes",
+                MatchesTextArea.substituteNumbers("cycle " + mayanTwenty + " closes", "cycle 13 closes",
+                        "cycle 13 closes", tok, tok));
+    }
+
+    /**
+     * A composition is only inserted when it is valid notation in the target's
+     * system: Roman forty is written subtractively rather than as a pile of
+     * twelves, counting rods are positional and cannot be composed (the value
+     * arrives in plain digits), and a fractional sign value has no digit
+     * spelling at all, so the target keeps its own number.
+     */
+    @Test
+    public void testInvalidCompositionsNeverReachTheTarget() {
+        ITokenizer tok = new DefaultTokenizer();
+
+        assertEquals("Chapter ⅩⅬ", MatchesTextArea.substituteNumbers("Kapitel 40", "Kapitel 4",
+                "Chapter Ⅳ", tok, tok));
+
+        String rods32 = new String(Character.toChars(0x1D36B)) + new String(Character.toChars(0x1D361));
+        assertEquals("silk 432 bolts", MatchesTextArea.substituteNumbers("bolt 432", "bolt 32",
+                "silk " + rods32 + " bolts", tok, tok));
+
+        // A fractional sign value is spelled out as a digit fraction.
+        assertEquals("mische 1/4 Tassen", MatchesTextArea.substituteNumbers("mix ꠰ cup", "mix 2 cup",
+                "mische 2 Tassen", tok, tok));
+    }
+
+    /**
+     * A genuine number in a segment substitutes even when a protected
+     * presentation form sits next to it, and the decoration numbers of the
+     * dingbat blocks are never treated as numbers at all.
+     */
+    @Test
+    public void testProtectedFormsDoNotBlockRealNumbers() {
+        ITokenizer tok = new DefaultTokenizer();
+        assertEquals("room 7 measures 3² units",
+                MatchesTextArea.substituteNumbers("room 7 measures 5² units", "room 4 measures 3² units",
+                        "room 4 measures 3² units", tok, tok));
+        assertEquals("❷ item 9", MatchesTextArea.substituteNumbers("❶ item 9", "❷ item 4",
+                "❷ item 4", tok, tok));
+    }
+
+    /**
+     * Presentation forms with a compatibility decomposition stay out of the
+     * substitution - a superscript exponent and an enclosed number must never
+     * be rewritten, so those target matches stay untouched even though the
+     * values differ. The precomposed vulgar fractions are real numbers and
+     * substitute like any other, glyph for glyph.
+     */
+    @Test
+    public void testPresentationFormsStayUntouched() {
+        ITokenizer tok = new DefaultTokenizer();
+        assertEquals("area 3² units", MatchesTextArea.substituteNumbers("area 5² units",
+                "area 3² units", "area 3² units", tok, tok));
+        assertEquals("floor ⑫ opens", MatchesTextArea.substituteNumbers("floor ⑪ opens",
+                "floor ⑫ opens", "floor ⑫ opens", tok, tok));
+        assertEquals("add ¼ measure", MatchesTextArea.substituteNumbers("add ¼ measure",
+                "add ½ measure", "add ½ measure", tok, tok));
+        assertEquals("knead ¾ portion", MatchesTextArea.substituteNumbers("knead ¾ portion",
+                "knead ⅔ portion", "knead ⅔ portion", tok, tok));
+        // A value no glyph carries (a Meroitic twelfth) is spelled out as a
+        // digit fraction: the right value in a foreign notation beats the
+        // target's own, wrong one.
+        String meroiticTwelfth = new String(Character.toChars(0x109F6));
+        assertEquals("pour 1/12 barrel", MatchesTextArea.substituteNumbers("pour " + meroiticTwelfth + " barrel",
+                "pour ⅚ barrel", "pour ⅚ barrel", tok, tok));
     }
 }

--- a/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -27,8 +27,13 @@ package org.omegat.gui.matches;
 
 import static org.junit.Assert.assertEquals;
 
+import java.nio.file.Files;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.omegat.core.Core;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectProperties;
 import org.omegat.tokenizer.DefaultTokenizer;
 import org.omegat.tokenizer.ITokenizer;
 import org.omegat.tokenizer.LuceneJapaneseTokenizer;
@@ -473,13 +478,10 @@ public class MatchesTextAreaTest {
 
     /**
      * Regression guard for the substitution side: a token made only of Roman
-     * letters is a numeral only in the fuzzy-matching score, where a false
-     * positive costs a little similarity. Here it rewrites text the translator
-     * gets handed, so an ordinary uppercase word must never be read as a number.
-     *
-     * These cases fail as long as the substitution side uses the same
-     * unrestricted Roman gate as the match scorer. Fix the production code, not
-     * the expectations.
+     * letters rewrites text the translator gets handed, so without the
+     * Latin-letter Roman sub-option (the default, and the state of these
+     * tests, which run without a loaded project) an ordinary uppercase word
+     * must never be read as a number.
      */
     @Test
     public void testUppercaseRomanWordsAreNotNumbers() {
@@ -516,6 +518,46 @@ public class MatchesTextAreaTest {
         trgMatch = "IV administration of 4 ml";
         assertEquals("IV administration of 3 ml",
                 MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+    }
+
+    /**
+     * With the project sub-option enabled, Latin-letter Roman numerals take
+     * part in the substitution like any other numeral system; without the
+     * main number option they stay words even when the sub-option flag is
+     * still stored.
+     */
+    @Test
+    public void testRomanSubstitutionWithSubOption() throws Exception {
+        ProjectProperties props = new ProjectProperties(Files.createTempDirectory("omegat").toFile());
+        props.setMatchNumbersEnabled(true);
+        props.setMatchNumbersRomanEnabled(true);
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public boolean isProjectLoaded() {
+                return true;
+            }
+
+            @Override
+            public ProjectProperties getProjectProperties() {
+                return props;
+            }
+        });
+        try {
+            ITokenizer tok = new DefaultTokenizer();
+            String source = "Kapitel 14";
+            String srcMatch = "Kapitel 12";
+            String trgMatch = "Chapter XII";
+            assertEquals("Chapter XIV",
+                    MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+
+            // The stored sub-option must not act while number matching
+            // itself is off.
+            props.setMatchNumbersEnabled(false);
+            assertEquals("Chapter XII",
+                    MatchesTextArea.substituteNumbers(source, srcMatch, trgMatch, tok, tok));
+        } finally {
+            Core.setProject(new NotLoadedProject());
+        }
     }
 
     /**

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -494,11 +494,11 @@ public class NumeralValueParserTest {
         assertEquals(Optional.of("3/4"), NumeralValueParser.parseTokenValue("3/4", true).map(Object::toString));
         assertFalse(NumeralValueParser.parseTokenValue("mix", true).isPresent());
 
-        // Deliberate boundary: Number-Other code points are not numeral tokens,
-        // so an exponent, a vulgar fraction and an enclosed number stay out of
-        // the number comparisons even though they carry a numeric value.
+        // Deliberate boundary: an exponent and an enclosed number stay out of
+        // the number comparisons even though they carry a numeric value; the
+        // precomposed vulgar fractions are real numbers and count.
         assertFalse(NumeralValueParser.parseTokenValue("²", true).isPresent());
-        assertFalse(NumeralValueParser.parseTokenValue("¾", true).isPresent());
+        assertEquals(Optional.of("3/4"), NumeralValueParser.parseTokenValue("¾", true).map(Object::toString));
         assertFalse(NumeralValueParser.parseTokenValue("⑩", true).isPresent());
 
         // Deliberate boundary: a Roman form without I, V or X is a unit or an
@@ -534,5 +534,67 @@ public class NumeralValueParserTest {
                 NumeralValueParser.parseTokenValue("99999999999999999998", true));
     }
 
+    /**
+     * The Number Forms block is never composed additively - forty is not four
+     * twelves. The Roman rule sets write the value subtractively instead, in
+     * the template's case, preferring the precomposed forms one to twelve.
+     */
+    @Test
+    public void renderRomanFormsSubtractively() {
+        assertEquals(Optional.of("ⅩⅬ"), NumeralValueParser.renderInSystemOf(BigInteger.valueOf(40), "Ⅳ"));
+        assertEquals(Optional.of("ⅹⅼ"), NumeralValueParser.renderInSystemOf(BigInteger.valueOf(40), "ⅳ"));
+        assertEquals(Optional.of("ⅯⅭⅯⅬⅩⅩⅩⅠⅤ"),
+                NumeralValueParser.renderInSystemOf(BigInteger.valueOf(1984), "Ⅻ"));
+        assertEquals(Optional.of("Ⅶ"), NumeralValueParser.renderInSystemOf(BigInteger.valueOf(7), "Ⅻ"));
+        assertEquals(Optional.of("ⅶ"), NumeralValueParser.renderInSystemOf(BigInteger.valueOf(7), "ⅻ"));
+    }
 
+    /**
+     * Counting rods are positional above the tens, so a greedy additive
+     * spelling would be invalid notation: the block is read, never written.
+     */
+    @Test
+    public void countingRodsAreReadButNotWritten() {
+        String rods32 = new String(Character.toChars(0x1D36B)) + new String(Character.toChars(0x1D361));
+        assertEquals(Optional.of(BigInteger.valueOf(32)),
+                NumeralValueParser.parseTokenWhole(rods32, false));
+        assertEquals(Optional.empty(),
+                NumeralValueParser.renderInSystemOf(BigInteger.valueOf(432), rods32));
+    }
+
+    /**
+     * A fraction value renders as the precomposed vulgar-fraction glyph when
+     * the template is such a glyph and a glyph with exactly that value
+     * exists; anything else stays unwritable.
+     */
+    @Test
+    public void renderVulgarFractionsExactly() {
+        NumeralValueParser.Rational quarter = NumeralValueParser.parseValue("1/4").orElseThrow();
+        NumeralValueParser.Rational twoFifths = NumeralValueParser.parseValue("2/5").orElseThrow();
+        NumeralValueParser.Rational fiveSevenths = NumeralValueParser.parseValue("5/7").orElseThrow();
+
+        assertEquals(Optional.of("¼"), NumeralValueParser.renderVulgarFractionOf(quarter, "½"));
+        assertEquals(Optional.of("⅖"), NumeralValueParser.renderVulgarFractionOf(twoFifths, "⅓"));
+        // No precomposed glyph carries five sevenths.
+        assertEquals(Optional.empty(), NumeralValueParser.renderVulgarFractionOf(fiveSevenths, "½"));
+        // A non-fraction template is not written.
+        assertEquals(Optional.empty(), NumeralValueParser.renderVulgarFractionOf(quarter, "12"));
+    }
+
+    /**
+     * The sign numerals join the whole-token reading, so the match scorer
+     * pairs them just like the insertion step does.
+     */
+    @Test
+    public void wholeTokenFormReadsSignNumerals() {
+        String mayanTwenty = new String(Character.toChars(0x1D2E1))
+                + new String(Character.toChars(0x1D2E0));
+        assertEquals(Optional.of(BigInteger.valueOf(20)),
+                NumeralValueParser.parseTokenWhole(mayanTwenty, false));
+        String aegeanLarge = new String(Character.toChars(0x10133));
+        assertEquals(Optional.of(BigInteger.valueOf(90000)),
+                NumeralValueParser.parseTokenWhole(aegeanLarge, false));
+        // A fractional sign is a value, not a whole number.
+        assertFalse(NumeralValueParser.parseTokenWhole("꠰", false).isPresent());
+    }
 }

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -27,6 +27,7 @@ package org.omegat.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigInteger;
@@ -467,5 +468,71 @@ public class NumeralValueParserTest {
         assertFalse(NumeralValueParser.parseWhole(",").isPresent());
         assertFalse(NumeralValueParser.parseWhole("don't").isPresent());
     }
+
+    /**
+     * The token forms gate letter-only input: a word must not become a numeral
+     * just because its letters happen to be Roman digits, while an unambiguous
+     * numeral of any system is read.
+     */
+    @Test
+    public void tokenFormsGateLetterOnlyInput() {
+        // Words made of Roman letters stay words, whatever ICU would read.
+        assertFalse(NumeralValueParser.parseTokenWhole("mix", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("civil", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("DID", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole(null, true).isPresent());
+
+        // Unambiguous numerals are read, by value.
+        assertEquals(Optional.of(BigInteger.valueOf(12)), NumeralValueParser.parseTokenWhole("XII", true));
+        assertEquals(Optional.of(BigInteger.valueOf(12)), NumeralValueParser.parseTokenWhole("十二", true));
+        assertEquals(Optional.of(BigInteger.valueOf(9)), NumeralValueParser.parseTokenWhole("٩", true));
+        assertEquals(Optional.of(BigInteger.valueOf(5)), NumeralValueParser.parseTokenWhole("５", true));
+
+        // The value form adds the non-integer numbers on top of the same gate.
+        assertEquals(Optional.of("3/2"), NumeralValueParser.parseTokenValue("1.5", true).map(Object::toString));
+        assertEquals(Optional.of("3/4"), NumeralValueParser.parseTokenValue("3/4", true).map(Object::toString));
+        assertFalse(NumeralValueParser.parseTokenValue("mix", true).isPresent());
+
+        // Deliberate boundary: Number-Other code points are not numeral tokens,
+        // so an exponent, a vulgar fraction and an enclosed number stay out of
+        // the number comparisons even though they carry a numeric value.
+        assertFalse(NumeralValueParser.parseTokenValue("²", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenValue("¾", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenValue("⑩", true).isPresent());
+
+        // Deliberate boundary: a Roman form without I, V or X is a unit or an
+        // abbreviation more often than a number.
+        assertFalse(NumeralValueParser.parseTokenWhole("L", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("M", true).isPresent());
+        assertFalse(NumeralValueParser.parseTokenWhole("CD", true).isPresent());
+
+        // Latin-letter Roman numerals are the caller's decision, because there is
+        // no telling them apart from ordinary uppercase words: the English
+        // pronoun, a size, a version prefix and a handful of words read as
+        // numbers where they are allowed and as prose where they are not.
+        for (String roman : new String[] { "I", "V", "X", "XL", "MIX", "DIV" }) {
+            assertTrue(roman, NumeralValueParser.parseTokenWhole(roman, true).isPresent());
+            assertFalse(roman, NumeralValueParser.parseTokenWhole(roman, false).isPresent());
+        }
+        assertEquals(Optional.of(BigInteger.ONE), NumeralValueParser.parseTokenWhole("I", true));
+        assertEquals(Optional.of(BigInteger.valueOf(1009)),
+                NumeralValueParser.parseTokenWhole("MIX", true));
+
+        // The switch is about Latin letters only: numerals of every other system,
+        // the dedicated Roman code points included, read the same either way.
+        for (String numeral : new String[] { "Ⅻ", "十二", "٩", "５", "12" }) {
+            assertEquals(numeral, NumeralValueParser.parseTokenWhole(numeral, true),
+                    NumeralValueParser.parseTokenWhole(numeral, false));
+            assertTrue(numeral, NumeralValueParser.parseTokenWhole(numeral, false).isPresent());
+        }
+
+        // Arbitrary length: the value is exact, not a double.
+        String big = "1234567890123456789012345678901234567890";
+        assertEquals(Optional.of(new BigInteger(big)), NumeralValueParser.parseTokenWhole(big, true));
+        assertNotEquals(NumeralValueParser.parseTokenValue("99999999999999999999", true),
+                NumeralValueParser.parseTokenValue("99999999999999999998", true));
+    }
+
 
 }

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -597,4 +597,50 @@ public class NumeralValueParserTest {
         // A fractional sign is a value, not a whole number.
         assertFalse(NumeralValueParser.parseTokenWhole("꠰", false).isPresent());
     }
+
+    /**
+     * The rendering list of a value covers digits of other scripts, the
+     * algorithmic systems and the dedicated Roman code points; every entry
+     * reads back as the same value, and Latin-letter Roman renderings appear
+     * only when allowed.
+     */
+    @Test
+    public void renderingsCoverTheWritingSystems() {
+        java.util.List<String> twelve = NumeralValueParser.renderings(BigInteger.valueOf(12), false);
+        assertTrue(twelve.contains("12"));
+        assertTrue(twelve.contains("\u5341\u4e8c")); // 十二
+        assertTrue(twelve.contains("\u216b")); // Ⅻ
+        assertTrue(twelve.contains("\u0661\u0662")); // ١٢
+        assertFalse(twelve.contains("XII"));
+        for (String rendering : twelve) {
+            assertEquals(rendering, Optional.of(BigInteger.valueOf(12)),
+                    NumeralValueParser.parseTokenWhole(rendering, false));
+        }
+        assertTrue(NumeralValueParser.renderings(BigInteger.valueOf(12), true).contains("XII"));
+    }
+
+    /**
+     * Locale knowledge resolves the separators the universal parser refuses
+     * as ambiguous: grouping and decimal separators of the given locale read
+     * as one number, wrong-locale shapes stay unread.
+     */
+    @Test
+    public void localeSeparatorsParseWithTheirLocale() {
+        java.util.Locale de = java.util.Locale.GERMANY;
+        java.util.Locale en = java.util.Locale.US;
+        Rational value = NumeralValueParser.parseTokenValueLocalized("1.234.567,89", false, de)
+                .orElseThrow(AssertionError::new);
+        Rational same = NumeralValueParser.parseTokenValueLocalized("1,234,567.89", false, en)
+                .orElseThrow(AssertionError::new);
+        assertEquals(0, value.compareTo(same));
+        // The wrong locale does not read the other locale's shape as one number.
+        assertFalse(NumeralValueParser.parseTokenValueLocalized("1,234,567.89", false, de).isPresent());
+        // Without a locale the behavior stays the documented refusal.
+        assertFalse(NumeralValueParser.parseTokenValueLocalized("1.234.567,89", false, null).isPresent());
+        // Indian secondary grouping: groups of two before the final three.
+        Rational lakh = NumeralValueParser
+                .parseTokenValueLocalized("12,34,567", false, java.util.Locale.of("en", "IN"))
+                .orElseThrow(AssertionError::new);
+        assertEquals(0, lakh.compareTo(NumeralValueParser.parseValue("1234567").orElseThrow()));
+    }
 }

--- a/src/test/java/org/omegat/util/ProjectFileStorageTest.java
+++ b/src/test/java/org/omegat/util/ProjectFileStorageTest.java
@@ -81,20 +81,46 @@ public class ProjectFileStorageTest {
 
     @Test
     public void testMatchNumbersRoundTrip() throws Exception {
-        // Absent flag reads as disabled and is not written for a default
-        // project; an enabled flag survives the write/read round trip.
+        // Number matching is on by default and only the opt-out is written,
+        // so default project files stay free of the element; the disabled
+        // state survives the write/read round trip.
         ProjectProperties defaults = getProjectProperties();
-        assertFalse(defaults.isMatchNumbersEnabled());
+        assertTrue(defaults.isMatchNumbersEnabled());
         ProjectFileStorage.writeProjectFile(defaults);
         ProjectProperties reread = ProjectFileStorage.loadPropertiesFile(tempDir,
                 new File(tempDir, "omegat.project"));
+        assertTrue(reread.isMatchNumbersEnabled());
+
+        ProjectProperties disabled = getProjectProperties();
+        disabled.setMatchNumbersEnabled(false);
+        ProjectFileStorage.writeProjectFile(disabled);
+        reread = ProjectFileStorage.loadPropertiesFile(tempDir, new File(tempDir, "omegat.project"));
         assertFalse(reread.isMatchNumbersEnabled());
 
+        // A legacy opt-in element still reads as enabled.
         ProjectProperties enabled = getProjectProperties();
         enabled.setMatchNumbersEnabled(true);
         ProjectFileStorage.writeProjectFile(enabled);
         reread = ProjectFileStorage.loadPropertiesFile(tempDir, new File(tempDir, "omegat.project"));
         assertTrue(reread.isMatchNumbersEnabled());
+    }
+
+    @Test
+    public void testMatchNumbersRomanRoundTrip() throws Exception {
+        // Roman numerals stay opt-in: absent reads as disabled, the enabled
+        // state survives the write/read round trip.
+        ProjectProperties defaults = getProjectProperties();
+        assertFalse(defaults.isMatchNumbersRomanEnabled());
+        ProjectFileStorage.writeProjectFile(defaults);
+        ProjectProperties reread = ProjectFileStorage.loadPropertiesFile(tempDir,
+                new File(tempDir, "omegat.project"));
+        assertFalse(reread.isMatchNumbersRomanEnabled());
+
+        ProjectProperties enabled = getProjectProperties();
+        enabled.setMatchNumbersRomanEnabled(true);
+        ProjectFileStorage.writeProjectFile(enabled);
+        reread = ProjectFileStorage.loadPropertiesFile(tempDir, new File(tempDir, "omegat.project"));
+        assertTrue(reread.isMatchNumbersRomanEnabled());
     }
 
     @Test

--- a/src/test/resources/data/tmx/test-equivalence-en-de.tmx
+++ b/src/test/resources/data/tmx/test-equivalence-en-de.tmx
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+<header datatype="plaintext" srclang="en" adminlang="EN-US" o-tmf="OmegaT TMX" segtype="sentence"
+creationtoolversion="test" creationtool="test"/>
+  <body>
+<!-- curly double quotes -->
+    <tu>
+      <tuv xml:lang="en">
+        <seg>Select the “Save” command from the menu.</seg>
+      </tuv>
+      <tuv xml:lang="de">
+        <seg>Wählen Sie den Befehl „Speichern“ im Menü.</seg>
+      </tuv>
+    </tu>
+<!-- curly apostrophe inside a word -->
+    <tu>
+      <tuv xml:lang="en">
+        <seg>It’s John’s house near the river.</seg>
+      </tuv>
+      <tuv xml:lang="de">
+        <seg>Es ist Johns Haus am Fluss.</seg>
+      </tuv>
+    </tu>
+<!-- en dash in a page range -->
+    <tu>
+      <tuv xml:lang="en">
+        <seg>See pages 3–4 for details.</seg>
+      </tuv>
+      <tuv xml:lang="de">
+        <seg>Details finden Sie auf den Seiten 3–4.</seg>
+      </tuv>
+    </tu>
+<!-- no-break space before the percent sign -->
+    <tu>
+      <tuv xml:lang="en">
+        <seg>The discount is 10 % this week.</seg>
+      </tuv>
+      <tuv xml:lang="de">
+        <seg>Der Rabatt beträgt diese Woche 10 %.</seg>
+      </tuv>
+    </tu>
+<!-- soft hyphen inside the word "information" -->
+    <tu>
+      <tuv xml:lang="en">
+        <seg>More infor­mation is available online.</seg>
+      </tuv>
+      <tuv xml:lang="de">
+        <seg>Weitere Informationen sind online verfügbar.</seg>
+      </tuv>
+    </tu>
+  </body>
+</tmx>

--- a/src/testAcceptance/java/org/omegat/gui/matches/NumeralMatchesSubstitutionTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/matches/NumeralMatchesSubstitutionTest.java
@@ -1,0 +1,122 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.matches;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.beans.PropertyChangeListener;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.swing.SwingUtilities;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.gui.main.MainWindow;
+import org.omegat.gui.main.TestCoreGUI;
+import org.omegat.util.Preferences;
+
+/**
+ * End-to-end check of value-based fuzzy match number substitution (SF #465):
+ * loads project_numerals fixture like user project, {@code match_numbers} in
+ * omegat.project enables number matching, recycling match writes source
+ * segment's number into match target - read from and rendered into numeral
+ * systems beyond ASCII digits. Per-system rules: unit tests. Here: wiring
+ * only, on representative segments.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class NumeralMatchesSubstitutionTest extends TestCoreGUI {
+
+    private static final Path PROJECT_PATH = Paths.get("src/testAcceptance/resources/data/project_numerals/");
+
+    /**
+     * Demo segments live in source/exotic-numerals.txt;
+     * source/beyond-coverage.txt sorts first with two segments, so README
+     * segment numbers are offset by two.
+     */
+    private static final int FIRST_DEMO_ENTRY = 3;
+
+    @Test
+    public void testMatchInsertionSubstitutesNumbersByValue() throws Exception {
+        Preferences.setPreference(Preferences.CONVERT_NUMBERS, true);
+        openSampleProject(PROJECT_PATH);
+        assertTrue("Fixture's match_numbers setting must reach the loaded project.",
+                Core.getProject().getProjectProperties().isMatchNumbersEnabled());
+
+        // Demo segment 1, Western digits: source 1984 replaces match's 1750.
+        assertEquals("Das Lagerverzeichnis nennt 1984 Tonkrüge.",
+                recycledTranslationOfEntry(FIRST_DEMO_ENTRY));
+        // Demo segment 2, Khmer digits: source value rendered in match
+        // target's digit script.
+        assertEquals("Die Volkszählung von Angkor erfasste 123456 Haushalte.",
+                recycledTranslationOfEntry(FIRST_DEMO_ENTRY + 1));
+        // Demo segment 3, Ethiopic sign numerals: read by value, written as
+        // target's digits.
+        assertEquals("Die Chronik datiert die Synode auf das Jahr 1976.",
+                recycledTranslationOfEntry(FIRST_DEMO_ENTRY + 2));
+        // Demo segment 23, counting-rod target: rods never composed, value
+        // arrives as plain digits.
+        assertEquals("Das Rechenbrett zählt 432 Münzen.",
+                recycledTranslationOfEntry(FIRST_DEMO_ENTRY + 22));
+
+        closeProject();
+    }
+
+    /**
+     * Activates entry, waits for match, returns editor translation after
+     * recycling that match.
+     */
+    private String recycledTranslationOfEntry(int entryNum) throws Exception {
+        MatchesTextArea matcher = (MatchesTextArea) Core.getMatcher();
+        CountDownLatch matchArrived = new CountDownLatch(1);
+        // Entry check keeps stray events of previously activated entries from
+        // releasing latch early.
+        PropertyChangeListener waiter = evt -> SwingUtilities.invokeLater(() -> {
+            if (matcher.getActiveMatch() != null
+                    && Core.getEditor().getCurrentEntryNumber() == entryNum) {
+                matchArrived.countDown();
+            }
+        });
+        matcher.addPropertyChangeListener("matches", waiter);
+        try {
+            GuiActionRunner.execute(() -> Core.getEditor().gotoEntry(entryNum));
+            assertTrue("No match arrived for entry " + entryNum + ".",
+                    matchArrived.await(timeout, TimeUnit.SECONDS));
+        } finally {
+            matcher.removePropertyChangeListener("matches", waiter);
+        }
+        return GuiActionRunner.execute(() -> {
+            MainWindow.doRecycleTrans();
+            return Core.getEditor().getCurrentTranslation();
+        });
+    }
+}

--- a/src/testAcceptance/resources/data/project_numerals/README.md
+++ b/src/testAcceptance/resources/data/project_numerals/README.md
@@ -1,0 +1,114 @@
+# Exotic numerals demo project
+
+A minimal OmegaT project (English to German, `match_numbers` enabled in `omegat.project`)
+illustrating how far the value-based fuzzy match number handling of SF-465
+reaches across the numeral systems encoded in Unicode. Every example was
+verified against `NumeralValueParser` before it went into this project.
+
+Open the project folder in OmegaT and step through the segments of
+`source/exotic-numerals.txt`: each segment has a translation-memory twin in
+`tm/exotic-numerals-demo.tmx` that differs only in the number value, so the
+Matches pane demonstrates the value comparison and substitution on scripts
+far beyond ASCII digits.
+
+Project doubles as fixture of acceptance test
+`NumeralMatchesSubstitutionTest`, verifying substitution on several segments
+below. Note: `source/beyond-coverage.txt` sorts before
+`source/exotic-numerals.txt`, so editor entry numbers run two ahead of
+segment numbers in this file.
+
+## Covered systems (one segment each)
+
+| Segment | System | Base | Codepoints used | Value in source / TM |
+|---|---|---|---|---|
+| 1 | Western digits | 10 | ASCII | 1984 / 1750 |
+| 2 | Khmer digits | 10 | U+17E0 block | 123456 / 98765 |
+| 3 | Ethiopic (multiplicative-additive) | 10, no zero | U+1369 block | 1976 / 1974 |
+| 4 | Cuneiform (Sumero-Akkadian) | 60 | U+12433, U+12432 | 432000 / 216000 |
+| 5 | Aegean (Linear A/B) | 10 | U+10133, U+10132 | 90000 / 80000 |
+| 6 | Mayan digit | 20 | U+1D2F3, U+1D2EB | 19 / 11 |
+| 7 | Kaktovik digit (Inupiaq, 1990s) | 20 | U+1D2D3, U+1D2C4 | 19 / 4 |
+| 8 | Roman (subtractive-additive) | mixed | ASCII letters | 1984 / 2026 |
+| 9 | CJK ideographic (multiplicative) | 10 | myriad grouping | 35000 / 1984 |
+| 10 | Meroitic (Kingdom of Kush) | 10 | U+109C0 block | 900000 / 1000 |
+| 11 | Pahawh Hmong | 10 | U+16B5B block | 10^12 / 10000 |
+| 12 | Greek acrophonic (Attic) | 5/10 | U+10147, U+10146 | 50000 / 5000 |
+| 13 | Ottoman Siyaq | 10 | U+1ED01 block | 90000 / 10000 |
+| 14 | Vulgar fractions | - | U+00BC, U+00BD | 1/4 / 1/2 |
+| 15 | Adlam digits (1980s, Guinea) | 10 | U+1E950 block | 1984 / 2026 |
+| 16 | Medefaidrin digit (Nigeria) | 20 | U+16E80 block | 19 / 7 |
+
+## Parsing versus substitution
+
+All sixteen numbers above parse to the right value and enter the
+value-based match comparison. The insertion step substitutes them as well
+(verified with both the default and the Lucene tokenizers): digit systems
+render in the target's digit script, sign numerals - Ethiopic
+composites, cuneiform, Mayan and Kaktovik digits - are spelled out as
+digits when the target writes digits, and a vulgar fraction (segment 14)
+becomes the precomposed glyph of its exact value, so a quarter replaces a
+half glyph for glyph.
+
+Two exclusions are deliberate and stay: Roman numerals written with Latin
+letters (segment 8) are never rewritten because "I", "MIX" or "DIV" cannot
+be told apart from words, and the remaining presentation forms carrying a
+compatibility decomposition - superscript exponents and enclosed numbers -
+must never be touched by a substitution.
+
+A related boundary holds for the protected-parts marking: Han numerals
+(segment 9) are read by value but stay out of the default custom-tag
+pattern, because their characters double as ordinary words in CJK prose
+and the untokenized pattern would flood such projects with false tags.
+A project that cannot meet Han characters outside numbers can add the
+class to the pattern under tag processing preferences.
+
+## Cross-system conversion (segments 17 to 19)
+
+When the match target writes its number in a numeral system rather than in
+digits, the source value is written in that system, whatever system the
+source itself uses. Three segments demonstrate the three writers:
+
+| Segment | Source system and value | Target system | Written as |
+|---|---|---|---|
+| 17 | Ethiopic 840 | Aegean | additive composition, 800 sign plus 40 sign |
+| 18 | Ethiopic 40 | Mayan digits | positional base twenty, two signs |
+| 19 | Meroitic 900000 | Ethiopic | ICU rule set writes the composite |
+
+Only an exact composition is inserted; otherwise the value falls back to
+plain digits.
+
+## Sign sequences read as one number (segments 20 and 21)
+
+The reading side composes sign sequences from the named numeral blocks as
+well: a Mayan two-digit column reads positionally in base twenty (segment
+20, value 20), and a largest-first cuneiform sign pair reads as an
+additive sum (segment 21, value 11). Single fraction signs - the
+cuneiform two-thirds at U+1245B, the North Indic quarter at U+A830, the
+Kharoshthi half at U+10A48 - resolve to their exact rational as well.
+
+## Valid notation only (segments 22 and 23)
+
+A composition is only inserted when it is valid notation in the target's
+system. The Roman code points of the Number Forms block are written
+subtractively through the ICU rule sets in the template's case (year 40
+becomes ⅩⅬ, never a pile of twelves), and the counting rods - positional
+above the tens - are read but never composed, so a rod-written target
+receives the value in plain digits instead.
+
+## Beyond coverage: debugging candidates
+
+`source/beyond-coverage.txt` keeps the remaining verified misses:
+
+1. Tamil multiplicative-additive numerals: ICU's rule set writes them but
+   cannot read them back, and the additive reader deliberately rejects
+   their ascending unit-multiplier order rather than misread it as a sum.
+2. Suzhou/Hangzhou numerals (U+3021 block) are positional decimal, but
+   their block mixes in the ten/twenty/thirty signs, so a digit run is
+   not composed.
+
+## Not representable in Unicode
+
+The Inca quipu records numbers as knot positions on cords; there is no
+Unicode encoding for it, so it cannot appear in a text-based demo. The
+Egyptian hieroglyph numerals are encoded but carry no Unicode numeric
+properties, which keeps them outside the parser's code-point path as well.

--- a/src/testAcceptance/resources/data/project_numerals/omegat.project
+++ b/src/testAcceptance/resources/data/project_numerals/omegat.project
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<omegat>
+  <project version="1.0">
+    <source_dir>__DEFAULT__</source_dir>
+    <source_dir_excludes>
+      <mask>**/.svn/**</mask>
+      <mask>**/CVS/**</mask>
+      <mask>**/.cvs/**</mask>
+      <mask>**/.git/**</mask>
+      <mask>**/.hg/**</mask>
+      <mask>**/.repositories/**</mask>
+      <mask>**/desktop.ini</mask>
+      <mask>**/Thumbs.db</mask>
+      <mask>**/.DS_Store</mask>
+      <mask>**/~$*</mask>
+    </source_dir_excludes>
+    <target_dir>__DEFAULT__</target_dir>
+    <tm_dir>__DEFAULT__</tm_dir>
+    <glossary_dir>__DEFAULT__</glossary_dir>
+    <glossary_file>__DEFAULT__</glossary_file>
+    <dictionary_dir>__DEFAULT__</dictionary_dir>
+    <export_tm_dir>__DEFAULT__</export_tm_dir>
+    <export_tm_levels>omegat level1 level2</export_tm_levels>
+    <source_lang>en</source_lang>
+    <target_lang>de</target_lang>
+    <source_tok>org.omegat.tokenizer.LuceneEnglishTokenizer</source_tok>
+    <target_tok>org.omegat.tokenizer.LuceneGermanTokenizer</target_tok>
+    <sentence_seg>true</sentence_seg>
+    <support_default_translations>true</support_default_translations>
+    <remove_tags>false</remove_tags>
+    <match_numbers>true</match_numbers>
+    <external_command></external_command>
+  </project>
+</omegat>

--- a/src/testAcceptance/resources/data/project_numerals/source/beyond-coverage.txt
+++ b/src/testAcceptance/resources/data/project_numerals/source/beyond-coverage.txt
@@ -1,0 +1,3 @@
+The Tamil deed states the sum ௲௯௱௨௰௪.
+
+The Suzhou invoice notes 〡〢〣 bolts of silk.

--- a/src/testAcceptance/resources/data/project_numerals/source/exotic-numerals.txt
+++ b/src/testAcceptance/resources/data/project_numerals/source/exotic-numerals.txt
@@ -1,0 +1,45 @@
+The warehouse inventory lists 1984 clay jars.
+
+The Angkor census recorded ១២៣៤៥៦ households.
+
+The chronicle dates the synod to the year ፲፱፻፸፮.
+
+The temple archive tallies 𒐳 measures of barley.
+
+The Knossos tablet counts 𐄳 sheep.
+
+The stela marks day 𝋳 of the winal.
+
+The Inupiaq worksheet shows 𝋓 seals.
+
+The cornerstone bears the year MCMLXXXIV.
+
+The ledger totals 三万五千 copper coins.
+
+The offering table lists 𐧵 measures of incense.
+
+The Pahawh primer spells the number 𖭡.
+
+The Attic inscription pledges 𐅇 drachmas.
+
+The Ottoman ledger registers 𞴭 akce.
+
+Add ¼ measure of honey to the mixture.
+
+The Adlam textbook prints the year 𞥑𞥙𞥘𞥔.
+
+The Medefaidrin hymnal numbers verse 𖺓.
+
+The customs house restates the toll of ፰፻፵ in the island ledger.
+
+The calendar priest transcribes ፵ tuns into the Long Count.
+
+The Kushite granary restates 𐧵 measures in the highland script.
+
+The Long Count tablet records 𝋡𝋠 tuns.
+
+The Uruk tally joins 𒐇𒐀 baskets.
+
+The chronicle dates the council to year 40.
+
+The abacus ledger counts 432 coins.

--- a/src/testAcceptance/resources/data/project_numerals/tm/exotic-numerals-demo.tmx
+++ b/src/testAcceptance/resources/data/project_numerals/tm/exotic-numerals-demo.tmx
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE tmx SYSTEM "tmx14.dtd">
+<tmx version="1.4">
+  <header creationtool="OmegaT" creationtoolversion="6.2.0" o-tmf="OmegaT TMX" adminlang="EN-US" datatype="plaintext" segtype="sentence" srclang="en"/>
+  <body>
+    <tu>
+      <tuv xml:lang="en"><seg>The warehouse inventory lists 1750 clay jars.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Lagerverzeichnis nennt 1750 Tonkrüge.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Angkor census recorded ៩៨៧៦៥ households.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Volkszählung von Angkor erfasste 98765 Haushalte.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The chronicle dates the synod to the year ፲፱፻፸፬.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Chronik datiert die Synode auf das Jahr 1974.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The temple archive tallies 𒐲 measures of barley.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Tempelarchiv verzeichnet 216000 Maß Gerste.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Knossos tablet counts 𐄲 sheep.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Tafel aus Knossos zählt 80000 Schafe.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The stela marks day 𝋫 of the winal.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Stele markiert Tag 11 des Winal.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Inupiaq worksheet shows 𝋄 seals.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Inupiaq-Arbeitsblatt zeigt 4 Robben.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The cornerstone bears the year MMXXVI.</seg></tuv>
+      <tuv xml:lang="de"><seg>Der Grundstein trägt die Jahreszahl 2026.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The ledger totals 千九百八十四 copper coins.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Kontobuch summiert 1984 Kupfermünzen.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The offering table lists 𐧛 measures of incense.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Opfertafel führt 1000 Maß Weihrauch auf.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Pahawh primer spells the number 𖭝.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Pahawh-Fibel schreibt die Zahl 10000.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Attic inscription pledges 𐅆 drachmas.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die attische Inschrift gelobt 5000 Drachmen.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Ottoman ledger registers 𞴥 akce.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das osmanische Rechnungsbuch verzeichnet 10000 Akçe.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>Add ½ measure of honey to the mixture.</seg></tuv>
+      <tuv xml:lang="de"><seg>Der Mischung ½ Maß Honig hinzufügen.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Adlam textbook prints the year 𞥒𞥐𞥒𞥖.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Adlam-Schulbuch druckt die Jahreszahl 2026.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Medefaidrin hymnal numbers verse 𖺇.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Medefaidrin-Gesangbuch nummeriert Vers 7.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The customs house restates the toll of ፮፻ in the island ledger.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Zollhaus weist die Abgabe von 𐄞 im Insel-Hauptbuch aus.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The calendar priest transcribes ፱ tuns into the Long Count.</seg></tuv>
+      <tuv xml:lang="de"><seg>Der Kalenderpriester überträgt 𝋩 Tun in die Lange Zählung.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Kushite granary restates 𐧛 measures in the highland script.</seg></tuv>
+      <tuv xml:lang="de"><seg>Der kuschitische Speicher weist ፲፻ Maß in der Hochlandschrift aus.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Long Count tablet records 33 tuns.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Tafel der Langen Zählung verzeichnet 33 Tun.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The Uruk tally joins 𒐆 baskets.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Zählung aus Uruk fasst 8 Körbe zusammen.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The chronicle dates the council to year 4.</seg></tuv>
+      <tuv xml:lang="de"><seg>Die Chronik datiert das Konzil auf das Jahr Ⅳ.</seg></tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en"><seg>The abacus ledger counts 32 coins.</seg></tuv>
+      <tuv xml:lang="de"><seg>Das Rechenbrett zählt 𝍫𝍡 Münzen.</seg></tuv>
+    </tu>
+  </body>
+</tmx>


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Straight quotes match curly quotes
  * https://sourceforge.net/p/omegat/feature-requests/1681/

## What does this PR change?

- Fuzzy matching folds character variant classes together: quotation marks and apostrophes, dashes, spaces, invisible formatting characters; NFC applies before comparison.
- Classes active by default, configurable per project via dialog with character inventories and live test area; opt-out persists as optional `match_equivalence_disabled` element in `omegat.project` ~(written only when disabling; reading requires tolerant parser from #2274).~ (written as sidecar outside project file so that older released versions simply ignore the new setting).
- Exact and keyword search match same variants pattern-side; offsets, highlighting, replace stay on raw text. New checkbox row per search/replace panel, prefilled from project setting, disabled in regexp mode.
- Replaces "Space matches nbsp" option; preference keys deprecated, `SearchExpression.spaceMatchNbsp` replaced by `equivalences`, regexp-mode nbsp rewriting removed.
- Match statistics windows and files name active classes.

## Other information

Folded match still differs literally from source; replacing span with tolerated invisible characters removes them.

### screenshots

(only attached to this comment, not part of the PR, will not be updated if details change)

with new default project setting active, all 3 fuzzy match passes (stem, nostem, verbatim) show a 100% match now, even though ‘ is not exactly equal '
<img width="1076" height="201" alt="Bildschirmfoto 2026-08-27 um 20 39 05" src="https://github.com/user-attachments/assets/0257cb44-6d01-4bfa-a7a6-0ea263304c3d" />

in the project settings is a new button "Character equivalence…"
<img width="754" height="384" alt="Bildschirmfoto 2026-08-27 um 20 39 25" src="https://github.com/user-attachments/assets/d26f3b44-2873-4f4f-a138-9cb77c8a0ef2" />

that opens a window with scrollable character info list per equivalence class and a test-text field with preset example text where user can experiment with text and equivalence classes for their own use case. characte lists of classes are not user editable, only opt-outable.
<img width="796" height="721" alt="Bildschirmfoto 2026-08-27 um 20 39 36" src="https://github.com/user-attachments/assets/eec0a3c7-af60-499e-a014-c32a2725a21b" />

in the search window, the NBSP checkbox is obsolete and thus removed, instead a new line with four checkboxes for the new equivalence classes, preset with project setting, disabled when regex, search for ‘ with the equivalence checkbox unchecked does not find the segment
<img width="879" height="595" alt="Bildschirmfoto 2026-08-27 um 20 43 36" src="https://github.com/user-attachments/assets/b68be80d-4065-4513-8793-db14b27bd6d9" />

search for ‘ with the checkbox checked does find the segment
<img width="879" height="595" alt="Bildschirmfoto 2026-08-27 um 20 43 26" src="https://github.com/user-attachments/assets/90190f2b-1a85-49c7-94f8-4a923a7c7dc1" />

the replace window also has the new checkboxes and only applies them in the search, not in the replace.
<img width="899" height="453" alt="Bildschirmfoto 2026-08-27 um 20 44 29" src="https://github.com/user-attachments/assets/6a567e39-7bca-426a-8790-57338f30ca40" />
