### PR TITLE
docs(dev): add architecture diagrams and fail CI when there are SVGs unreferenced by dev-documentation

### DIFF
--- a/ci/azure-pipelines/build_doc_steps.yml
+++ b/ci/azure-pipelines/build_doc_steps.yml
@@ -9,6 +9,9 @@ steps:
         gradle | "$(Agent.OS)"
         gradle
       path: '$(GRADLE_USER_HOME)/caches/modules-2'
+  - script: python3 ci/check-docs-assets.py
+    condition: ${{ parameters.condition }}
+    displayName: 'Check documentation assets are referenced'
   - task: Gradle@3
     condition: ${{ parameters.condition }}
     inputs:

--- a/ci/azure-pipelines/check_steps.yml
+++ b/ci/azure-pipelines/check_steps.yml
@@ -7,6 +7,8 @@ steps:
         gradle | "$(Agent.OS)"
         gradle
       path: '$(GRADLE_USER_HOME)'
+  - script: python3 ci/check-docs-assets.py
+    displayName: 'Check documentation assets are referenced'
   - task: Gradle@3
     displayName: Check
     inputs:

--- a/ci/check-docs-assets.py
+++ b/ci/check-docs-assets.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Guard for the developer documentation published on Read the Docs:
+# every image under src/docs/developer must be referenced by at least one
+# Markdown page there, so no unlinked media blobs accumulate in the
+# repository (see PR #2255 and 48.DeveloperDocumentation.md).
+#
+# Standard library only; run from the repository root:
+#   python3 ci/check-docs-assets.py
+# Exit code 0 when every image is referenced, 1 with a list of orphans.
+#
+# Recognised reference forms, matching what 48.DeveloperDocumentation.md
+# prescribes: plain Markdown images/links "](path)" and raw HTML
+# <img src="path">. MyST image directives and reference-style links are
+# deliberately not supported.
+
+import pathlib
+import re
+import sys
+
+DOCS_DIR = pathlib.Path(__file__).resolve().parent.parent / "src" / "docs" / "developer"
+IMAGE_SUFFIXES = {".svg", ".png", ".jpg", ".jpeg", ".gif"}
+
+
+def main():
+    images = [p for p in DOCS_DIR.rglob("*")
+              if p.suffix.lower() in IMAGE_SUFFIXES and "_build" not in p.parts]
+    referenced = set()
+    for page in DOCS_DIR.rglob("*.md"):
+        if "_build" in page.parts:
+            continue
+        text = page.read_text(encoding="utf-8", errors="replace")
+        # Markdown images/links "](path)" and raw HTML <img src="path">.
+        for match in re.findall(r"\]\(([^)\s]+)\)|<img[^>]+src=[\"']([^\"']+)[\"']", text):
+            for target in match:
+                if target:
+                    referenced.add((page.parent / target.split("#")[0]).resolve())
+    orphans = [img for img in images if img.resolve() not in referenced]
+    if orphans:
+        print("Unreferenced documentation images (add a Markdown reference or remove the file):")
+        for img in sorted(orphans):
+            print("  " + str(img.relative_to(DOCS_DIR.parent.parent.parent)))
+        return 1
+    print("check-docs-assets: %d images, all referenced." % len(images))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/docs/developer/21.OmegaTInternals.md
+++ b/src/docs/developer/21.OmegaTInternals.md
@@ -6,6 +6,11 @@ Components in OmegaT:
 
 Each component must implement a specific interface, and only this interface should be used to call this component from other components. 
 
+A more detailed structural overview — the `Core` hub, the three main components with their
+internals, the event bus and the dockable panes — is available as an editable SVG:
+
+![OmegaT architecture overview](assets/omegat-architecture-overview.svg)
+
 ## Threads usage
 
 

--- a/src/docs/developer/22.CoreEvents.md
+++ b/src/docs/developer/22.CoreEvents.md
@@ -2,6 +2,11 @@
 
 There are OmegaT standard API that hooks GUI events defined in `org.omegat.core.CoreEvents` class.
 
+The following map shows how events travel through the application — who fires them, how they
+are delivered on the event dispatch thread, and where known pitfalls are:
+
+![OmegaT event flow map](assets/omegat-event-flow-overview.svg)
+
 ## Event
 
 OmegaT fires event calls on following timing.

--- a/src/docs/developer/93.BuildingInstallerPackage.md
+++ b/src/docs/developer/93.BuildingInstallerPackage.md
@@ -1,5 +1,12 @@
 # Building and testing the installer package
 
+The following map shows what a full distribution (`installDist`) contains, to scale,
+and where its size comes from — including known reduction opportunities. It is a
+historic snapshot at one certain point of time in the past (2026-08-01); the numbers
+are not maintained:
+
+![OmegaT shipping ballast map](assets/omegat-shipping-ballast.svg)
+
 ## Building the Windows installer
 
 The OmegaT project uses `Launch4j` to create the application launcher and

--- a/src/docs/developer/assets/omegat-architecture-overview.svg
+++ b/src/docs/developer/assets/omegat-architecture-overview.svg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OmegaT architecture overview diagram (editable SVG).
+  Companion to src/docs/developer/21.OmegaTInternals.md.
+
+  🄯 2026 - This file is part of OmegaT, released under the GNU General
+  Public License version 3 or (at your option) any later version.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1760 1320" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <g transform="translate(24,10) scale(0.16)">
+    <path fill="#1e282c" d="m 145.84482,32.68197 c -17.435,0 -33.882,2.683 -48.883002,7.973 -14.783,5.214 -27.816,12.832 -38.737,22.641 -11.013,9.892 -19.58,21.744 -25.462,35.229 -6.042,13.851 -9.105,29.115 -9.105,45.37 0,21.473 7.679,41.858 22.823,60.588 7.582,9.379 16.92,18.207 27.854,26.347 l -14.577,0 c -8.347,0 -12.896,-0.369 -16.173,-2.465 -3.317,-2.122 -6.026,-6.481 -9.66,-15.545 -0.609,-1.518 -2.079,-2.511 -3.713,-2.511 l -10.212,0 c -1.135,0 -2.216,0.481 -2.975,1.325 -0.759,0.845 -1.123,1.972 -1.002,3.1 l 6.201,58.031 c 0.217,2.032 1.932,3.574 3.977,3.574 l 93.382002,0 c 1.417,0 2.728,-0.75 3.447,-1.971 l 2.917,-4.955 c 0.735,-1.248 0.737,-2.797 0.006,-4.048 l -0.507,-0.867 c -6.861,-11.732 -17.231,-29.463 -25.685002,-50.082 -4.62,-11.265 -8.205,-22.288 -10.656,-32.763 -2.861,-12.226 -4.27,-24.086 -4.188,-35.254 0,-0.009 0,-0.019 0,-0.029 0,-14.669 1.357,-27.923 4.033,-39.395 2.639,-11.314 6.581,-20.977 11.715002,-28.719 10.305,-15.542 25.384,-23.422 44.816,-23.422 19.577,0 34.775,7.661 45.174,22.771 5.137,7.465 9.082,16.756 11.725,27.616 2.674,10.988 4.03,23.643 4.03,37.612 0,22.021 -5.354,46.297 -15.911,72.155 -8.788,21.52 -19.212,39.359 -25.44,50.018 l -0.416,0.712 c -0.794,1.36 -0.717,3.06 0.197,4.342 l 3.283,4.603 c 0.751,1.052 1.964,1.677 3.257,1.677 l 91.923,0 c 1.988,0 3.674,-1.46 3.959,-3.428 l 8.392,-58.031 c 0.166,-1.147 -0.175,-2.313 -0.936,-3.189 -0.76,-0.878 -1.862,-1.382 -3.023,-1.382 l -10.216,0 c -1.611,0 -3.064,0.966 -3.688,2.45 -3.762,8.958 -6.614,13.492 -9.842,15.649 -3.081,2.059 -7.149,2.421 -14.558,2.421 l -19.256,0 c 10.409,-8.448 22.111,-18.599 31.947,-31.103 6.544,-8.32 11.629,-16.954 15.112,-25.663 4.054,-10.133 6.108,-20.76 6.108,-31.585 0,-15.938 -3.008,-30.927 -8.938,-44.549 -5.799,-13.318 -14.252,-25.029 -25.125,-34.809 -10.83,-9.742 -23.774,-17.308 -38.474,-22.488 -14.97,-5.275 -31.429,-7.951 -48.92,-7.951 l 0,0 z m -118.187002,111.213 c 0,-64.045 49.244001,-107.213 118.187002,-107.213 69.307,0 117.458,43.168 117.458,105.797 l 0,0 0,0 c 0,45.646 -37.572,73.952 -60.553,92.351 l 4,0 0,0 2.41,0 0,0 24.23,0 c 15.321,0 20.063,-1.414 28.088,-20.521 l 10.216,0 0,0 0,0 -8.392,58.03 -91.922,0 -3.283,-4.603 0,0 0,0 c 12.402,-21.231 42.313,-71.829 42.313,-124.903 0,-57.323 -22.25,-91.999 -64.929,-91.999 -42.315,0 -64.564001,35.385 -64.564001,95.536 -0.002,0.292 -0.003,0.584 -0.003,0.877 -0.035,49.569 27.808001,96.569 41.586001,120.137 l 0,0 0,0 -2.917,4.955 -93.382001,0 -6.201001,-58.029 0,0 0,0 10.212001,0 c 7.660999,19.106 12.404999,20.521 29.545999,20.521 l 20.159,0 0,0 3.202001,0 0,0 4,0 c -20.793001,-13.446 -59.461001,-43.876 -59.461001,-90.936 l 0,0 0,0 z"/>
+    <path fill="#ef3b39" d="m 216.634,-2 c -2.431,0 -6.061,0.811 -9.55,4.678 0,0 0.001,-10e-4 0.002,-10e-4 -12.968,14.276 -41.592,38.801 -52.015,43.395 l -0.067,0.029 -0.066,0.032 c -4.885,2.37 -9.878,5.65 -9.878,12.002 0,2.827 1.132,5.242 3.185,6.801 1.667,1.265 3.807,1.906 6.361,1.906 l 15.028,0 -0.316,40.34 0,0.015 0,0.016 c 0,6.482 -0.182,16.369 -0.356,25.93 -0.173,9.441 -0.336,18.357 -0.336,24.156 0,8.939 4.283,17.845 11.75,24.43 3.834,3.38 8.338,6.031 13.389,7.878 5.359,1.96 11.189,2.954 17.326,2.954 19.707,0 37.266,-4.894 50.775,-14.149 l 0.046,-0.032 0.046,-0.032 c 3.351,-2.438 4.382,-6.308 2.564,-9.492 l -2.351,-4.887 -0.024,-0.054 -0.027,-0.052 c -1.671,-3.229 -3.932,-3.908 -5.533,-3.908 -1.076,0 -2.141,0.321 -3.168,0.952 -4.635,2.506 -9.133,3.484 -15.994,3.484 -3.84,0 -7.019,-1.641 -9.449,-4.874 -1.67,-2.224 -2.989,-5.201 -3.924,-8.852 -1.118,-4.365 -1.684,-9.711 -1.684,-15.889 l 0,-26.556 c 0,-14.072 0,-28.579 0.517,-41.378 l 36.72,0 c 1.664,0 5.678,-0.555 6.991,-5.7 l 0.009,-0.028 0.007,-0.029 3.387,-14.113 c 0.671,-1.711 0.509,-3.624 -0.467,-5.223 -1.175,-1.926 -3.331,-3.076 -5.768,-3.076 l -39.854,0 1.225,-31.475 0.003,-0.078 0,-0.078 C 225.138,1.718 221.641,-2 216.634,-2 l 0,0 z M 149.06,58.135 c 0,-3.361 2.078,-5.712 7.624,-8.403 11.438,-5.04 40.544,-30.252 53.366,-44.37 2.426,-2.69 4.852,-3.362 6.584,-3.362 3.117,0 4.504,2.354 4.504,5.042 l 0,0 0,0 -1.387,35.631 4,0 0,0 0.003,0 0,0 40.009,0 c 1.64,0 2.633,1.046 2.639,2.148 0.002,0.294 -0.066,0.593 -0.212,0.876 l -3.47,14.455 c -0.344,1.346 -1.038,2.69 -3.116,2.69 l -40.543,0 c -0.683,13.567 -0.693,29.414 -0.693,44.653 0,0.242 0,0.483 0,0.725 l 0,26.556 c 0,27.563 10.742,33.615 19.057,33.615 7.279,0 12.479,-1.008 18.021,-4.033 0.38,-0.246 0.76,-0.403 1.141,-0.403 0.659,0 1.319,0.468 1.98,1.746 l 2.424,5.041 c 0.292,0.474 0.42,0.946 0.422,1.404 0.006,1.17 -0.812,2.241 -1.809,2.966 -5.892,4.037 -21.483,13.449 -48.514,13.449 -23.564,0 -38.465,-15.799 -38.465,-31.262 l 0,0 0,0 c 0,-11.767 0.692,-37.313 0.692,-50.086 l 0.316,-40.371 0,0 0,0 0,0 0.031,-4 -19.06,0 c -3.118,0 -5.544,-1.344 -5.544,-4.707 l 0,0 0,0 z"/>
+  </g>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#555555"/>
+    </marker>
+    <marker id="arrowRed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c0605c"/>
+    </marker>
+  </defs>
+
+  <!-- background -->
+  <rect x="0" y="0" width="1760" height="1300" fill="#ffffff"/>
+
+  <!-- title -->
+  <text x="880" y="50" text-anchor="middle" font-size="28" font-weight="bold" fill="#1a1a1a">OmegaT — Architecture Overview — ΩᵗAO</text>
+  <text x="880" y="78" text-anchor="middle" font-size="14" fill="#666666">Components, event flow and editor internals · src/main/java/org/omegat · July 2026</text>
+
+  <!-- legend -->
+  <line x1="1500" y1="44" x2="1544" y2="44" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="1552" y="48" font-size="11.5" fill="#444444">call / composition</text>
+  <line x1="1500" y1="68" x2="1544" y2="68" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="1552" y="72" font-size="11.5" fill="#444444">event flow (async, on the EDT)</text>
+
+  <!-- Main -->
+  <rect x="800" y="104" width="160" height="46" rx="8" fill="#ffffff" stroke="#888888" stroke-width="1.4"/>
+  <text x="880" y="124" text-anchor="middle" font-size="15" font-weight="bold" fill="#222222">Main</text>
+  <text x="880" y="141" text-anchor="middle" font-size="11.5" fill="#666666">bootstrap (CLI / GUI)</text>
+  <line x1="880" y1="150" x2="880" y2="174" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+
+  <!-- Core hub -->
+  <rect x="240" y="178" width="1280" height="76" rx="10" fill="#fff3cd" stroke="#c9971a" stroke-width="1.6"/>
+  <text x="880" y="206" text-anchor="middle" font-size="17" font-weight="bold" fill="#222222">Core — static service hub</text>
+  <text x="880" y="232" text-anchor="middle" font-size="13" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#554400">Core.getProject() · Core.getEditor() · Core.getMainWindow() · Core.getMatcher() · Core.getSpellChecker() · Core.registerMarker(…)</text>
+
+  <!-- arrows Core -> components -->
+  <line x1="300" y1="254" x2="300" y2="294" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <line x1="880" y1="254" x2="880" y2="294" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <line x1="1460" y1="254" x2="1460" y2="294" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+
+  <!-- ============ column A: project ============ -->
+  <rect x="40" y="296" width="520" height="64" rx="8" fill="#dfeefb" stroke="#4a7ba6" stroke-width="1.5"/>
+  <text x="300" y="322" text-anchor="middle" font-size="15" font-weight="bold" fill="#1d3f5e">IProject — RealProject · NotLoadedProject</text>
+  <text x="300" y="344" text-anchor="middle" font-size="12" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#44607a">org.omegat.core.data</text>
+  <line x1="300" y1="360" x2="300" y2="372" stroke="#555555" stroke-width="1.4"/>
+
+  <rect x="40" y="372" width="520" height="290" rx="8" fill="#f0f7f0" stroke="#6a9a6a" stroke-width="1.3"/>
+  <text x="60" y="398" font-size="13.5" font-weight="bold" fill="#2c522c">Data model &amp; project I/O</text>
+  <g font-size="12.5" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#333333">
+    <text x="60" y="428">SourceTextEntry — one source segment</text>
+    <text x="60" y="454">TMXEntry — a stored translation</text>
+    <text x="60" y="480">ProjectTMX — project memory (project_save.tmx)</text>
+    <text x="60" y="506">ProjectProperties — omegat.project settings</text>
+    <text x="60" y="532">team2/ — team project sync via Git / SVN</text>
+    <text x="60" y="558">core.threads — SaveThread (autosave)</text>
+  </g>
+
+  <!-- ============ column B: editor ============ -->
+  <rect x="620" y="296" width="520" height="64" rx="8" fill="#dfeefb" stroke="#4a7ba6" stroke-width="1.5"/>
+  <text x="880" y="322" text-anchor="middle" font-size="15" font-weight="bold" fill="#1d3f5e">IEditor — EditorController</text>
+  <text x="880" y="344" text-anchor="middle" font-size="12" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#44607a">org.omegat.gui.editor</text>
+  <line x1="880" y1="360" x2="880" y2="372" stroke="#555555" stroke-width="1.4"/>
+
+  <rect x="620" y="372" width="520" height="290" rx="8" fill="#eef3fb" stroke="#5b7fb8" stroke-width="1.3"/>
+  <text x="640" y="398" font-size="13.5" font-weight="bold" fill="#2a4470">Editor internals</text>
+  <g font-size="12.5" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#333333">
+    <text x="640" y="428">SegmentBuilder — renders one segment</text>
+    <text x="640" y="454">MarkerController — runs the IMarker pipeline</text>
+    <text x="640" y="480">mark/ — IMarker impls (Identical…, ComesFromMT…)</text>
+    <text x="640" y="506">EditorSettings — view options (marks, colours)</text>
+    <text x="640" y="558">filter/ — editor document filtering</text>
+  </g>
+
+  <!-- ============ column C: main window ============ -->
+  <rect x="1200" y="296" width="520" height="64" rx="8" fill="#dfeefb" stroke="#4a7ba6" stroke-width="1.5"/>
+  <text x="1460" y="322" text-anchor="middle" font-size="15" font-weight="bold" fill="#1d3f5e">IMainWindow — MainWindow</text>
+  <text x="1460" y="344" text-anchor="middle" font-size="12" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#44607a">org.omegat.gui.main</text>
+  <line x1="1460" y1="360" x2="1460" y2="372" stroke="#555555" stroke-width="1.4"/>
+
+  <rect x="1200" y="372" width="520" height="128" rx="8" fill="#eef3fb" stroke="#5b7fb8" stroke-width="1.3"/>
+  <text x="1220" y="398" font-size="13.5" font-weight="bold" fill="#2a4470">Menus &amp; frame</text>
+  <g font-size="12.5" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#333333">
+    <text x="1220" y="428">BaseMainWindowMenu — menu construction</text>
+    <text x="1220" y="454">MainWindowMenuHandler — menu actions</text>
+    <text x="1220" y="480">docking framework — hosts the panes below</text>
+  </g>
+
+  <rect x="1200" y="514" width="520" height="148" rx="8" fill="#e6f6f4" stroke="#3f9187" stroke-width="1.3"/>
+  <text x="1220" y="540" font-size="13.5" font-weight="bold" fill="#1e5b53">Preferences — org.omegat.gui.preferences</text>
+  <g font-size="12.5" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#333333">
+    <text x="1220" y="570">PreferencesWindowController — dialog shell</text>
+    <text x="1220" y="596">view/*Controller extend BasePreferencesController</text>
+    <text x="1220" y="622">e.g. CustomColorSelection·, Appearance·, Editing·</text>
+  </g>
+
+  <!-- fires arrows into the bus -->
+  <line x1="300" y1="662" x2="300" y2="704" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="312" y="690" font-size="11.5" fill="#a34844">fires project events</text>
+  <line x1="880" y1="662" x2="880" y2="704" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="892" y="690" font-size="11.5" fill="#a34844">fires entry events</text>
+
+  <!-- ============ event bus ============ -->
+  <rect x="40" y="706" width="1680" height="84" rx="10" fill="#fdeaea" stroke="#c0605c" stroke-width="1.6"/>
+  <text x="880" y="736" text-anchor="middle" font-size="16" font-weight="bold" fill="#7a2e2b">CoreEvents — application event bus (delivered on the EDT via SwingUtilities.invokeLater)</text>
+  <text x="880" y="764" text-anchor="middle" font-size="12.5" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#5c3331">fireProjectChange(LOAD·SAVE·COMPILE·CLOSE) · fireEntryActivated · fireFontChanged · fireApplicationStartup/Shutdown — IProjectEventListener · IEntryEventListener · …</text>
+
+  <!-- listen arrows to the panes -->
+  <line x1="500" y1="790" x2="500" y2="832" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="512" y="818" font-size="11.5" fill="#a34844">listen</text>
+  <line x1="1250" y1="790" x2="1250" y2="832" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="1262" y="818" font-size="11.5" fill="#a34844">listen</text>
+
+  <!-- ============ panes ============ -->
+  <rect x="40" y="834" width="1680" height="210" rx="10" fill="#f4effb" stroke="#7d5fa8" stroke-width="1.5"/>
+  <text x="60" y="862" font-size="14.5" font-weight="bold" fill="#4a3572">Dockable panes — event consumers (org.omegat.gui.*) · read the model via Core.getProject()</text>
+
+  <!-- pane boxes row 1 -->
+  <g>
+    <rect x="66" y="876" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="195" y="900" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Matches</text>
+    <text x="195" y="922" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">MatchesTextArea · VarExpansion</text>
+
+    <rect x="336" y="876" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="465" y="900" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Glossary</text>
+    <text x="465" y="922" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">GlossaryTextArea</text>
+
+    <rect x="606" y="876" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="735" y="900" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Dictionaries</text>
+    <text x="735" y="922" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">DictionariesTextArea</text>
+
+    <rect x="876" y="876" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="1005" y="900" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Machine Translation</text>
+    <text x="1005" y="922" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">gui.exttrans</text>
+
+    <rect x="1146" y="876" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="1275" y="900" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Notes · Comments</text>
+    <text x="1275" y="922" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">gui.notes · gui.comments</text>
+
+    <rect x="1416" y="876" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="1545" y="900" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Multiple Translations</text>
+    <text x="1545" y="922" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">gui.multtrans</text>
+  </g>
+
+  <!-- pane boxes row 2 -->
+  <g>
+    <rect x="66" y="948" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="195" y="972" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Segment Properties</text>
+    <text x="195" y="994" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">gui.properties</text>
+
+    <rect x="336" y="948" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="465" y="972" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Project Files</text>
+    <text x="465" y="994" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">ProjectFilesListController</text>
+
+    <rect x="606" y="948" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="735" y="972" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Issues</text>
+    <text x="735" y="994" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">gui.issues — provider registry</text>
+
+    <rect x="876" y="948" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="1005" y="972" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Search</text>
+    <text x="1005" y="994" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">gui.search — Search window</text>
+
+    <rect x="1146" y="948" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="1275" y="972" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Scripting</text>
+    <text x="1275" y="994" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">ScriptingWindow · ScriptsMonitor</text>
+
+    <rect x="1416" y="948" width="258" height="64" rx="6" fill="#ffffff" stroke="#9a83bd" stroke-width="1"/>
+    <text x="1545" y="972" text-anchor="middle" font-size="13" font-weight="bold" fill="#333333">Statistics</text>
+    <text x="1545" y="994" text-anchor="middle" font-size="11.5" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">gui.stat</text>
+  </g>
+
+  <!-- ============ cross-cutting ============ -->
+  <g>
+    <rect x="40" y="1078" width="405" height="140" rx="8" fill="#f2f2f2" stroke="#8a8a8a" stroke-width="1.2"/>
+    <text x="60" y="1106" font-size="14" font-weight="bold" fill="#333333">File filters</text>
+    <g font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#444444">
+      <text x="60" y="1134">filters2 / filters3 / filters4</text>
+      <text x="60" y="1158">IFilter implementations, one per format</text>
+      <text x="60" y="1182">(plugin-like registry)</text>
+    </g>
+
+    <rect x="465" y="1078" width="405" height="140" rx="8" fill="#f2f2f2" stroke="#8a8a8a" stroke-width="1.2"/>
+    <text x="485" y="1106" font-size="14" font-weight="bold" fill="#333333">Segmentation &amp; matching</text>
+    <g font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#444444">
+      <text x="485" y="1134">core.segmentation — SRX · Segmenter</text>
+      <text x="485" y="1158">core.matching — NearString,</text>
+      <text x="485" y="1182">fuzzy scoring (tokens, Levenshtein)</text>
+    </g>
+
+    <rect x="890" y="1078" width="405" height="140" rx="8" fill="#f2f2f2" stroke="#8a8a8a" stroke-width="1.2"/>
+    <text x="910" y="1106" font-size="14" font-weight="bold" fill="#333333">MT · spellcheck · modules</text>
+    <g font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#444444">
+      <text x="910" y="1134">core.machinetranslators · core.spellchecker</text>
+      <text x="910" y="1158">Gradle submodules: machinetranslators/,</text>
+      <text x="910" y="1182">spellchecker/, language-modules/, theme/, …</text>
+    </g>
+
+    <rect x="1315" y="1078" width="405" height="140" rx="8" fill="#f2f2f2" stroke="#8a8a8a" stroke-width="1.2"/>
+    <text x="1335" y="1106" font-size="14" font-weight="bold" fill="#333333">Utilities</text>
+    <g font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#444444">
+      <text x="1335" y="1134">util — Preferences · OStrings · Log</text>
+      <text x="1335" y="1158">util.gui — Styles.EditorColor,</text>
+      <text x="1335" y="1182">UIDesignManager</text>
+    </g>
+  </g>
+
+  <!-- footer -->
+  <text x="40" y="1266" font-size="11.5" fill="#888888">Snapshot of master, end of July 2026, not automatically updated. Companion docs: src/docs/developer/21.OmegaTInternals.md · 22.CoreEvents.md · 23.CoreMethods.md · 36.SourceTree.md</text>
+  <circle cx="30" cy="1284.2" r="5.6" fill="none" stroke="#5f6b71" stroke-width="1.1"/>
+  <path d="M 27.2,1282.5 A 3.3 3.3 0 1 1 27.2,1285.9" fill="none" stroke="#5f6b71" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="42" y="1288" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#5f6b71">2026  -  OmegaT - Computer Assisted Translation (CAT) tool  -  This file is part of OmegaT, released under the GNU General Public License v3 or later</text>
+  <text x="42" y="1303" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#5f6b71">OmegaT is distributed WITHOUT ANY WARRANTY, without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE - see the GNU General Public License for more details.</text>
+</svg>

--- a/src/docs/developer/assets/omegat-event-flow-overview.svg
+++ b/src/docs/developer/assets/omegat-event-flow-overview.svg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OmegaT event flow overview diagram (editable SVG).
+  Event-centric companion to omegat-architecture-overview.svg and to
+  src/docs/developer/22.CoreEvents.md. Includes map-style overlays:
+  core/GUI territories, the EDT boundary, and numbered hazard pins.
+
+  🄯 2026 - This file is part of OmegaT, released under the GNU General
+  Public License version 3 or (at your option) any later version.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1760 1720" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <g transform="translate(24,10) scale(0.16)">
+    <path fill="#1e282c" d="m 145.84482,32.68197 c -17.435,0 -33.882,2.683 -48.883002,7.973 -14.783,5.214 -27.816,12.832 -38.737,22.641 -11.013,9.892 -19.58,21.744 -25.462,35.229 -6.042,13.851 -9.105,29.115 -9.105,45.37 0,21.473 7.679,41.858 22.823,60.588 7.582,9.379 16.92,18.207 27.854,26.347 l -14.577,0 c -8.347,0 -12.896,-0.369 -16.173,-2.465 -3.317,-2.122 -6.026,-6.481 -9.66,-15.545 -0.609,-1.518 -2.079,-2.511 -3.713,-2.511 l -10.212,0 c -1.135,0 -2.216,0.481 -2.975,1.325 -0.759,0.845 -1.123,1.972 -1.002,3.1 l 6.201,58.031 c 0.217,2.032 1.932,3.574 3.977,3.574 l 93.382002,0 c 1.417,0 2.728,-0.75 3.447,-1.971 l 2.917,-4.955 c 0.735,-1.248 0.737,-2.797 0.006,-4.048 l -0.507,-0.867 c -6.861,-11.732 -17.231,-29.463 -25.685002,-50.082 -4.62,-11.265 -8.205,-22.288 -10.656,-32.763 -2.861,-12.226 -4.27,-24.086 -4.188,-35.254 0,-0.009 0,-0.019 0,-0.029 0,-14.669 1.357,-27.923 4.033,-39.395 2.639,-11.314 6.581,-20.977 11.715002,-28.719 10.305,-15.542 25.384,-23.422 44.816,-23.422 19.577,0 34.775,7.661 45.174,22.771 5.137,7.465 9.082,16.756 11.725,27.616 2.674,10.988 4.03,23.643 4.03,37.612 0,22.021 -5.354,46.297 -15.911,72.155 -8.788,21.52 -19.212,39.359 -25.44,50.018 l -0.416,0.712 c -0.794,1.36 -0.717,3.06 0.197,4.342 l 3.283,4.603 c 0.751,1.052 1.964,1.677 3.257,1.677 l 91.923,0 c 1.988,0 3.674,-1.46 3.959,-3.428 l 8.392,-58.031 c 0.166,-1.147 -0.175,-2.313 -0.936,-3.189 -0.76,-0.878 -1.862,-1.382 -3.023,-1.382 l -10.216,0 c -1.611,0 -3.064,0.966 -3.688,2.45 -3.762,8.958 -6.614,13.492 -9.842,15.649 -3.081,2.059 -7.149,2.421 -14.558,2.421 l -19.256,0 c 10.409,-8.448 22.111,-18.599 31.947,-31.103 6.544,-8.32 11.629,-16.954 15.112,-25.663 4.054,-10.133 6.108,-20.76 6.108,-31.585 0,-15.938 -3.008,-30.927 -8.938,-44.549 -5.799,-13.318 -14.252,-25.029 -25.125,-34.809 -10.83,-9.742 -23.774,-17.308 -38.474,-22.488 -14.97,-5.275 -31.429,-7.951 -48.92,-7.951 l 0,0 z m -118.187002,111.213 c 0,-64.045 49.244001,-107.213 118.187002,-107.213 69.307,0 117.458,43.168 117.458,105.797 l 0,0 0,0 c 0,45.646 -37.572,73.952 -60.553,92.351 l 4,0 0,0 2.41,0 0,0 24.23,0 c 15.321,0 20.063,-1.414 28.088,-20.521 l 10.216,0 0,0 0,0 -8.392,58.03 -91.922,0 -3.283,-4.603 0,0 0,0 c 12.402,-21.231 42.313,-71.829 42.313,-124.903 0,-57.323 -22.25,-91.999 -64.929,-91.999 -42.315,0 -64.564001,35.385 -64.564001,95.536 -0.002,0.292 -0.003,0.584 -0.003,0.877 -0.035,49.569 27.808001,96.569 41.586001,120.137 l 0,0 0,0 -2.917,4.955 -93.382001,0 -6.201001,-58.029 0,0 0,0 10.212001,0 c 7.660999,19.106 12.404999,20.521 29.545999,20.521 l 20.159,0 0,0 3.202001,0 0,0 4,0 c -20.793001,-13.446 -59.461001,-43.876 -59.461001,-90.936 l 0,0 0,0 z"/>
+    <path fill="#ef3b39" d="m 216.634,-2 c -2.431,0 -6.061,0.811 -9.55,4.678 0,0 0.001,-10e-4 0.002,-10e-4 -12.968,14.276 -41.592,38.801 -52.015,43.395 l -0.067,0.029 -0.066,0.032 c -4.885,2.37 -9.878,5.65 -9.878,12.002 0,2.827 1.132,5.242 3.185,6.801 1.667,1.265 3.807,1.906 6.361,1.906 l 15.028,0 -0.316,40.34 0,0.015 0,0.016 c 0,6.482 -0.182,16.369 -0.356,25.93 -0.173,9.441 -0.336,18.357 -0.336,24.156 0,8.939 4.283,17.845 11.75,24.43 3.834,3.38 8.338,6.031 13.389,7.878 5.359,1.96 11.189,2.954 17.326,2.954 19.707,0 37.266,-4.894 50.775,-14.149 l 0.046,-0.032 0.046,-0.032 c 3.351,-2.438 4.382,-6.308 2.564,-9.492 l -2.351,-4.887 -0.024,-0.054 -0.027,-0.052 c -1.671,-3.229 -3.932,-3.908 -5.533,-3.908 -1.076,0 -2.141,0.321 -3.168,0.952 -4.635,2.506 -9.133,3.484 -15.994,3.484 -3.84,0 -7.019,-1.641 -9.449,-4.874 -1.67,-2.224 -2.989,-5.201 -3.924,-8.852 -1.118,-4.365 -1.684,-9.711 -1.684,-15.889 l 0,-26.556 c 0,-14.072 0,-28.579 0.517,-41.378 l 36.72,0 c 1.664,0 5.678,-0.555 6.991,-5.7 l 0.009,-0.028 0.007,-0.029 3.387,-14.113 c 0.671,-1.711 0.509,-3.624 -0.467,-5.223 -1.175,-1.926 -3.331,-3.076 -5.768,-3.076 l -39.854,0 1.225,-31.475 0.003,-0.078 0,-0.078 C 225.138,1.718 221.641,-2 216.634,-2 l 0,0 z M 149.06,58.135 c 0,-3.361 2.078,-5.712 7.624,-8.403 11.438,-5.04 40.544,-30.252 53.366,-44.37 2.426,-2.69 4.852,-3.362 6.584,-3.362 3.117,0 4.504,2.354 4.504,5.042 l 0,0 0,0 -1.387,35.631 4,0 0,0 0.003,0 0,0 40.009,0 c 1.64,0 2.633,1.046 2.639,2.148 0.002,0.294 -0.066,0.593 -0.212,0.876 l -3.47,14.455 c -0.344,1.346 -1.038,2.69 -3.116,2.69 l -40.543,0 c -0.683,13.567 -0.693,29.414 -0.693,44.653 0,0.242 0,0.483 0,0.725 l 0,26.556 c 0,27.563 10.742,33.615 19.057,33.615 7.279,0 12.479,-1.008 18.021,-4.033 0.38,-0.246 0.76,-0.403 1.141,-0.403 0.659,0 1.319,0.468 1.98,1.746 l 2.424,5.041 c 0.292,0.474 0.42,0.946 0.422,1.404 0.006,1.17 -0.812,2.241 -1.809,2.966 -5.892,4.037 -21.483,13.449 -48.514,13.449 -23.564,0 -38.465,-15.799 -38.465,-31.262 l 0,0 0,0 c 0,-11.767 0.692,-37.313 0.692,-50.086 l 0.316,-40.371 0,0 0,0 0,0 0.031,-4 -19.06,0 c -3.118,0 -5.544,-1.344 -5.544,-4.707 l 0,0 0,0 z"/>
+  </g>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#555555"/>
+    </marker>
+    <marker id="arrowRed" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c0605c"/>
+    </marker>
+  </defs>
+
+  <!-- background -->
+  <rect x="0" y="0" width="1760" height="1700" fill="#ffffff"/>
+
+  <!-- title -->
+  <text x="880" y="50" text-anchor="middle" font-size="28" font-weight="bold" fill="#1a1a1a">OmegaT — Event Flow Map — ΩᵗEFMap</text>
+  <text x="880" y="78" text-anchor="middle" font-size="14" fill="#666666">Who fires what, where it is delivered, who reacts — with core/GUI territories and known hazards · org.omegat.core.CoreEvents · July 2026</text>
+
+  <!-- legend -->
+  <line x1="1490" y1="38" x2="1534" y2="38" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="1542" y="42" font-size="11.5" fill="#444444">synchronous call</text>
+  <line x1="1490" y1="60" x2="1534" y2="60" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="1542" y="64" font-size="11.5" fill="#444444">asynchronous hop (thread change)</text>
+  <circle cx="1512" cy="82" r="9" fill="#c0392b"/>
+  <text x="1512" y="86" text-anchor="middle" font-size="11" font-weight="bold" fill="#ffffff">n</text>
+  <text x="1542" y="86" font-size="11.5" fill="#444444">known trouble spot (hazard list below)</text>
+
+  <!-- ============ event catalogue ============ -->
+  <rect x="40" y="100" width="1680" height="180" rx="10" fill="#fff3cd" stroke="#c9971a" stroke-width="1.5"/>
+  <text x="60" y="128" font-size="15" font-weight="bold" fill="#554400">Event catalogue — CoreEvents fire methods, listener interfaces, typical consumers</text>
+  <g font-size="12.5" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#4a3d10">
+    <text x="60" y="158">fireApplicationStartup / fireApplicationShutdown  →  IApplicationEventListener   — plugin bootstrap and teardown</text>
+    <text x="60" y="184">fireProjectChange(CREATE·LOAD·SAVE·COMPILE·CLOSE·MODIFIED)  →  IProjectEventListener   — panes, menus, ScriptsMonitor</text>
+    <text x="60" y="210">fireEntryNewFile / fireEntryActivated  →  IEntryEventListener   — matches, glossary, dictionaries, MT, segment properties</text>
+    <text x="60" y="236">fireFontChanged  →  IFontChangedEventListener   — editor and panes re-apply the display font</text>
+    <text x="60" y="262">fireEditorNewWord  →  IEditorEventListener   — reacts to a newly typed word (e.g. event scripts)</text>
+  </g>
+  <circle cx="905" cy="154" r="11" fill="#c0392b"/>
+  <text x="905" y="158" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">1</text>
+  <circle cx="935" cy="232" r="11" fill="#c0392b"/>
+  <text x="935" y="236" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">4</text>
+
+  <!-- ============ territories (map layer, behind everything below) ============ -->
+  <rect x="55" y="296" width="715" height="895" rx="14" fill="#fff9e6" opacity="0.55"/>
+  <rect x="820" y="296" width="810" height="895" rx="14" fill="#f5f0fb" opacity="0.45"/>
+  <text x="412" y="1178" text-anchor="middle" font-size="12.5" font-weight="bold" letter-spacing="2" fill="#a8842a">CORE TERRITORY — org.omegat.core.* (headless)</text>
+  <text x="1225" y="1178" text-anchor="middle" font-size="12.5" font-weight="bold" letter-spacing="2" fill="#7d5fa8">GUI TERRITORY — org.omegat.gui.* (Swing)</text>
+
+  <!-- EDT boundary -->
+  <line x1="795" y1="296" x2="795" y2="1156" stroke="#c9971a" stroke-width="1.4" stroke-dasharray="8,6"/>
+  <text x="795" y="374" text-anchor="middle" font-size="11.5" fill="#996f1a">⇠ core  |  GUI ⇢   EDT boundary — cross only via invokeLater / SwingWorker</text>
+
+  <!-- ============ swimlane headers ============ -->
+  <rect x="90" y="306" width="320" height="50" rx="8" fill="#dfeefb" stroke="#4a7ba6" stroke-width="1.4"/>
+  <text x="250" y="327" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#1d3f5e">Calling thread</text>
+  <text x="250" y="346" text-anchor="middle" font-size="11.5" fill="#44607a">background · SwingWorker</text>
+
+  <rect x="500" y="306" width="240" height="50" rx="8" fill="#fdeaea" stroke="#c0605c" stroke-width="1.4"/>
+  <text x="620" y="327" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#7a2e2b">CoreEvents</text>
+  <text x="620" y="346" text-anchor="middle" font-size="11.5" fill="#8c5350">static event bus</text>
+  <circle cx="738" cy="308" r="11" fill="#c0392b"/>
+  <text x="738" y="312" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">2</text>
+
+  <rect x="850" y="306" width="320" height="50" rx="8" fill="#f4effb" stroke="#7d5fa8" stroke-width="1.4"/>
+  <text x="1010" y="327" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#4a3572">EDT</text>
+  <text x="1010" y="346" text-anchor="middle" font-size="11.5" fill="#6a5590">Swing event dispatch thread — listeners</text>
+  <circle cx="1168" cy="308" r="11" fill="#c0392b"/>
+  <text x="1168" y="312" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">3</text>
+
+  <rect x="1290" y="306" width="320" height="50" rx="8" fill="#f2f2f2" stroke="#8a8a8a" stroke-width="1.4"/>
+  <text x="1450" y="327" text-anchor="middle" font-size="13.5" font-weight="bold" fill="#333333">Worker threads</text>
+  <text x="1450" y="346" text-anchor="middle" font-size="11.5" fill="#666666">matcher · scripts · MT connectors</text>
+
+  <!-- lifelines -->
+  <line x1="250" y1="356" x2="250" y2="1156" stroke="#bbbbbb" stroke-width="1" stroke-dasharray="3,5"/>
+  <line x1="620" y1="356" x2="620" y2="1156" stroke="#bbbbbb" stroke-width="1" stroke-dasharray="3,5"/>
+  <line x1="1010" y1="356" x2="1010" y2="1156" stroke="#bbbbbb" stroke-width="1" stroke-dasharray="3,5"/>
+  <line x1="1450" y1="356" x2="1450" y2="1156" stroke="#bbbbbb" stroke-width="1" stroke-dasharray="3,5"/>
+
+  <!-- ============ section 1: LOAD ============ -->
+  <rect x="40" y="388" width="1680" height="30" rx="6" fill="#eef3fb"/>
+  <text x="60" y="409" font-size="13.5" font-weight="bold" fill="#2a4470">① Open a project — fireProjectChange(LOAD)</text>
+
+  <rect x="120" y="432" width="260" height="34" rx="6" fill="#ffffff" stroke="#4a7ba6" stroke-width="1.1"/>
+  <text x="250" y="454" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#333333">RealProject.loadProject()</text>
+
+  <line x1="250" y1="486" x2="612" y2="486" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="431" y="478" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">fireProjectChange(LOAD)</text>
+
+  <line x1="620" y1="526" x2="1002" y2="526" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="811" y="518" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#a34844">invokeLater → onProjectChanged(LOAD)</text>
+
+  <rect x="855" y="548" width="310" height="52" rx="6" fill="#f4effb" stroke="#7d5fa8" stroke-width="1.1"/>
+  <text x="1010" y="569" text-anchor="middle" font-size="12" fill="#4a3572">EditorController loads the document,</text>
+  <text x="1010" y="588" text-anchor="middle" font-size="12" fill="#4a3572">panes refresh, menus enable</text>
+
+  <line x1="1010" y1="622" x2="1442" y2="622" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="1226" y="614" text-anchor="middle" font-size="12" fill="#a34844">ScriptsMonitor runs project_changed scripts (SwingWorker)</text>
+
+  <!-- ============ section 2: entry activated ============ -->
+  <rect x="40" y="656" width="1680" height="30" rx="6" fill="#eef3fb"/>
+  <text x="60" y="677" font-size="13.5" font-weight="bold" fill="#2a4470">② Activate a segment — fireEntryActivated(SourceTextEntry)</text>
+
+  <rect x="855" y="700" width="310" height="34" rx="6" fill="#ffffff" stroke="#7d5fa8" stroke-width="1.1"/>
+  <text x="1010" y="722" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#333333">EditorController.activateEntry()</text>
+
+  <line x1="1010" y1="754" x2="628" y2="754" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="819" y="746" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">fireEntryActivated(ste)</text>
+
+  <line x1="620" y1="794" x2="1002" y2="794" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="811" y="786" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#a34844">invokeLater (queued) → onEntryActivated</text>
+
+  <rect x="855" y="816" width="310" height="52" rx="6" fill="#f4effb" stroke="#7d5fa8" stroke-width="1.1"/>
+  <text x="1010" y="837" text-anchor="middle" font-size="12" fill="#4a3572">Matches · Glossary · Dictionaries ·</text>
+  <text x="1010" y="856" text-anchor="middle" font-size="12" fill="#4a3572">MT · Segment Properties update</text>
+  <circle cx="1163" cy="818" r="11" fill="#c0392b"/>
+  <text x="1163" y="822" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">4</text>
+
+  <line x1="1010" y1="890" x2="1442" y2="890" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="1226" y="882" text-anchor="middle" font-size="12" fill="#555555">FindMatchesThread — fuzzy search off the EDT</text>
+
+  <line x1="1450" y1="928" x2="1018" y2="928" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="1234" y="920" text-anchor="middle" font-size="12" fill="#a34844">results → EDT: MatchesTextArea shows best matches</text>
+
+  <!-- ============ section 3: COMPILE ============ -->
+  <rect x="40" y="964" width="1680" height="30" rx="6" fill="#eef3fb"/>
+  <text x="60" y="985" font-size="13.5" font-weight="bold" fill="#2a4470">③ Create translated documents — fireProjectChange(COMPILE)</text>
+
+  <rect x="105" y="1008" width="290" height="34" rx="6" fill="#ffffff" stroke="#4a7ba6" stroke-width="1.1"/>
+  <text x="250" y="1030" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#333333">compileProjectAndCommit()</text>
+
+  <line x1="250" y1="1062" x2="612" y2="1062" stroke="#555555" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="431" y="1054" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#555555">fireProjectChange(COMPILE)</text>
+
+  <line x1="620" y1="1102" x2="1002" y2="1102" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="811" y="1094" text-anchor="middle" font-size="12" font-family="ui-monospace, Menlo, Consolas, monospace" fill="#a34844">invokeLater → listeners</text>
+
+  <line x1="1010" y1="1102" x2="1442" y2="1102" stroke="#c0605c" stroke-width="1.6" stroke-dasharray="5,4" marker-end="url(#arrowRed)"/>
+  <text x="1226" y="1094" text-anchor="middle" font-size="12" fill="#a34844">event scripts as SwingWorker</text>
+
+  <rect x="105" y="1086" width="290" height="52" rx="6" fill="#ffffff" stroke="#4a7ba6" stroke-width="1.1"/>
+  <text x="250" y="1107" text-anchor="middle" font-size="12" fill="#333333">caller continues immediately:</text>
+  <text x="250" y="1126" text-anchor="middle" font-size="12" fill="#333333">commit target files (team project)</text>
+
+  <rect x="105" y="1146" width="1060" height="34" rx="6" fill="#fdeaea" stroke="#c0605c" stroke-width="1.2"/>
+  <circle cx="105" cy="1146" r="11" fill="#c0392b"/>
+  <text x="105" y="1150" text-anchor="middle" font-size="12" font-weight="bold" fill="#ffffff">5</text>
+  <text x="640" y="1168" text-anchor="middle" font-size="12" fill="#7a2e2b">fire* never blocks — COMPILE listeners and their scripts may still be running while the commit proceeds (SF-1277)</text>
+
+  <!-- ============ mechanics ============ -->
+  <rect x="40" y="1216" width="1680" height="152" rx="10" fill="#f2f2f2" stroke="#8a8a8a" stroke-width="1.3"/>
+  <text x="60" y="1244" font-size="15" font-weight="bold" fill="#333333">Delivery mechanics</text>
+  <g font-size="12.5" fill="#444444">
+    <text x="60" y="1272">• Every fire* method wraps delivery in SwingUtilities.invokeLater — listeners always run on the EDT, and the caller never waits for them.</text>
+    <text x="60" y="1298">• Listeners run in registration order; each call is individually try/catch-ed and logged (ERROR_EVENT_…), so one broken listener cannot break the loop.</text>
+    <text x="60" y="1324">• Components and plugins subscribe statically: CoreEvents.register…Listener(…) / unregister…Listener(…) — from anywhere, at any time.</text>
+    <text x="60" y="1350">• Rule of thumb: react quickly on the EDT and push long work to a SwingWorker — the matcher, the event scripts and the MT connectors all do exactly that.</text>
+  </g>
+
+  <!-- ============ hazard list ============ -->
+  <rect x="40" y="1392" width="1680" height="238" rx="10" fill="#fdf3f3" stroke="#c0605c" stroke-width="1.4"/>
+  <text x="60" y="1420" font-size="15" font-weight="bold" fill="#7a2e2b">Known trouble spots — hazard map</text>
+  <g font-size="12.5" fill="#5c3331">
+    <circle cx="72" cy="1444" r="10" fill="#c0392b"/>
+    <text x="72" y="1448" text-anchor="middle" font-size="11.5" font-weight="bold" fill="#ffffff">1</text>
+    <text x="94" y="1448">APPLICATION_STARTUP fires before most listeners could register (startup scripts run from ScriptsMonitor.start() instead); SHUTDOWN scripts may be cut off — the JVM can exit first (FIXME in ScriptsMonitor).</text>
+
+    <circle cx="72" cy="1482" r="10" fill="#c0392b"/>
+    <text x="72" y="1486" text-anchor="middle" font-size="11.5" font-weight="bold" fill="#ffffff">2</text>
+    <text x="94" y="1486">CoreEvents is a static, mutable singleton bus: hidden coupling between components, registration-order sensitivity, and tests need TestCoreInitializer scaffolding.</text>
+
+    <circle cx="72" cy="1520" r="10" fill="#c0392b"/>
+    <text x="72" y="1524" text-anchor="middle" font-size="11.5" font-weight="bold" fill="#ffffff">3</text>
+    <text x="94" y="1524">Anything slow inside a listener freezes the whole UI — the EDT is the application's single UI thread. Long work must go to a SwingWorker.</text>
+
+    <circle cx="72" cy="1558" r="10" fill="#c0392b"/>
+    <text x="72" y="1562" text-anchor="middle" font-size="11.5" font-weight="bold" fill="#ffffff">4</text>
+    <text x="94" y="1562">Several panes read colours and fonts only once at construction (MatchesTextArea even caches attribute sets statically) — live updates need an explicit broadcast: fonts have fireFontChanged; colours have no equivalent broadcast yet.</text>
+
+    <circle cx="72" cy="1596" r="10" fill="#c0392b"/>
+    <text x="72" y="1600" text-anchor="middle" font-size="11.5" font-weight="bold" fill="#ffffff">5</text>
+    <text x="94" y="1600">fireProjectChange(COMPILE) is fire-and-forget: committing target files can overtake compile-time event scripts that still modify them (SF-1277).</text>
+  </g>
+
+  <!-- footer -->
+  <text x="40" y="1672" font-size="11.5" fill="#888888">Snapshot of master, end of July 2026, not automatically updated. Companion: omegat-architecture-overview.svg · src/docs/developer/22.CoreEvents.md · 21.OmegaTInternals.md</text>
+  <circle cx="30" cy="1690.2" r="5.6" fill="none" stroke="#5f6b71" stroke-width="1.1"/>
+  <path d="M 27.2,1688.5 A 3.3 3.3 0 1 1 27.2,1691.9" fill="none" stroke="#5f6b71" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="42" y="1694" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#5f6b71">2026  -  OmegaT - Computer Assisted Translation (CAT) tool  -  This file is part of OmegaT, released under the GNU General Public License v3 or later</text>
+  <text x="42" y="1709" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#5f6b71">OmegaT is distributed WITHOUT ANY WARRANTY, without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE - see the GNU General Public License for more details.</text>
+</svg>

--- a/src/docs/developer/assets/omegat-shipping-ballast.svg
+++ b/src/docs/developer/assets/omegat-shipping-ballast.svg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OmegaT shipping ballast map (editable SVG).
+  Size analysis of a full installDist: what could be dropped or restructured
+  without losing any function. Companion to omegat-architecture-overview.svg.
+
+  🄯 2026 - This file is part of OmegaT, released under the GNU General
+  Public License version 3 or (at your option) any later version.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1760 1200" font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <g transform="translate(24,10) scale(0.16)">
+    <path fill="#1e282c" d="m 145.84482,32.68197 c -17.435,0 -33.882,2.683 -48.883002,7.973 -14.783,5.214 -27.816,12.832 -38.737,22.641 -11.013,9.892 -19.58,21.744 -25.462,35.229 -6.042,13.851 -9.105,29.115 -9.105,45.37 0,21.473 7.679,41.858 22.823,60.588 7.582,9.379 16.92,18.207 27.854,26.347 l -14.577,0 c -8.347,0 -12.896,-0.369 -16.173,-2.465 -3.317,-2.122 -6.026,-6.481 -9.66,-15.545 -0.609,-1.518 -2.079,-2.511 -3.713,-2.511 l -10.212,0 c -1.135,0 -2.216,0.481 -2.975,1.325 -0.759,0.845 -1.123,1.972 -1.002,3.1 l 6.201,58.031 c 0.217,2.032 1.932,3.574 3.977,3.574 l 93.382002,0 c 1.417,0 2.728,-0.75 3.447,-1.971 l 2.917,-4.955 c 0.735,-1.248 0.737,-2.797 0.006,-4.048 l -0.507,-0.867 c -6.861,-11.732 -17.231,-29.463 -25.685002,-50.082 -4.62,-11.265 -8.205,-22.288 -10.656,-32.763 -2.861,-12.226 -4.27,-24.086 -4.188,-35.254 0,-0.009 0,-0.019 0,-0.029 0,-14.669 1.357,-27.923 4.033,-39.395 2.639,-11.314 6.581,-20.977 11.715002,-28.719 10.305,-15.542 25.384,-23.422 44.816,-23.422 19.577,0 34.775,7.661 45.174,22.771 5.137,7.465 9.082,16.756 11.725,27.616 2.674,10.988 4.03,23.643 4.03,37.612 0,22.021 -5.354,46.297 -15.911,72.155 -8.788,21.52 -19.212,39.359 -25.44,50.018 l -0.416,0.712 c -0.794,1.36 -0.717,3.06 0.197,4.342 l 3.283,4.603 c 0.751,1.052 1.964,1.677 3.257,1.677 l 91.923,0 c 1.988,0 3.674,-1.46 3.959,-3.428 l 8.392,-58.031 c 0.166,-1.147 -0.175,-2.313 -0.936,-3.189 -0.76,-0.878 -1.862,-1.382 -3.023,-1.382 l -10.216,0 c -1.611,0 -3.064,0.966 -3.688,2.45 -3.762,8.958 -6.614,13.492 -9.842,15.649 -3.081,2.059 -7.149,2.421 -14.558,2.421 l -19.256,0 c 10.409,-8.448 22.111,-18.599 31.947,-31.103 6.544,-8.32 11.629,-16.954 15.112,-25.663 4.054,-10.133 6.108,-20.76 6.108,-31.585 0,-15.938 -3.008,-30.927 -8.938,-44.549 -5.799,-13.318 -14.252,-25.029 -25.125,-34.809 -10.83,-9.742 -23.774,-17.308 -38.474,-22.488 -14.97,-5.275 -31.429,-7.951 -48.92,-7.951 l 0,0 z m -118.187002,111.213 c 0,-64.045 49.244001,-107.213 118.187002,-107.213 69.307,0 117.458,43.168 117.458,105.797 l 0,0 0,0 c 0,45.646 -37.572,73.952 -60.553,92.351 l 4,0 0,0 2.41,0 0,0 24.23,0 c 15.321,0 20.063,-1.414 28.088,-20.521 l 10.216,0 0,0 0,0 -8.392,58.03 -91.922,0 -3.283,-4.603 0,0 0,0 c 12.402,-21.231 42.313,-71.829 42.313,-124.903 0,-57.323 -22.25,-91.999 -64.929,-91.999 -42.315,0 -64.564001,35.385 -64.564001,95.536 -0.002,0.292 -0.003,0.584 -0.003,0.877 -0.035,49.569 27.808001,96.569 41.586001,120.137 l 0,0 0,0 -2.917,4.955 -93.382001,0 -6.201001,-58.029 0,0 0,0 10.212001,0 c 7.660999,19.106 12.404999,20.521 29.545999,20.521 l 20.159,0 0,0 3.202001,0 0,0 4,0 c -20.793001,-13.446 -59.461001,-43.876 -59.461001,-90.936 l 0,0 0,0 z"/>
+    <path fill="#ef3b39" d="m 216.634,-2 c -2.431,0 -6.061,0.811 -9.55,4.678 0,0 0.001,-10e-4 0.002,-10e-4 -12.968,14.276 -41.592,38.801 -52.015,43.395 l -0.067,0.029 -0.066,0.032 c -4.885,2.37 -9.878,5.65 -9.878,12.002 0,2.827 1.132,5.242 3.185,6.801 1.667,1.265 3.807,1.906 6.361,1.906 l 15.028,0 -0.316,40.34 0,0.015 0,0.016 c 0,6.482 -0.182,16.369 -0.356,25.93 -0.173,9.441 -0.336,18.357 -0.336,24.156 0,8.939 4.283,17.845 11.75,24.43 3.834,3.38 8.338,6.031 13.389,7.878 5.359,1.96 11.189,2.954 17.326,2.954 19.707,0 37.266,-4.894 50.775,-14.149 l 0.046,-0.032 0.046,-0.032 c 3.351,-2.438 4.382,-6.308 2.564,-9.492 l -2.351,-4.887 -0.024,-0.054 -0.027,-0.052 c -1.671,-3.229 -3.932,-3.908 -5.533,-3.908 -1.076,0 -2.141,0.321 -3.168,0.952 -4.635,2.506 -9.133,3.484 -15.994,3.484 -3.84,0 -7.019,-1.641 -9.449,-4.874 -1.67,-2.224 -2.989,-5.201 -3.924,-8.852 -1.118,-4.365 -1.684,-9.711 -1.684,-15.889 l 0,-26.556 c 0,-14.072 0,-28.579 0.517,-41.378 l 36.72,0 c 1.664,0 5.678,-0.555 6.991,-5.7 l 0.009,-0.028 0.007,-0.029 3.387,-14.113 c 0.671,-1.711 0.509,-3.624 -0.467,-5.223 -1.175,-1.926 -3.331,-3.076 -5.768,-3.076 l -39.854,0 1.225,-31.475 0.003,-0.078 0,-0.078 C 225.138,1.718 221.641,-2 216.634,-2 l 0,0 z M 149.06,58.135 c 0,-3.361 2.078,-5.712 7.624,-8.403 11.438,-5.04 40.544,-30.252 53.366,-44.37 2.426,-2.69 4.852,-3.362 6.584,-3.362 3.117,0 4.504,2.354 4.504,5.042 l 0,0 0,0 -1.387,35.631 4,0 0,0 0.003,0 0,0 40.009,0 c 1.64,0 2.633,1.046 2.639,2.148 0.002,0.294 -0.066,0.593 -0.212,0.876 l -3.47,14.455 c -0.344,1.346 -1.038,2.69 -3.116,2.69 l -40.543,0 c -0.683,13.567 -0.693,29.414 -0.693,44.653 0,0.242 0,0.483 0,0.725 l 0,26.556 c 0,27.563 10.742,33.615 19.057,33.615 7.279,0 12.479,-1.008 18.021,-4.033 0.38,-0.246 0.76,-0.403 1.141,-0.403 0.659,0 1.319,0.468 1.98,1.746 l 2.424,5.041 c 0.292,0.474 0.42,0.946 0.422,1.404 0.006,1.17 -0.812,2.241 -1.809,2.966 -5.892,4.037 -21.483,13.449 -48.514,13.449 -23.564,0 -38.465,-15.799 -38.465,-31.262 l 0,0 0,0 c 0,-11.767 0.692,-37.313 0.692,-50.086 l 0.316,-40.371 0,0 0,0 0,0 0.031,-4 -19.06,0 c -3.118,0 -5.544,-1.344 -5.544,-4.707 l 0,0 0,0 z"/>
+  </g>
+
+
+  <!-- background -->
+  <rect x="0" y="0" width="1760" height="1200" fill="#ffffff"/>
+
+  <!-- title -->
+  <text x="880" y="50" text-anchor="middle" font-size="28" font-weight="bold" fill="#1a1a1a">OmegaT — Shipping Ballast Map — ΩᵗSBMap</text>
+  <text x="880" y="78" text-anchor="middle" font-size="14" fill="#666666">installDist size anatomy (407 MB, to scale) — what could go without losing function · historic snapshot 2026-08-01, numbers not maintained</text>
+
+  <!-- ============ proportional stacked bar (2.4 px per MB) ============ -->
+  <text x="145" y="128" text-anchor="middle" font-size="14" font-weight="bold" fill="#333333">installDist — 407 MB</text>
+
+  <!-- language module segments -->
+  <g stroke="#ffffff" stroke-width="0.6">
+    <rect x="60" y="140.0" width="170" height="112.6" fill="#ffe9a8"/>
+    <rect x="60" y="252.6" width="170" height="79.0"  fill="#f6dd90"/>
+    <rect x="60" y="331.6" width="170" height="66.7"  fill="#ffe9a8"/>
+    <rect x="60" y="398.3" width="170" height="59.0"  fill="#f6dd90"/>
+    <rect x="60" y="457.3" width="170" height="39.1"  fill="#ffe9a8"/>
+    <rect x="60" y="496.4" width="170" height="35.3"  fill="#f6dd90"/>
+    <rect x="60" y="531.7" width="170" height="32.4"  fill="#ffe9a8"/>
+    <rect x="60" y="564.1" width="170" height="28.8"  fill="#f6dd90"/>
+    <rect x="60" y="592.9" width="170" height="22.1"  fill="#ffe9a8"/>
+    <rect x="60" y="615.0" width="170" height="20.6"  fill="#f6dd90"/>
+    <rect x="60" y="635.6" width="170" height="19.4"  fill="#ffe9a8"/>
+    <rect x="60" y="655.0" width="170" height="15.4"  fill="#f6dd90"/>
+    <rect x="60" y="670.4" width="170" height="14.4"  fill="#ffe9a8"/>
+    <rect x="60" y="684.8" width="170" height="13.0"  fill="#f6dd90"/>
+    <rect x="60" y="697.8" width="170" height="11.0"  fill="#ffe9a8"/>
+    <rect x="60" y="708.8" width="170" height="28.3"  fill="#f6dd90"/>
+  </g>
+  <rect x="60" y="140.0" width="170" height="597.1" fill="none" stroke="#c9971a" stroke-width="1.8"/>
+
+  <!-- lib segments (ballast findings tinted: red = duplicate, orange = replaceable) -->
+  <g stroke="#ffffff" stroke-width="0.6">
+    <rect x="60" y="737.1" width="170" height="34.8"  fill="#dfeefb"/>
+    <rect x="60" y="771.9" width="170" height="24.2"  fill="#f5d0a8"/>
+    <rect x="60" y="796.1" width="170" height="23.5"  fill="#dfeefb"/>
+    <rect x="60" y="819.6" width="170" height="18.5"  fill="#cde2f5"/>
+    <rect x="60" y="838.1" width="170" height="15.1"  fill="#dfeefb"/>
+    <rect x="60" y="853.2" width="170" height="10.8"  fill="#f2b8b4"/>
+    <rect x="60" y="864.0" width="170" height="9.8"   fill="#dfeefb"/>
+    <rect x="60" y="873.8" width="170" height="9.8"   fill="#cde2f5"/>
+    <rect x="60" y="883.6" width="170" height="8.2"   fill="#dfeefb"/>
+    <rect x="60" y="891.8" width="170" height="7.9"   fill="#cde2f5"/>
+    <rect x="60" y="899.7" width="170" height="7.0"   fill="#dfeefb"/>
+    <rect x="60" y="906.7" width="170" height="6.2"   fill="#f5d0a8"/>
+    <rect x="60" y="912.9" width="170" height="135.4" fill="#cde2f5"/>
+  </g>
+  <rect x="60" y="737.1" width="170" height="311.2" fill="none" stroke="#4a7ba6" stroke-width="1.8"/>
+
+  <!-- other segments -->
+  <g stroke="#ffffff" stroke-width="0.6">
+    <rect x="60" y="1048.3" width="170" height="33.1" fill="#ececec"/>
+    <rect x="60" y="1081.4" width="170" height="17.3" fill="#e0e0e0"/>
+    <rect x="60" y="1098.7" width="170" height="10.6" fill="#ececec"/>
+    <rect x="60" y="1109.3" width="170" height="3.1"  fill="#e0e0e0"/>
+    <rect x="60" y="1112.4" width="170" height="2.6"  fill="#ececec"/>
+    <rect x="60" y="1115.0" width="170" height="3.6"  fill="#e0e0e0"/>
+  </g>
+  <rect x="60" y="1048.3" width="170" height="70.3" fill="none" stroke="#8a8a8a" stroke-width="1.8"/>
+
+  <!-- rotated group captions -->
+  <text transform="rotate(-90 44 438)" x="44" y="438" text-anchor="middle" font-size="12.5" font-weight="bold" fill="#a8842a">29 language modules · 249 MB · 61 %</text>
+  <text transform="rotate(-90 44 892)" x="44" y="892" text-anchor="middle" font-size="12.5" font-weight="bold" fill="#4a7ba6">lib/ · 187 jars · 130 MB · 32 %</text>
+  <text x="145" y="1136" text-anchor="middle" font-size="11.5" font-weight="bold" fill="#666666">other · 29 MB · 7 %</text>
+
+  <!-- segment labels with leader ticks -->
+  <g stroke="#999999" stroke-width="0.8">
+    <line x1="232" y1="196"    x2="244" y2="196"/>
+    <line x1="232" y1="292"    x2="244" y2="292"/>
+    <line x1="232" y1="365"    x2="244" y2="365"/>
+    <line x1="232" y1="428"    x2="244" y2="428"/>
+    <line x1="232" y1="477"    x2="244" y2="477"/>
+    <line x1="232" y1="514"    x2="244" y2="514"/>
+    <line x1="232" y1="548"    x2="244" y2="548"/>
+    <line x1="232" y1="578"    x2="244" y2="578"/>
+    <line x1="232" y1="604"    x2="244" y2="604"/>
+    <line x1="232" y1="625"    x2="244" y2="625"/>
+    <line x1="232" y1="645"    x2="244" y2="645"/>
+    <line x1="232" y1="663"    x2="244" y2="663"/>
+    <line x1="232" y1="678"    x2="244" y2="678"/>
+    <line x1="232" y1="691.3"  x2="244" y2="692"/>
+    <line x1="232" y1="703.3"  x2="244" y2="706"/>
+    <line x1="232" y1="723"    x2="244" y2="723"/>
+    <line x1="232" y1="754.5"  x2="244" y2="755"/>
+    <line x1="232" y1="784"    x2="244" y2="784"/>
+    <line x1="232" y1="807.9"  x2="244" y2="808"/>
+    <line x1="232" y1="828.9"  x2="244" y2="829"/>
+    <line x1="232" y1="845.7"  x2="244" y2="846"/>
+    <line x1="232" y1="858.6"  x2="244" y2="860"/>
+    <line x1="232" y1="868.9"  x2="244" y2="874"/>
+    <line x1="232" y1="878.7"  x2="244" y2="888"/>
+    <line x1="232" y1="887.7"  x2="244" y2="902"/>
+    <line x1="232" y1="895.8"  x2="244" y2="916"/>
+    <line x1="232" y1="903.2"  x2="244" y2="930"/>
+    <line x1="232" y1="909.8"  x2="244" y2="944"/>
+    <line x1="232" y1="980.6"  x2="244" y2="981"/>
+    <line x1="232" y1="1064.9" x2="244" y2="1065"/>
+    <line x1="232" y1="1090.1" x2="244" y2="1090"/>
+    <line x1="232" y1="1104"   x2="244" y2="1104"/>
+    <line x1="232" y1="1110.9" x2="244" y2="1118"/>
+    <line x1="232" y1="1113.7" x2="244" y2="1132"/>
+    <line x1="232" y1="1116.8" x2="244" y2="1146"/>
+  </g>
+  <g font-size="10.5" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace" fill="#555555">
+    <text x="248" y="200">nl 46.9</text>
+    <text x="248" y="296">de 32.9</text>
+    <text x="248" y="369">en 27.8</text>
+    <text x="248" y="432">ja 24.6</text>
+    <text x="248" y="481">ru 16.3</text>
+    <text x="248" y="518">ar 14.7</text>
+    <text x="248" y="552">ga 13.5</text>
+    <text x="248" y="582">ca 12.0</text>
+    <text x="248" y="608">pt 9.2</text>
+    <text x="248" y="629">uk 8.6</text>
+    <text x="248" y="649">zh 8.1</text>
+    <text x="248" y="667">fr 6.4</text>
+    <text x="248" y="682">gl 6.0</text>
+    <text x="248" y="696">pl 5.4</text>
+    <text x="248" y="710">es 4.6</text>
+    <text x="248" y="727">14 more 11.8</text>
+    <text x="248" y="759">icu4j 14.5</text>
+    <text x="248" y="788">grpc-netty-shaded 10.1</text>
+    <text x="248" y="812">bcprov 9.8</text>
+    <text x="248" y="833">groovy 7.7</text>
+    <text x="248" y="850">fastutil 6.3</text>
+    <text x="248" y="864">kuromoji 4.5 ⚠dup</text>
+    <text x="248" y="878">svnkit 4.1</text>
+    <text x="248" y="892">lucene-core 4.1</text>
+    <text x="248" y="906">smartcn 3.4</text>
+    <text x="248" y="920">jgit 3.3</text>
+    <text x="248" y="934">guava 2.9</text>
+    <text x="248" y="948">proto-google 2.6</text>
+    <text x="248" y="985">175 further jars 56.4</text>
+    <text x="248" y="1069">other modules 13.8</text>
+    <text x="248" y="1094">docs 7.2</text>
+    <text x="248" y="1108">OmegaT.jar 4.4</text>
+    <text x="248" y="1122">images 1.3</text>
+    <text x="248" y="1136">scripts 1.1</text>
+    <text x="248" y="1150">misc 1.5</text>
+  </g>
+
+  <!-- bar mini-legend -->
+  <rect x="60" y="1152" width="14" height="10" fill="#f2b8b4" stroke="#c0392b" stroke-width="0.8"/>
+  <text x="80" y="1161" font-size="10.5" fill="#555555">confirmed duplicate</text>
+  <rect x="60" y="1168" width="14" height="10" fill="#f5d0a8" stroke="#d07020" stroke-width="0.8"/>
+  <text x="80" y="1177" font-size="10.5" fill="#555555">replaceable (gRPC chain)</text>
+
+  <!-- ============ card 1: confirmed duplicate ============ -->
+  <rect x="420" y="140" width="1300" height="150" rx="10" fill="#fdeaea" stroke="#c0392b" stroke-width="1.6"/>
+  <text x="440" y="170" font-size="16" font-weight="bold" fill="#7a2e2b">Confirmed duplicate — ≈ 4.5 MB, deletable outright</text>
+  <g font-size="12.5" fill="#5c3331">
+    <text x="440" y="200">The kuromoji Japanese tokenizer ships twice: lib/lucene-analysis-kuromoji-9.12.3.jar (4.5 MB) and the identical 75-class set</text>
+    <text x="440" y="224">org.apache.lucene.analysis.ja again inside modules/omegat-language-ja.jar.</text>
+    <text x="440" y="256">Counter-check: smartcn (Chinese) is NOT duplicated — the zh module contains no analyzer classes. So this is a fixable packaging slip in the ja module, not a pattern.</text>
+  </g>
+
+  <!-- ============ card 2: replaceable ============ -->
+  <rect x="420" y="310" width="1300" height="210" rx="10" fill="#fdf1e3" stroke="#d07020" stroke-width="1.6"/>
+  <text x="440" y="340" font-size="16" font-weight="bold" fill="#8a4a10">Replaceable without losing any function — ≈ 17 MB</text>
+  <g font-size="12.5" fill="#6b4423">
+    <text x="440" y="370">Google MT: the connector itself is 36 KB of glue, but it pulls the full gRPC client stack into lib/ — 11 jars, 15.6 MB</text>
+    <text x="440" y="394">(grpc-netty-shaded 10.1 · proto-google-common-protos 2.6 · protobuf-java 1.8 · gax · auth · opencensus · …).</text>
+    <text x="440" y="418">The same translation API is served over plain REST/JSON; a thin HTTP client keeps the feature and drops the stack.</text>
+    <text x="440" y="454">Second JavaScript engine: rhino-all 1.8 MB rides along although scripting runs on nashorn-core (2.0 MB) — the script editor</text>
+    <text x="440" y="478">dependency already excludes rhino, so another transitive pulls it (origin to be confirmed via dependencyInsight).</text>
+  </g>
+
+  <!-- ============ card 3: structural option ============ -->
+  <rect x="420" y="540" width="1300" height="200" rx="10" fill="#fff8e0" stroke="#c9971a" stroke-width="1.6"/>
+  <text x="440" y="570" font-size="16" font-weight="bold" fill="#6b5210">Structural option — up to 249 MB (61 %): slim distribution + language packs</text>
+  <g font-size="12.5" fill="#5c4a1a">
+    <text x="440" y="600">The 29 language jars carry LanguageTool data: spelling dictionaries, synthesis dictionaries, grammar rules — nl alone is 47 MB</text>
+    <text x="440" y="624">(nl_NL.dict 15 + dutch_synth.dict 14 + dutch.dict 13 + rules).</text>
+    <text x="440" y="656">They are already cleanly modular: no LanguageTool core classes are duplicated inside them (verified). A slim default install</text>
+    <text x="440" y="680">with on-demand language packs would lose no function — every pack stays available, just not preinstalled.</text>
+    <text x="440" y="712">Every user pays today for all 29 languages; hardly anyone uses more than a handful.</text>
+  </g>
+
+  <!-- ============ card 4: keep ============ -->
+  <rect x="420" y="760" width="1300" height="190" rx="10" fill="#eaf5ec" stroke="#3a7d44" stroke-width="1.6"/>
+  <text x="440" y="790" font-size="16" font-weight="bold" fill="#2c5e34">Earns its size — keep</text>
+  <g font-size="12.5" fill="#2f4f36">
+    <text x="440" y="820">icu4j 14.5 — required by LanguageTool core.   Team stack ≈ 19 MB — jgit 3.3 · svnkit 4.1 · sshd 1.8 · bcprov 9.8 (team projects, modern SSH).</text>
+    <text x="440" y="848">groovy 7.7 — the scripting feature.   lucene-core 4.1 + CJK analyzers — the tokenizers.   fastutil 6.3 — LanguageTool performance.</text>
+    <text x="440" y="876">docs 7.2 — offline manuals.   pdfbox 2.0 — PDF support.</text>
+    <text x="440" y="908">Also checked, found clean: no duplicate artifact versions in lib/ (the two annotations-*.jar are different artifacts, 34 KB total).</text>
+  </g>
+
+  <!-- ============ verdict ============ -->
+  <rect x="420" y="980" width="1300" height="110" rx="10" fill="#f2f2f2" stroke="#555555" stroke-width="1.6"/>
+  <text x="440" y="1012" font-size="16" font-weight="bold" fill="#222222">Verdict</text>
+  <g font-size="12.5" fill="#333333">
+    <text x="440" y="1040">Hard savings with zero functional change: ≈ 22 MB (~5 %) — kuromoji dedup + gRPC→REST + rhino. The real lever is distribution</text>
+    <text x="440" y="1064">shape: slim installer + language packs (−61 %). Findings verified on the actual installDist via class-set comparison (unzip -l).</text>
+  </g>
+
+  <!-- footer -->
+  <text x="420" y="1150" font-size="11.5" fill="#888888">Historic snapshot of an integration installDist, 2026-08-01, not automatically updated.</text>
+  <text x="420" y="1170" font-size="11.5" fill="#888888">Companion: omegat-architecture-overview.svg · omegat-event-flow-overview.svg</text>
+  <circle cx="30" cy="1168.2" r="5.6" fill="none" stroke="#5f6b71" stroke-width="1.1"/>
+  <path d="M 27.2,1166.5 A 3.3 3.3 0 1 1 27.2,1169.9" fill="none" stroke="#5f6b71" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="42" y="1172" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#5f6b71">2026  -  OmegaT - Computer Assisted Translation (CAT) tool  -  This file is part of OmegaT, released under the GNU General Public License v3 or later</text>
+  <text x="42" y="1187" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#5f6b71">OmegaT is distributed WITHOUT ANY WARRANTY, without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE - see the GNU General Public License for more details.</text>
+</svg>


### PR DESCRIPTION
## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

None; revives #2200 content per 48.DeveloperDocumentation rules from #2275.

## What does this PR change?

- Adds three SVG infographics under `src/docs/developer/assets/`: architecture overview, event-flow overview, shipping-ballast map (marked as historic snapshot), embedded in chapters 21, 22 and 93.
- Adds CI guard `ci/check-docs-assets.py` failing when any developer documentation image is unreferenced by a Markdown page (follow-up of #2255); runs in PR documentation job and check stages.

## Other information

Rendered pages verified with a local Sphinx build.
