### PR TITLE
chore(build): align module dependency resolution with application-provided versions

### DIFF
--- a/aligner/build.gradle
+++ b/aligner/build.gradle
@@ -13,6 +13,15 @@ dependencies {
         // Aligner
         implementation(libs.tokyo.northside.maligna) {
             exclude module: 'commons-logging'
+            // Fork of net.loomchild:segment keeping original package names;
+            // parent-first loading shadows it completely behind application's
+            // loomchild copy (LanguageTool dependency), so bundling it only
+            // adds unreachable dead weight. OmegaT's aligner never invokes
+            // maligna's SRX split path - only maligna class touching segment
+            // is SrxSplitAlgorithm (new SrxAnyParser(), SrxParser.parse,
+            // SrxTextIterator, TextIterator.hasNext/next; all present in
+            // application copy with identical signatures anyway).
+            exclude group: 'tokyo.northside', module: 'segment'
         }
         implementation(libs.slf4j.jcl)
         compileOnly(libs.jetbrains.annotations)

--- a/build-logic/src/main/groovy/org/omegat/module/DependencyAlignment.groovy
+++ b/build-logic/src/main/groovy/org/omegat/module/DependencyAlignment.groovy
@@ -1,0 +1,53 @@
+package org.omegat.module
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+
+/**
+ * Aligns dependency resolution of given configuration to versions application
+ * ships on its runtime classpath. Parent-first class loading serves shared
+ * libraries from application copy regardless of module-resolved version;
+ * alignment makes module classpaths match runtime reality and keeps
+ * version-skewed duplicates out of distribution (invariant guarded in CI by
+ * tool/check_duplicate_dependencies.py).
+ */
+final class DependencyAlignment {
+
+    private DependencyAlignment() {
+    }
+
+    /**
+     * Rewrites requested versions to application-resolved version where same
+     * group and name appear on application runtime classpath. Never attach to
+     * root runtimeClasspath itself: version map resolves that configuration,
+     * rule there would recurse (guarded below). Deadlock-free at execution
+     * time because module plugin's afterEvaluate already resolves root
+     * runtimeClasspath at configuration time; closure then only reads
+     * memoized resolution state.
+     */
+    static void alignToApplication(Project rootProject, Configuration configuration) {
+        def rootRuntime = rootProject.configurations.getByName("runtimeClasspath")
+        if (configuration.is(rootRuntime)) {
+            throw new IllegalArgumentException(
+                    "alignToApplication must not target root runtimeClasspath itself")
+        }
+        def coreVersions = null
+        configuration.resolutionStrategy.eachDependency { details ->
+            if (coreVersions == null) {
+                coreVersions = [:]
+                rootRuntime.incoming.resolutionResult.allComponents.each { component ->
+                    def id = component.id
+                    if (id instanceof ModuleComponentIdentifier) {
+                        coreVersions["${id.group}:${id.module}".toString()] = id.version
+                    }
+                }
+            }
+            def coreVersion = coreVersions["${details.requested.group}:${details.requested.name}".toString()]
+            if (coreVersion != null && coreVersion != details.requested.version) {
+                details.useVersion(coreVersion)
+                details.because("aligned with the application-provided version")
+            }
+        }
+    }
+}

--- a/build-logic/src/main/groovy/org/omegat/module/OmegatModulePlugin.groovy
+++ b/build-logic/src/main/groovy/org/omegat/module/OmegatModulePlugin.groovy
@@ -92,6 +92,12 @@ class OmegatModulePlugin implements Plugin<Project> {
         def coreRuntimeClasspath = project.rootProject.configurations.named("runtimeClasspath")
         def moduleRuntimeClasspath = project.configurations.named("runtimeClasspath")
 
+        ['compileClasspath', 'runtimeClasspath', 'testCompileClasspath', 'testRuntimeClasspath'].each { alignedName ->
+            project.configurations.matching { it.name == alignedName }.configureEach { conf ->
+                DependencyAlignment.alignToApplication(project.rootProject, conf)
+            }
+        }
+
         project.afterEvaluate {
             def plainEntries = []
             def signingTasks = []

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.apache.tools.ant.filters.FixCrLfFilter
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.omegat.gradle.PropertiesUtil
+import org.omegat.module.DependencyAlignment
 
 plugins {
     id 'org.omegat.version'
@@ -74,6 +75,9 @@ configurations {
         transitive = false
     }
 }
+// lib/provided/module of source distribution resolves through this
+// configuration; align to application versions like module classpaths
+DependencyAlignment.alignToApplication(project, configurations.moduleRuntimeLibs)
 
 dependencies {
     // Libs are provided in the "source" distribution only

--- a/tool/known_dependency_skews.txt
+++ b/tool/known_dependency_skews.txt
@@ -1,21 +1,5 @@
 # Tolerated legacy version skews between lib/provided/core and
 # lib/provided/module, checked by check_duplicate_dependencies.py.
-# Goal: shrink list to empty. Remove line once versions align;
-# checker errors on stale entries.
-error_prone_annotations
-guava
-j2objc-annotations
-jackson-core
-jackson-databind
-jaxb-core
-jaxb-runtime
-jetbrains-annotations
-jna
-jna-platform
-jspecify
-jsr305
-morfologik-fsa
-morfologik-stemming
-segment
-slf4j-api
-txw2
+# Empty since module resolution aligns to application-provided versions
+# (DependencyAlignment, build-logic); add entry with reason only when
+# alignment is impossible for a library. Checker errors on stale entries.


### PR DESCRIPTION
## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

- (none — distribution dependency hygiene, follow-up to #2315)

## What does this PR change?

- Module fat jars and source distribution's `lib/provided/module` carried 18 version skews against application libs (icu4j, guava, jackson, jna, morfologik, slf4j, …). Parent-first class loading serves shared libraries from application copy regardless of module-resolved version: skewed bundled copies are unreachable dead weight, and modules compile against versions they never run with.
- New `DependencyAlignment` helper (build-logic) rewrites module classpaths and root `moduleRuntimeLibs` resolution to application-resolved versions; propagates automatically on future core bumps.
- Aligner drops `tokyo.northside:segment`: fork keeps `net.loomchild` package names, fully shadowed by application's loomchild copy; only maligna class touching segment is SrxSplitAlgorithm, whose members all exist in application copy — and OmegaT's aligner never invokes that split path.
- Duplicate dependency checker baseline (#2315) shrinks to empty; any future skew fails CI.
- Distribution `modules/` folder shrinks 235 MB → 191 MB (−43 MB, −19%); ~15 MB of that overlaps with #2313's icu4j removal, ~28 MB is net new.

## Other information

Stacked on #2315. Verified: checker green (92 module jars, was 95), full test suite, distributionSmokeTest, configuration-cache run green, source distribution self-build resolution replayed locally.
