### PR TITLE
fix(mt/mymemory): restore no-arg constructor of MyMemoryHumanTranslate

### DIFF
--- a/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryHumanTranslate.java
+++ b/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryHumanTranslate.java
@@ -55,6 +55,10 @@ public final class MyMemoryHumanTranslate extends AbstractMyMemoryTranslate {
         super(url);
     }
 
+    /** Instantiated reflectively by MachineTranslatorsManager. */
+    public MyMemoryHumanTranslate() {
+    }
+
     @Override
     protected String getPreferenceName() {
         return ALLOW_MYMEMORY_HUMAN_TRANSLATE;

--- a/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryMachineTranslate.java
+++ b/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryMachineTranslate.java
@@ -55,6 +55,7 @@ public final class MyMemoryMachineTranslate extends AbstractMyMemoryTranslate {
         super(url);
     }
 
+    /** Instantiated reflectively by MachineTranslatorsManager. */
     public MyMemoryMachineTranslate() {
     }
 

--- a/machinetranslators/mymemory/src/test/java/org/omegat/machinetranslators/mymemory/MyMemoryTranslationTest.java
+++ b/machinetranslators/mymemory/src/test/java/org/omegat/machinetranslators/mymemory/MyMemoryTranslationTest.java
@@ -26,6 +26,7 @@
 package org.omegat.machinetranslators.mymemory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,12 +36,24 @@ import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import org.junit.Test;
 
 import org.omegat.core.TestCoreWireMock;
+import org.omegat.gui.exttrans.IMachineTranslation;
 import org.omegat.util.Language;
 import org.omegat.util.Preferences;
 
 public class MyMemoryTranslationTest extends TestCoreWireMock {
 
     private static final int HTTP_OK = 200;
+
+    // MachineTranslatorsManager instantiates connectors reflectively via
+    // no-arg constructor; connector without one vanishes from MT menu
+    // with only logged exception
+    @Test
+    public void testConnectorsProvideNoArgConstructor() throws Exception {
+        for (Class<?> connector : new Class<?>[] {MyMemoryHumanTranslate.class,
+                MyMemoryMachineTranslate.class}) {
+            assertTrue(connector.getDeclaredConstructor().newInstance() instanceof IMachineTranslation);
+        }
+    }
 
     @Test
     public void testMMMTResponse() throws Exception {


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- (none — master regression from #2290)

## What does this PR change?

- `MachineTranslatorsManager` instantiates registered connectors reflectively through no-arg constructor. Cleanup in #2290 removed seemingly unused constructor of `MyMemoryHumanTranslate`; result: NoSuchMethodException on every GUI start, connector missing from machine translation menu.
- Restore constructor, mark both MyMemory constructors as reflectively used, add regression test mirroring manager's instantiation path (fails with NoSuchMethodException without fix).

## Other information

Sibling `MyMemoryMachineTranslate` kept its pair all along; sweep over all machinetranslators modules found no further connector with parameterized constructor lacking no-arg one.
