### PR TITLE
docs(adr): number matching

### DIFF
--- a/src/docs/developer/adr/2026010.ValueBasedNumberMatching.md
+++ b/src/docs/developer/adr/2026010.ValueBasedNumberMatching.md
@@ -7,7 +7,7 @@
 ## Context
 
 - Project option `match_numbers` (PR#2155, `omegat.project`) lets fuzzy matching consider numbers.
-- SF #465 asks for number handling beyond ASCII digits: same value written differently — full-width digits, Khmer, Han, sign systems — should compare equal and insert correctly.
+- RFE #465 asks for number handling beyond ASCII digits: same value written differently — full-width digits, Khmer, Han, sign systems — should compare equal and insert correctly.
 - Insertion substitution (`Preferences.CONVERT_NUMBERS`) previously copied digit strings verbatim; wrong notation or wrong value reached target.
 
 ## Decision

--- a/src/docs/developer/adr/2026010.ValueBasedNumberMatching.md
+++ b/src/docs/developer/adr/2026010.ValueBasedNumberMatching.md
@@ -1,0 +1,25 @@
+# ADR: Value-Based Fuzzy Match Numbers
+
+## Status
+
+**Proposed** (Date: 2026-08-29)
+
+## Context
+
+- Project option `match_numbers` (#2155, `omegat.project`) lets fuzzy matching consider numbers.
+- SF #465 asks for number handling beyond ASCII digits: same value written differently — full-width digits, Khmer, Han, sign systems — should compare equal and insert correctly.
+- Insertion substitution (`Preferences.CONVERT_NUMBERS`) previously copied digit strings verbatim; wrong notation or wrong value reached target.
+
+## Decision
+
+- `NumeralValueParser` parses number tokens to exact rational values. Sources: Unicode numeric properties, positional digit runs, additive/multiplicative sign systems (Ethiopic, cuneiform, Aegean, Mayan, Kaktovik, Greek acrophonic, Ottoman Siyaq, Meroitic, Pahawh Hmong, Medefaidrin, CJK ideographic, Roman via ICU rule sets), vulgar fractions.
+- Match comparison (`FindMatches`): with `match_numbers` enabled, number tokens compare by value. Number-only segments compare via placeholder class minus fixed penalty instead of scoring zero.
+- Insertion (`MatchesTextArea.substituteNumbers`): source and match numbers pair as multisets by value; target notation wins — source value rendered in target token's digit script or numeral system (ICU `RuleBasedNumberFormat`). Only valid notation gets composed; otherwise plain digits.
+- Exclusions: Latin-letter Roman numerals never rewritten (word ambiguity: "I", "MIX"); compatibility-decomposition forms (superscripts, enclosed numbers) untouched; Han characters stay outside default protected-parts pattern (double as CJK prose).
+- Coverage pinned by fixture `src/testAcceptance/resources/data/project_numerals/` (README lists systems, limits, non-encodable systems) plus `NumeralMatchesSubstitutionTest` end-to-end.
+
+## Consequences
+
+- Exotic-script sources yield correct target numbers; verbatim-copy wrong-value insertions disappear.
+- ICU rule sets bound write-back: systems ICU cannot read stay read-only or excluded (Tamil, Suzhou — documented in fixture README).
+- Team distribution of `match_numbers` stays out of scope here; follow-up ADR planned after developer mailing list discussion of team synchronization extension (backward compatibility, SVN/Git configurations).

--- a/src/docs/developer/adr/2026010.ValueBasedNumberMatching.md
+++ b/src/docs/developer/adr/2026010.ValueBasedNumberMatching.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-- Project option `match_numbers` (#2155, `omegat.project`) lets fuzzy matching consider numbers.
+- Project option `match_numbers` (PR#2155, `omegat.project`) lets fuzzy matching consider numbers.
 - SF #465 asks for number handling beyond ASCII digits: same value written differently — full-width digits, Khmer, Han, sign systems — should compare equal and insert correctly.
 - Insertion substitution (`Preferences.CONVERT_NUMBERS`) previously copied digit strings verbatim; wrong notation or wrong value reached target.
 

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -21,6 +21,10 @@
 - 2026001 [Glossary Search and Sort Implementation](2026001.GlossarySearchAndSort.md)
 - 2026008 [Segment Sorting in the Editor](2026008.EditorSegmentSorting.md)
 
+### Matching
+
+- 2026010 [Value-Based Fuzzy Match Numbers](2026010.ValueBasedNumberMatching.md)
+
 ### Filters
 
 - 2025009 [Yaml Filter Specification](2025009.YAMLFilterSpecification.md) 


### PR DESCRIPTION
## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

- Consider numbers for fuzzy matches
  * https://sourceforge.net/p/omegat/feature-requests/465/

## What does this PR change?

- ADR 2026010 records the design of value-based fuzzy match numbers (#2228): value parsing, multiset comparison, rendering in the target's notation, exclusions and fixture coverage.

## Other information

previously ~_Stacked on #2228 (only the last commit belongs to this PR)._~ A separate ADR for team distribution of the option follows after discussion on the dev-list.
