### PR TITLE
[manual] Glossary external file handling clarification

### DIFF
--- a/src/docs/manual/en/App_Glossaries.xml
+++ b/src/docs/manual/en/App_Glossaries.xml
@@ -31,16 +31,15 @@
             <para>You do not need to prepare the file in advance.</para>
             <para>It will be created the first time you add an entry to the
                		glossary.</para>
-            <note>
+            <warning>
                <para>If you choose to use an existing file as the default glossary,
                   all new entries will be recorded in tab-separated format and saved in
                   UTF-8 by default.</para>
-               <para>In case of using an external UTF-8 file glossary.txt file not created within OmegaT, change the file extension to .utf8 or add "# Glossary in tab-separated format -*- coding: utf-8 -*-" comment as the first line in the file.</para>
-               <para>If you want to specify a different encoding, you can do so by
-                  		  adding a “magic” comment that takes the following form:</para>
+               <para>If the file is in a different encoding, specify that encoding by
+                  		  adding a comment that takes the following form:</para>
                <simplelist type="vert">
                   <member>
-                     <code># -*- coding: &lt;charset&gt; -*-</code>,
+                     <code># -*- coding: &lt;charset&gt; -*-</code>
                      </member>
                </simplelist>
                <para>where 
@@ -48,7 +47,9 @@
                   the sets listed in the 
                   <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.iana.org/assignments/character-sets/character-sets.xhtml">IANA
                      Charset Registry</link>.</para>
-            </note>
+               <para>Even if the file is in UTF-8, make sure to add a comment that properly
+                  specifies the encoding: <code># -*- coding: utf-8 -*-</code>.</para>
+            </warning>
          </listitem>
       </varlistentry>
       <varlistentry>

--- a/src/docs/manual/en/App_Glossaries.xml
+++ b/src/docs/manual/en/App_Glossaries.xml
@@ -35,6 +35,7 @@
                <para>If you choose to use an existing file as the default glossary,
                   all new entries will be recorded in tab-separated format and saved in
                   UTF-8 by default.</para>
+               <para>In case of using an external UTF-8 file glossary.txt file not created within OmegaT, change the file extension to .utf8 or add "# Glossary in tab-separated format -*- coding: utf-8 -*-" comment as the first line in the file.</para>
                <para>If you want to specify a different encoding, you can do so by
                   		  adding a “magic” comment that takes the following form:</para>
                <simplelist type="vert">


### PR DESCRIPTION
Added clarification on using external glossary UTF-8 .txt files not created within OmegaT.

<!--- Please provide a general summary of your changes in the title above -->

<!-- Note: The OmegaT project uses GitHub pull requests for code review only.
The "real" code base is hosted on SourceForge; the GitHub project is a mirror.

If your PR is accepted it will be applied to the SourceForge repository by a
core contributor and the PR ticket will be closed. It will appear to have been
"closed without merging" but that is normal. --->

## Pull request type

<!-- Please try to limit your pull request to one type; submit multiple pull
requests if needed. -->

Please mark github LABEL of the type of change your PR introduces:

- [documentation]

## Which ticket is resolved?

<!-- Please refer to a relevant SourceForge ticket

Feature requests: https://sourceforge.net/p/omegat/feature-requests/

Bugs: https://sourceforge.net/p/omegat/bugs/

Documentation: https://sourceforge.net/p/omegat/documentation/ 

 Please paste a ticket title and URL  
-->

- Glossary external file handling clarification
- https://sourceforge.net/p/omegat/documentation/456/
 


<!-- 
 Above block is used for changelog. 
-->

## What does this PR change?

- adds a note on how to ensure proper UTF-8 coding of external .txt glossary files
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
