### PR TITLE
feat(filters): add handling for malformed character encoding in file processing(RFE-1759)

### DIFF
--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -66,6 +66,7 @@ import javax.xml.stream.XMLStreamException;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.Nullable;
 import org.omegat.core.statistics.StatOutputFormat;
+import org.omegat.filters2.FilterEncodingException;
 import org.xml.sax.SAXParseException;
 
 import org.omegat.core.Core;
@@ -1160,6 +1161,11 @@ public class RealProject implements IProject {
                     fi.fileEncoding = filter.getInEncodingLastParsedFile();
                     projectFilesList.add(fi);
                 }
+            } catch (FilterEncodingException ex) {
+                Log.logErrorRB("TF_SOURCE_LOAD_ENCODING_ERROR", filepath, ex.getFilterName(), ex.getSourceEncoding());
+                Core.getMainWindow().displayErrorRB(null, "TF_SOURCE_LOAD_ENCODING_ERROR", filepath,
+                        ex.getFilterName(), ex.getSourceEncoding());
+                errorSrcList.add(filepath);
             } catch (TranslationException e) {
                 // ignore failed file and continue loading next.
                 Log.logErrorRB("TF_SOURCE_LOAD_ERROR", e.getLocalizedMessage());

--- a/src/main/java/org/omegat/filters2/AbstractFilter.java
+++ b/src/main/java/org/omegat/filters2/AbstractFilter.java
@@ -37,7 +37,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
@@ -439,12 +441,13 @@ public abstract class AbstractFilter implements IFilter {
     protected void processFile(File inFile, @Nullable File outFile, FilterContext fc)
             throws IOException, TranslationException {
         String encoding = getInputEncoding(fc, inFile);
+        String outEncoding = null;
         try (BufferedReader reader = createReader(inFile, encoding)) {
             inEncodingLastParsedFile = encoding == null ? Charset.defaultCharset().name() : encoding;
             BufferedWriter writer = null;
             try {
                 if (outFile != null) {
-                    String outEncoding = getOutputEncoding(fc);
+                    outEncoding = getOutputEncoding(fc);
                     writer = createWriter(outFile, outEncoding);
                 } else {
                     writer = new NullBufferedWriter();
@@ -455,7 +458,17 @@ public abstract class AbstractFilter implements IFilter {
                     writer.close();
                 }
             }
+        } catch (CharacterCodingException | IllegalCharsetNameException | UnsupportedEncodingException ex) {
+            throw new FilterEncodingException(inFile, outFile, getFileFormatName(),
+                    encoding == null ? ENCODING_AUTO_HUMAN : encoding, getOutEncodingString(outFile, outEncoding), ex);
         }
+    }
+
+    private String getOutEncodingString(@Nullable File outFile, @Nullable String outEncoding) {
+        if (outEncoding == null) {
+            return outFile == null ? "" : ENCODING_AUTO_HUMAN;
+        }
+        return outEncoding;
     }
 
     /**
@@ -472,7 +485,7 @@ public abstract class AbstractFilter implements IFilter {
      * @throws IOException
      *             when I/O error occurred.
      */
-    protected String getInputEncoding(FilterContext fc, File inFile) throws IOException {
+    protected @Nullable String getInputEncoding(FilterContext fc, File inFile) throws IOException {
         String encoding = fc.getInEncoding();
         if (encoding == null && isSourceEncodingVariable()) {
             encoding = EncodingDetector.detectEncoding(inFile);

--- a/src/main/java/org/omegat/filters2/FilterEncodingException.java
+++ b/src/main/java/org/omegat/filters2/FilterEncodingException.java
@@ -1,0 +1,70 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Hiroshi Miura
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+package org.omegat.filters2;
+
+import java.io.File;
+
+import org.jspecify.annotations.Nullable;
+import org.omegat.util.OStrings;
+import org.omegat.util.StringUtil;
+
+@SuppressWarnings("serial")
+public class FilterEncodingException extends TranslationException {
+    private final File sourceFile;
+    private final @Nullable File targetFile;
+    private final String filterName;
+    private final String sourceEncoding;
+    private final String targetEncoding;
+
+    public FilterEncodingException(File sourceFile, @Nullable File targetFile, String filterName,
+                                   String sourceEncoding, String targetEncoding, Throwable cause) {
+        super(cause);
+        this.sourceFile = sourceFile;
+        this.targetFile = targetFile;
+        this.filterName = filterName;
+        this.sourceEncoding = sourceEncoding;
+        this.targetEncoding = targetEncoding;
+    }
+
+    public File getSourceFile() {
+        return sourceFile;
+    }
+
+    public @Nullable File getTargetFile() {
+        return targetFile;
+    }
+
+    public String getFilterName() {
+        return filterName;
+    }
+
+    public String getSourceEncoding() {
+        return sourceEncoding;
+    }
+
+    public String getTargetEncoding() {
+        return targetEncoding;
+    }
+}

--- a/src/main/java/org/omegat/filters2/FilterEncodingException.java
+++ b/src/main/java/org/omegat/filters2/FilterEncodingException.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -27,8 +27,6 @@ package org.omegat.filters2;
 import java.io.File;
 
 import org.jspecify.annotations.Nullable;
-import org.omegat.util.OStrings;
-import org.omegat.util.StringUtil;
 
 @SuppressWarnings("serial")
 public class FilterEncodingException extends TranslationException {

--- a/src/main/java/org/omegat/filters2/master/FilterMaster.java
+++ b/src/main/java/org/omegat/filters2/master/FilterMaster.java
@@ -65,6 +65,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 import org.omegat.core.Core;
 import org.omegat.filters2.AbstractFilter;
 import org.omegat.filters2.FilterContext;
+import org.omegat.filters2.FilterEncodingException;
 import org.omegat.filters2.IAlignCallback;
 import org.omegat.filters2.IFilter;
 import org.omegat.filters2.IParseCallback;
@@ -285,6 +286,16 @@ public class FilterMaster {
         IFilter filterObject = lookup.filterObject;
         try {
             filterObject.translateFile(inFile, outFile, lookup.config, fc, translateCallback);
+        } catch (FilterEncodingException ex) {
+            Log.log(ex);
+            IMainWindow mw = Core.getMainWindow();
+            if (mw != null) {
+                mw.displayErrorRB(null, "FILTERMASTER_ERROR_MALFORMED_FILE_ENCODING",
+                        filename,
+                        ex.getFilterName(),
+                        ex.getSourceEncoding(),
+                        ex.getTargetEncoding());
+            }
         } catch (UnsupportedEncodingException | CharacterCodingException ex) {
             Log.logErrorRB(ex, "FILTERMASTER_ERROR_UNKNOWN_ENCODING");
             IMainWindow mw = Core.getMainWindow();

--- a/src/main/java/org/omegat/gui/main/ConsoleWindow.java
+++ b/src/main/java/org/omegat/gui/main/ConsoleWindow.java
@@ -31,6 +31,7 @@ import java.awt.HeadlessException;
 
 import javax.swing.JFrame;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.data.RuntimePreferenceStore;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
@@ -47,7 +48,7 @@ import com.vlsolutions.swing.docking.DockingDesktop;
 public class ConsoleWindow implements IMainWindow {
 
     @Override
-    public void displayErrorRB(Throwable ex, String errorKey, Object... params) {
+    public void displayErrorRB(@Nullable Throwable ex, String errorKey, Object@Nullable... params) {
         String msg;
         if (params != null) {
             msg = StringUtil.format(OStrings.getString(errorKey), params);

--- a/src/main/java/org/omegat/gui/main/IMainWindow.java
+++ b/src/main/java/org/omegat/gui/main/IMainWindow.java
@@ -33,6 +33,7 @@ import javax.swing.JFrame;
 
 import com.vlsolutions.swing.docking.Dockable;
 import com.vlsolutions.swing.docking.DockingDesktop;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for access to main window functionality.
@@ -142,7 +143,7 @@ public interface IMainWindow {
      * @param params
      *            error text parameters
      */
-    void displayErrorRB(Throwable ex, String errorKey, Object... params);
+    void displayErrorRB(@Nullable Throwable ex, String errorKey, Object@Nullable... params);
 
     /**
      * Show message in an ErrorDialog

--- a/src/main/java/org/omegat/gui/main/MainWindow.java
+++ b/src/main/java/org/omegat/gui/main/MainWindow.java
@@ -68,6 +68,7 @@ import javax.swing.WindowConstants;
 import javax.swing.plaf.FontUIResource;
 import javax.swing.text.JTextComponent;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.data.DataUtils;
@@ -439,7 +440,7 @@ public class MainWindow implements IMainWindow {
     }
 
     @Override
-    public void displayErrorRB(final Throwable ex, final String errorKey, final Object... params) {
+    public void displayErrorRB(@Nullable Throwable ex, String errorKey, Object@Nullable... params) {
         UIThreadsUtil.executeInSwingThread(() -> {
             String msg;
             if (params != null) {

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -1191,6 +1191,7 @@ FILTERMASTER_ERROR_LOADING_FILTER=Filter '{0}' could not be loaded from '{1}'
 
 FILTERMASTER_ERROR_SRC_TRG_SAME_FILE=Translated file path cannot be identical to the source file path:\n{0}
 
+FILTERMASTER_ERROR_MALFORMED_FILE_ENCODING=Malformed character encoding was found while processing file: {0}\nFile filter: {1}\nSource encoding: {2}\nTarget encoding: {3}\n\nPlease check that the file encoding matches the file filter settings.
 FILTERMASTER_ERROR_UNKNOWN_ENCODING=Detect a wrong character encoding or wrong character in specified encoding when \
   output to translation file. Please check your project configuration and translations.
 

--- a/src/testAcceptance/java/org/omegat/gui/main/TestMainWindow.java
+++ b/src/testAcceptance/java/org/omegat/gui/main/TestMainWindow.java
@@ -41,6 +41,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.plaf.FontUIResource;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.TestCoreState;
 import tokyo.northside.logging.ILogger;
@@ -251,7 +252,7 @@ class TestMainWindow implements IMainWindow {
     }
 
     @Override
-    public void displayErrorRB(final Throwable ex, final String errorKey, final Object... params) {
+    public void displayErrorRB(@Nullable Throwable ex, final String errorKey, Object@Nullable... params) {
     }
 
     @Override


### PR DESCRIPTION
Intorduce new exception class that hold source file path, configured econding path, target file path, configured target encoding, and show an error information without stacktrace.

## Pull request type
- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- filter: improve error message when wrong char encoding is configured in bundle properties filter
- https://sourceforge.net/p/omegat/feature-requests/1759/

## What does this PR change?

- Introduced `FilterEncodingException` to standardize error reporting
- Enhanced `AbstractFilter` and `FilterMaster` to detect and manage malformed or unsupported file encodings
- Updated error messages to provide detailed encoding-related information
- Added nullability annotations and utility methods for better encoding handling
## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
