### PR TITLE
feat(team): negotiate per-project settings with team through sidecar file

### DIFF
--- a/src/main/java/org/omegat/core/data/IProject.java
+++ b/src/main/java/org/omegat/core/data/IProject.java
@@ -29,6 +29,7 @@
 package org.omegat.core.data;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -106,6 +107,51 @@ public interface IProject {
      * @throws Exception if any error occurs during the commit process
      */
     void commitSourceFiles() throws Exception;
+
+    /**
+     * Sets a registered team project setting and commits the project
+     * settings file (omegat/project_settings.properties) to the team
+     * repository, so the whole team gets the value. The setting lives in
+     * its own file because older OmegaT versions reject unknown elements in
+     * omegat.project but ignore extra files. No operation for non-team
+     * projects. Must run through Core.executeExclusively, like saveProject.
+     *
+     * @param key
+     *            key of a setting registered in {@link TeamSettingsRegistry}
+     * @param value
+     *            raw value to distribute, null for the default
+     * @throws Exception
+     *             if writing or committing the file fails
+     */
+    default void publishProjectSetting(String key, @Nullable String value) throws Exception {
+    }
+
+    /**
+     * Sets a registered team project setting for this session and writes it
+     * to the local project settings file only: the next open of the team
+     * project supersedes it with the remote value again. No operation for
+     * non-team projects. Must run through Core.executeExclusively, like
+     * saveProject.
+     *
+     * @param key
+     *            key of a setting registered in {@link TeamSettingsRegistry}
+     * @param value
+     *            raw value to restore, null for the default
+     * @throws Exception
+     *             if writing the file fails
+     */
+    default void useLocalProjectSetting(String key, @Nullable String value) throws Exception {
+    }
+
+    /**
+     * The local raw values that the team values superseded during the last
+     * load of a team project, keyed by setting key; an entry with null value
+     * means the local side had the default. Empty when everything agreed,
+     * always empty for non-team projects.
+     */
+    default Map<String, @Nullable String> getSupersededLocalSettings() {
+        return Collections.emptyMap();
+    }
 
     /**
      * Get project properties.

--- a/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
+++ b/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
@@ -1,0 +1,168 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+import org.jspecify.annotations.Nullable;
+
+import org.omegat.util.Log;
+
+/**
+ * Storage of optional per-project settings in
+ * {@code omegat/project_settings.properties}. The settings live in their own
+ * file instead of {@code omegat.project} on purpose: the project file parser
+ * of released OmegaT versions rejects unknown elements, so a new element
+ * there would make the project unreadable for every team member on an older
+ * version, while an extra file in the {@code omegat} folder is ignored.
+ *
+ * The file is written deterministically (sorted keys, no timestamp comment),
+ * so distributing an unchanged file to a team repository stays recognisable
+ * as a byte-identical no-op.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class ProjectSettingsStorage {
+
+    public static final String FILE_PROJECT_SETTINGS = "project_settings.properties";
+
+    private ProjectSettingsStorage() {
+    }
+
+    /** The settings file of the given project. */
+    public static File getFile(ProjectProperties config) {
+        return new File(config.getProjectInternal(), FILE_PROJECT_SETTINGS);
+    }
+
+    /**
+     * The stored raw value of given key: null when the file or the key is
+     * absent or the file is unreadable, so callers can distinguish "not
+     * configured" from an explicit value.
+     */
+    public static @Nullable String load(ProjectProperties config, String key) {
+        File file = getFile(config);
+        if (!file.isFile()) {
+            return null;
+        }
+        Properties props = new Properties();
+        try (Reader in = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+            props.load(in);
+        } catch (IOException ex) {
+            Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+            return null;
+        }
+        String value = props.getProperty(key);
+        return value == null ? null : value.trim();
+    }
+
+    /**
+     * Store the raw value under given key (null removes the key), keeping
+     * any other keys of the file so settings can share it. Removing a key
+     * from an absent file is a no-op, so it never materialises the file.
+     */
+    public static void save(ProjectProperties config, String key, @Nullable String value)
+            throws IOException {
+        File file = getFile(config);
+        if (value == null && !file.isFile()) {
+            return;
+        }
+        Map<String, String> entries = new TreeMap<>();
+        if (file.isFile()) {
+            Properties existing = new Properties();
+            try (Reader in = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+                existing.load(in);
+            }
+            existing.stringPropertyNames().forEach(k -> entries.put(k, existing.getProperty(k)));
+        }
+        if (value == null) {
+            entries.remove(key);
+        } else {
+            entries.put(key, value);
+        }
+        File dir = file.getParentFile();
+        if (dir != null && !dir.isDirectory() && !dir.mkdirs()) {
+            throw new IOException("Cannot create " + dir);
+        }
+        try (Writer out = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+            for (Map.Entry<String, String> e : entries.entrySet()) {
+                out.write(escape(e.getKey(), true) + "=" + escape(e.getValue(), false) + "\n");
+            }
+        }
+    }
+
+    /**
+     * Escape a key or value the way {@code Properties.store} would, minus
+     * the Latin-1 escaping (the file is read and written as UTF-8), so
+     * foreign keys of other settings survive the load/save round trip
+     * unchanged.
+     */
+    private static String escape(String s, boolean isKey) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+            case '\\':
+                sb.append("\\\\");
+                break;
+            case '\t':
+                sb.append("\\t");
+                break;
+            case '\n':
+                sb.append("\\n");
+                break;
+            case '\r':
+                sb.append("\\r");
+                break;
+            case '\f':
+                sb.append("\\f");
+                break;
+            case '=':
+            case ':':
+            case '#':
+            case '!':
+                sb.append('\\').append(c);
+                break;
+            case ' ':
+                if (isKey || i == 0) {
+                    sb.append('\\');
+                }
+                sb.append(c);
+                break;
+            default:
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -252,11 +252,214 @@ public class RealProject implements IProject {
             FilterMaster.saveConfig(config.getProjectFilters(),
                     new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
             ProjectFileStorage.writeProjectFile(config);
+            persistSessionSettings(config, supersededLocalSettings.keySet());
         } finally {
             lockProject();
         }
         Preferences.setPreference(Preferences.SOURCE_LOCALE, config.getSourceLanguage().toString());
         Preferences.setPreference(Preferences.TARGET_LOCALE, config.getTargetLanguage().toString());
+    }
+
+    /**
+     * Persist the session values of all registered team settings to the
+     * sidecar file. Opt-in: only materialised once a setting was used, so
+     * default projects stay byte-identical to older OmegaT versions. While
+     * a superseded local value awaits the user's decision, the session runs
+     * on the team value but the file keeps the local one - persisting the
+     * session value here would silently turn a dismissed question into
+     * "take the team value". Static for testability.
+     */
+    static void persistSessionSettings(ProjectProperties config, Set<String> supersededKeys)
+            throws IOException {
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            String sessionValue = setting.read(config);
+            if (!supersededKeys.contains(setting.getKey())
+                    && (sessionValue != null || ProjectSettingsStorage.getFile(config).isFile())) {
+                ProjectSettingsStorage.save(config, setting.getKey(), sessionValue);
+            }
+        }
+    }
+
+    /**
+     * The local raw values that the just synced team values superseded
+     * during the load, keyed by setting key (null value = local default), or
+     * empty when everything agreed. Read by the question shown after a team
+     * project opened.
+     */
+    private volatile Map<String, @Nullable String> supersededLocalSettings = Collections.emptyMap();
+
+    @Override
+    public Map<String, @Nullable String> getSupersededLocalSettings() {
+        return supersededLocalSettings;
+    }
+
+    @Override
+    public void publishProjectSetting(String key, @Nullable String value) throws Exception {
+        if (!remoteRepositoryProvider.isManaged()) {
+            return;
+        }
+        TeamSetting setting = requireRegistered(key);
+        // The session and the local file keep the user's value even when the
+        // commit fails: the file then still diverges from the team and the
+        // next open asks again.
+        setting.apply(config, value);
+        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        // A checkout parked between teamSyncPrepare and teamSync must not be
+        // moved to latest behind the sync's back (same cleanup as
+        // saveProject).
+        tmxPrepared = null;
+        glossaryPrepared = null;
+        remoteRepositoryProvider.cleanPrepared();
+        commitProjectSettings(remoteRepositoryProvider, config);
+        clearSupersededLocalSetting(key);
+    }
+
+    @Override
+    public void useLocalProjectSetting(String key, @Nullable String value) throws Exception {
+        if (!remoteRepositoryProvider.isManaged()) {
+            return;
+        }
+        TeamSetting setting = requireRegistered(key);
+        setting.apply(config, value);
+        // Local write only: the next open of the team project syncs the
+        // remote file back in, notices a divergence and asks again.
+        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        clearSupersededLocalSetting(key);
+    }
+
+    private static TeamSetting requireRegistered(String key) {
+        TeamSetting setting = TeamSettingsRegistry.byKey(key);
+        if (setting == null) {
+            throw new IllegalArgumentException("Unknown team setting: " + key);
+        }
+        return setting;
+    }
+
+    private void clearSupersededLocalSetting(String key) {
+        if (supersededLocalSettings.containsKey(key)) {
+            Map<String, @Nullable String> remaining = new HashMap<>(supersededLocalSettings);
+            remaining.remove(key);
+            supersededLocalSettings = Collections.unmodifiableMap(remaining);
+        }
+    }
+
+    /**
+     * Commit the project settings file to the team repositories. Skips the
+     * commit when every repository copy is already byte-identical, because
+     * git reports the no-op commit of an unchanged file the same way as a
+     * rejected push. Static for testability.
+     */
+    static void commitProjectSettings(RemoteRepositoryProvider provider, ProjectProperties config)
+            throws Exception {
+        // The checkout may be stale, and a commit onto an old base would be
+        // rejected on push.
+        provider.switchAllToLatest();
+        String underRoot = config.getProjectInternalRelative()
+                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
+        if (!provider.isIdenticalInRepositoriesIgnoringEol(underRoot)) {
+            provider.copyFilesFromProjectToRepos(underRoot, null);
+            if (!provider.commitFilesChecked(underRoot, "Update the shared project settings")) {
+                throw new IOException(OStrings.getString("TEAM_SETTING_SHARE_ERROR"));
+            }
+        }
+    }
+
+    /**
+     * Apply the stored project settings to the session. For an online team
+     * project the team's state wins: the sync just overwrote a diverging
+     * local file with the remote one, and a purely local file (which the
+     * sync leaves alone, because it never existed remotely) does not count
+     * either - the team default stays active until the value is shared.
+     * Either way the superseded local values are kept for the question shown
+     * after the load, so every open asks again until the value is shared or
+     * dropped, as the share prompt promises.
+     *
+     * @param preSyncValues
+     *            the locally stored normalized values from before the team
+     *            sync, keyed by setting key
+     */
+    private void loadProjectSettings(Map<String, @Nullable String> preSyncValues) {
+        if (TeamSettingsRegistry.all().isEmpty()) {
+            supersededLocalSettings = Collections.emptyMap();
+            return;
+        }
+        boolean teamOnline = remoteRepositoryProvider.isManaged() && isOnlineMode;
+        boolean identical = false;
+        if (teamOnline) {
+            try {
+                // After the sync a settings file that exists remotely is
+                // byte-identical locally; a non-identical or absent file
+                // means the team does not carry the setting, so the local
+                // file is a local-only divergence.
+                identical = remoteRepositoryProvider.isIdenticalInRepositories(
+                        config.getProjectInternalRelative()
+                                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+            } catch (IOException ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                // fall back to trusting the local file
+                identical = true;
+            }
+        }
+        Map<String, @Nullable String> superseded = new HashMap<>();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            String preSync = preSyncValues.get(setting.getKey());
+            String postSync = setting.normalize(ProjectSettingsStorage.load(config, setting.getKey()));
+            SettingResolution state = resolveSetting(preSync, postSync, identical, teamOnline);
+            setting.apply(config, state.effective);
+            if (state.asks) {
+                superseded.put(setting.getKey(), state.supersededLocal);
+            }
+        }
+        supersededLocalSettings = Collections.unmodifiableMap(superseded);
+    }
+
+    /** Snapshot of the stored normalized values of all registered settings. */
+    private Map<String, @Nullable String> readStoredSettings() {
+        Map<String, @Nullable String> values = new HashMap<>();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            values.put(setting.getKey(),
+                    setting.normalize(ProjectSettingsStorage.load(config, setting.getKey())));
+        }
+        return values;
+    }
+
+    /** Resolution of one team setting after a load. */
+    static final class SettingResolution {
+        final @Nullable String effective;
+        final boolean asks;
+        final @Nullable String supersededLocal;
+
+        SettingResolution(@Nullable String effective, boolean asks, @Nullable String supersededLocal) {
+            this.effective = effective;
+            this.asks = asks;
+            this.supersededLocal = supersededLocal;
+        }
+    }
+
+    /**
+     * Decide which raw value a load activates and whether it superseded a
+     * diverging local value that the user should be asked about. Works on
+     * normalized values (default = null). Pure function for testability.
+     *
+     * @param preSyncStored
+     *            locally stored value from before the team sync, null when
+     *            file or key were absent
+     * @param postSyncStored
+     *            stored value after the team sync
+     * @param identicalInRepositories
+     *            whether the settings file is byte-identical in every team
+     *            repository (meaningless when teamOnline is false)
+     * @param teamOnline
+     *            whether this is a team project loaded in online mode
+     */
+    static SettingResolution resolveSetting(@Nullable String preSyncStored,
+            @Nullable String postSyncStored, boolean identicalInRepositories, boolean teamOnline) {
+        if (!teamOnline) {
+            return new SettingResolution(postSyncStored, false, null);
+        }
+        String team = identicalInRepositories ? postSyncStored : null;
+        boolean asks = !Objects.equals(preSyncStored, team);
+        return new SettingResolution(team, asks, asks ? preSyncStored : null);
     }
 
     /**
@@ -343,6 +546,7 @@ public class RealProject implements IProject {
 
             Core.getMainWindow().showStatusMessageRB("CT_LOADING_PROJECT");
 
+            Map<String, @Nullable String> preSyncSettings = readStoredSettings();
             if (remoteRepositoryProvider.isManaged()) {
                 try {
                     tmxPrepared = null;
@@ -360,6 +564,7 @@ public class RealProject implements IProject {
                 config.loadProjectFilters();
                 config.loadProjectSRX();
             }
+            loadProjectSettings(preSyncSettings);
 
             loadFilterSettings();
             loadSegmentationSettings();

--- a/src/main/java/org/omegat/core/data/TeamSetting.java
+++ b/src/main/java/org/omegat/core/data/TeamSetting.java
@@ -1,0 +1,146 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+import org.jspecify.annotations.Nullable;
+import org.openide.awt.Mnemonics;
+
+import org.omegat.util.OStrings;
+
+/**
+ * Descriptor of one per-project setting negotiated with team, stored in
+ * sidecar file handled by {@link ProjectSettingsStorage}. Feature code
+ * registers descriptor through {@link TeamSettingsRegistry}; core then
+ * loads, saves, distributes and questions the setting generically. Raw
+ * values are strings; null means "not configured", i.e. default.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSetting {
+
+    private final String key;
+    private final String nameKey;
+    private final Function<ProjectProperties, @Nullable String> reader;
+    private final BiConsumer<ProjectProperties, @Nullable String> applier;
+    private final Function<@Nullable String, String> valueDescriber;
+    private final UnaryOperator<@Nullable String> normalizer;
+
+    private TeamSetting(String key, String nameKey, Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+        this.key = key;
+        this.nameKey = nameKey;
+        this.reader = reader;
+        this.applier = applier;
+        this.valueDescriber = valueDescriber;
+        this.normalizer = normalizer;
+    }
+
+    /**
+     * Descriptor with fully custom behaviour, for non-boolean settings.
+     *
+     * @param key
+     *            key in project_settings.properties
+     * @param nameKey
+     *            resource key of localized display name
+     * @param reader
+     *            current session value as normalized raw string, null for
+     *            default
+     * @param applier
+     *            applies raw value (null = default) to session; must be an
+     *            idempotent setter, it also runs with unchanged values
+     * @param valueDescriber
+     *            localized description of raw value for dialogs
+     * @param normalizer
+     *            canonical form of raw value; must map default to null
+     */
+    public static TeamSetting of(String key, String nameKey,
+            Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+        return new TeamSetting(key, nameKey, reader, applier, valueDescriber, normalizer);
+    }
+
+    /**
+     * Boolean setting; absent key means given default, only the non-default
+     * value materialises in the file, so default projects stay byte-identical
+     * to projects of older OmegaT versions.
+     */
+    public static TeamSetting ofBoolean(String key, String nameKey, boolean defaultValue,
+            Predicate<ProjectProperties> getter, BiConsumer<ProjectProperties, Boolean> setter) {
+        UnaryOperator<@Nullable String> normalizer = raw -> {
+            boolean value = raw == null ? defaultValue : Boolean.parseBoolean(raw.trim());
+            return value == defaultValue ? null : Boolean.toString(value);
+        };
+        return new TeamSetting(key, nameKey,
+                config -> getter.test(config) == defaultValue ? null : Boolean.toString(!defaultValue),
+                (config, raw) -> setter.accept(config,
+                        raw == null ? defaultValue : Boolean.parseBoolean(raw.trim())),
+                raw -> OStrings.getString(
+                        (raw == null ? defaultValue : Boolean.parseBoolean(raw.trim()))
+                                ? "TEAM_SETTING_VALUE_ON"
+                                : "TEAM_SETTING_VALUE_OFF"),
+                normalizer);
+    }
+
+    /** Key in project_settings.properties. */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Localized display name for dialogs. Mnemonic markers are stripped, so
+     * existing menu or checkbox label keys work as name key.
+     */
+    public String getDisplayName() {
+        return Mnemonics.removeMnemonics(OStrings.getString(nameKey));
+    }
+
+    /** Current session value as normalized raw string, null for default. */
+    public @Nullable String read(ProjectProperties config) {
+        return normalize(reader.apply(config));
+    }
+
+    /** Applies raw value (null = default) to session. */
+    public void apply(ProjectProperties config, @Nullable String raw) {
+        applier.accept(config, normalize(raw));
+    }
+
+    /** Localized description of raw value for dialogs. */
+    public String describe(@Nullable String raw) {
+        return valueDescriber.apply(raw);
+    }
+
+    /** Canonical form of raw value; default maps to null. */
+    public @Nullable String normalize(@Nullable String raw) {
+        return normalizer.apply(raw);
+    }
+}

--- a/src/main/java/org/omegat/core/data/TeamSettingsRegistry.java
+++ b/src/main/java/org/omegat/core/data/TeamSettingsRegistry.java
@@ -1,0 +1,70 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Registry of team-negotiated project settings. Feature code registers its
+ * {@link TeamSetting} at plugin load; core iterates registered settings when
+ * loading, saving and distributing projects. Empty registry means every
+ * related code path stays no-op.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSettingsRegistry {
+
+    private static final List<TeamSetting> SETTINGS = new CopyOnWriteArrayList<>();
+
+    private TeamSettingsRegistry() {
+    }
+
+    /** Registers setting; rejects duplicate key. */
+    public static void register(TeamSetting setting) {
+        if (byKey(setting.getKey()) != null) {
+            throw new IllegalArgumentException("Team setting already registered: " + setting.getKey());
+        }
+        SETTINGS.add(setting);
+    }
+
+    /** Removes setting with given key, for plugin unload and tests. */
+    public static void unregister(String key) {
+        SETTINGS.removeIf(s -> s.getKey().equals(key));
+    }
+
+    /** All registered settings, in registration order. */
+    public static List<TeamSetting> all() {
+        return List.copyOf(SETTINGS);
+    }
+
+    /** Setting with given key, null when unknown. */
+    public static @Nullable TeamSetting byKey(String key) {
+        return SETTINGS.stream().filter(s -> s.getKey().equals(key)).findFirst().orElse(null);
+    }
+}

--- a/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -28,6 +28,7 @@ package org.omegat.core.team2;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -196,6 +197,60 @@ public class RemoteRepositoryProvider {
         return !getMappings(path).isEmpty();
     }
 
+    /**
+     * Whether every checked-out repository copy of the given project file is
+     * byte-identical to the file in the project directory, i.e. committing
+     * it would be a no-op. Only meaningful for files that are copied without
+     * EOL conversion, and after the repositories have been switched to a
+     * version.
+     */
+    public boolean isIdenticalInRepositories(String localPath) throws IOException {
+        File localFile = new File(projectRoot, localPath);
+        boolean found = false;
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile == null) {
+                continue;
+            }
+            if (!repoFile.exists() || !FileUtils.contentEquals(localFile, repoFile)) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
+    /**
+     * Like {@link #isIdenticalInRepositories}, but treating CRLF and LF line
+     * endings as equal: repository checkouts may re-line-end text files (git
+     * autocrlf on Windows), and that must not disguise an unchanged file as
+     * a change, whose empty commit then reports like a rejected push.
+     */
+    public boolean isIdenticalInRepositoriesIgnoringEol(String localPath) throws IOException {
+        File localFile = new File(projectRoot, localPath);
+        boolean found = false;
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile == null) {
+                continue;
+            }
+            if (!repoFile.exists() || !contentEqualsIgnoringEol(localFile, repoFile)) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
+    private static boolean contentEqualsIgnoringEol(File a, File b) throws IOException {
+        return normalizeEol(FileUtils.readFileToByteArray(a))
+                .equals(normalizeEol(FileUtils.readFileToByteArray(b)));
+    }
+
+    private static String normalizeEol(byte[] content) {
+        return new String(content, StandardCharsets.ISO_8859_1).replace("\r\n", "\n");
+    }
+
     public void cleanPrepared() throws IOException {
         FileUtils.deleteDirectory(new File(projectRoot, REPO_PREPARE_SUBDIR));
     }
@@ -297,6 +352,23 @@ public class RemoteRepositoryProvider {
         for (IRemoteRepository2 repo : repos.values()) {
             repo.commit(null, commentText);
         }
+    }
+
+    /**
+     * Same as commitFiles, but reports whether every affected repository
+     * accepted the commit: a rejected push (for example non-fast-forward)
+     * makes IRemoteRepository2.commit return null instead of throwing.
+     */
+    public boolean commitFilesChecked(String path, String commentText) throws Exception {
+        Map<String, IRemoteRepository2> repos = new TreeMap<>();
+        for (Mapping m : getMappings(path)) {
+            repos.put(m.repoDefinition.getUrl(), m.repo);
+        }
+        boolean accepted = true;
+        for (IRemoteRepository2 repo : repos.values()) {
+            accepted &= repo.commit(null, commentText) != null;
+        }
+        return accepted;
     }
 
     /**
@@ -509,6 +581,29 @@ public class RemoteRepositoryProvider {
          */
         public boolean matches() {
             return filterPrefix != null;
+        }
+
+        /**
+         * The file for the given project path inside this mapping's
+         * checked-out repository copy, or null when the path is outside the
+         * mapping.
+         */
+        @Nullable
+        File fileInRepository(String path) {
+            String p = withLeadingSlash(withoutTrailingSlash(path));
+            String local = withSlashes(repoMapping.getLocal());
+            String relative;
+            if (withTrailingSlash(p).equals(local)) {
+                // file mapping: the repository part is the file itself
+                relative = "";
+            } else if (p.startsWith(local)) {
+                relative = p.substring(local.length());
+            } else {
+                return null;
+            }
+            File base = new File(getRepositoryDir(repoDefinition),
+                    withoutLeadingSlash(repoMapping.getRepository()));
+            return new File(base, relative);
         }
 
         public void copyFromRepoToProject(final String postfix) throws IOException {

--- a/src/main/java/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/main/java/org/omegat/gui/main/ProjectUICommands.java
@@ -40,7 +40,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
@@ -58,9 +60,12 @@ import org.omegat.convert.ConvertProject;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.KnownException;
+import org.omegat.core.data.IProject;
 import org.omegat.core.data.ProjectFactory;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.RuntimePreferenceStore;
+import org.omegat.core.data.TeamSetting;
+import org.omegat.core.data.TeamSettingsRegistry;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.segmentation.SRXManager;
@@ -329,13 +334,104 @@ public final class ProjectUICommands {
             protected void done() {
                 try {
                     get();
-                    SwingUtilities.invokeLater(Core.getEditor()::requestFocus);
+                    SwingUtilities.invokeLater(() -> {
+                        Core.getEditor().requestFocus();
+                        promptForSupersededSettings();
+                    });
                 } catch (Exception ex) {
                     Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                     Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                 }
             }
         }.execute();
+    }
+
+    /**
+     * The team's project settings file of the just opened team project
+     * carried different values than this checkout, and the team values are
+     * now active. Asks the user per setting what to do with the local value:
+     * share it with the team, use the team's value, or restore it for this
+     * session only - the next open supersedes and asks again. Dismissing a
+     * dialog leaves the team's value active.
+     */
+    private static void promptForSupersededSettings() {
+        IProject project = Core.getProject();
+        if (!project.isProjectLoaded()) {
+            return;
+        }
+        for (Map.Entry<String, @Nullable String> entry : project.getSupersededLocalSettings().entrySet()) {
+            TeamSetting setting = TeamSettingsRegistry.byKey(entry.getKey());
+            if (setting == null) {
+                continue;
+            }
+            String localValue = entry.getValue();
+            String teamValue = setting.read(project.getProjectProperties());
+            String[] options = { OStrings.getString("TEAM_SETTING_SHARE"),
+                    OStrings.getString("TEAM_SETTING_TAKE_TEAM"),
+                    OStrings.getString("TEAM_SETTING_KEEP_THIS_TIME") };
+            int answer = JOptionPane.showOptionDialog(Core.getMainWindow().getApplicationFrame(),
+                    OStrings.getString("TEAM_SETTING_DIVERGED_MESSAGE", setting.getDisplayName(),
+                            setting.describe(localValue), setting.describe(teamValue)),
+                    OStrings.getString("TEAM_SETTING_DIVERGED_TITLE"), JOptionPane.DEFAULT_OPTION,
+                    JOptionPane.QUESTION_MESSAGE, null, options, options[1]);
+            if (answer != 0 && answer != 1 && answer != 2) {
+                // Dismissed: the team's value stays active for this session,
+                // the local file keeps the local value, and the next open
+                // asks again.
+                continue;
+            }
+            boolean share = answer == 0;
+            String value = answer == 1 ? teamValue : localValue;
+            // The repository work must stay off the EDT and must not run
+            // beside the auto-save thread. Taking the team's value persists
+            // it locally, so the divergence is settled instead of
+            // resurfacing on every open.
+            new SwingWorker<Void, Void>() {
+                @Override
+                protected Void doInBackground() throws Exception {
+                    Core.executeExclusively(true, () -> {
+                        try {
+                            if (share) {
+                                project.publishProjectSetting(entry.getKey(), value);
+                            } else {
+                                project.useLocalProjectSetting(entry.getKey(), value);
+                            }
+                        } catch (Exception ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    });
+                    return null;
+                }
+
+                @Override
+                protected void done() {
+                    try {
+                        get();
+                    } catch (Exception ex) {
+                        String key = share ? "TEAM_SETTING_SHARE_ERROR" : "TEAM_SETTING_APPLY_ERROR";
+                        Log.logErrorRB(ex, key);
+                        Core.getMainWindow().displayErrorRB(ex, key);
+                    }
+                }
+            }.execute();
+        }
+    }
+
+    /** Session values of all registered team settings, keyed by setting key. */
+    private static Map<String, @Nullable String> readSessionTeamSettings() {
+        Map<String, @Nullable String> values = new HashMap<>();
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            values.put(setting.getKey(), setting.read(props));
+        }
+        return values;
+    }
+
+    private static void applySessionTeamSettings(Map<String, @Nullable String> values) {
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            setting.apply(props, values.get(setting.getKey()));
+        }
     }
 
     private static @Nullable File selectProjectRootFolder(File projectDirectory) {
@@ -864,18 +960,64 @@ public final class ProjectUICommands {
         // commit the current entry first
         Core.getEditor().commitAndLeave();
 
+        // The dialog edits the live properties, so the current values have
+        // to be captured before it is shown.
+        final Map<String, @Nullable String> teamSettingsBefore = readSessionTeamSettings();
+
         // displaying the dialog to change paths and other properties
         final ProjectProperties newProps =
                 ProjectPropertiesDialogController.showDialog(frame, Core.getProject().getProjectProperties(),
                 Core.getProject().getProjectProperties().getProjectName(),
                 ProjectPropertiesDialog.Mode.EDIT_PROJECT);
         if (newProps == null) {
+            // The dialog edits the live properties even before a validation
+            // stops its OK, so cancelling must not leave flipped values.
+            applySessionTeamSettings(teamSettingsBefore);
             return;
         }
+
+        // Changing a team setting right here is the natural moment to offer
+        // its distribution; declining keeps it local, and the next open of
+        // the project asks again.
+        final Map<String, @Nullable String> changedTeamSettings = new HashMap<>();
+        if (Core.getProject().isRemoteProject()) {
+            for (TeamSetting setting : TeamSettingsRegistry.all()) {
+                String after = setting.read(newProps);
+                if (!Objects.equals(teamSettingsBefore.get(setting.getKey()), after)) {
+                    changedTeamSettings.put(setting.getKey(), after);
+                }
+            }
+        }
+        final Map<String, @Nullable String> settingsToShare = new HashMap<>();
+        changedTeamSettings.forEach((key, value) -> {
+            TeamSetting setting = TeamSettingsRegistry.byKey(key);
+            if (setting != null && promptToShareSettingChange(setting, value)) {
+                settingsToShare.put(key, value);
+            }
+        });
 
         int res = JOptionPane.showConfirmDialog(frame, OStrings.getString("MW_REOPEN_QUESTION"),
                 OStrings.getString("MW_REOPEN_TITLE"), JOptionPane.YES_NO_OPTION);
         if (res != JOptionPane.YES_OPTION) {
+            if (!settingsToShare.isEmpty()) {
+                new SwingWorker<Void, Void>() {
+                    @Override
+                    protected Void doInBackground() throws Exception {
+                        Core.executeExclusively(true, () -> publishSettingsLoggingErrors(settingsToShare));
+                        return null;
+                    }
+
+                    @Override
+                    protected void done() {
+                        try {
+                            get();
+                        } catch (Exception ex) {
+                            Log.logErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                            Core.getMainWindow().displayErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                        }
+                    }
+                }.execute();
+            }
             return;
         }
 
@@ -885,10 +1027,30 @@ public final class ProjectUICommands {
             @Override
             protected Void doInBackground() throws Exception {
                 Core.executeExclusively(true, () -> {
+                    if (!settingsToShare.isEmpty()) {
+                        // A failed share must not abort the reload; the
+                        // local file keeps the value, so the next open
+                        // offers the distribution again.
+                        publishSettingsLoggingErrors(settingsToShare);
+                    }
                     Core.getProject().saveProject(true);
                     ProjectFactory.closeProject();
 
                     ProjectFactory.loadProject(newProps, true);
+                    changedTeamSettings.forEach((key, value) -> {
+                        if (!settingsToShare.containsKey(key)) {
+                            // The share was declined, so the freshly chosen
+                            // value must stay local: without this, the
+                            // reload would classify it as local-only
+                            // divergence and fall back to the team default
+                            // without a word.
+                            try {
+                                Core.getProject().useLocalProjectSetting(key, value);
+                            } catch (Exception ex) {
+                                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                            }
+                        }
+                    });
                 });
                 return null;
             }
@@ -908,6 +1070,32 @@ public final class ProjectUICommands {
                 }
             }
         }.execute();
+    }
+
+    /**
+     * The properties dialog of a team project just changed a registered
+     * team setting; asks whether to distribute the change.
+     */
+    private static boolean promptToShareSettingChange(TeamSetting setting, @Nullable String value) {
+        String[] options = { OStrings.getString("TEAM_SETTING_SHARE"),
+                OStrings.getString("TEAM_SETTING_KEEP_FOR_NOW") };
+        return JOptionPane.showOptionDialog(Core.getMainWindow().getApplicationFrame(),
+                OStrings.getString("TEAM_SETTING_CHANGED_MESSAGE", setting.getDisplayName(),
+                        setting.describe(value)),
+                OStrings.getString("TEAM_SETTING_DIVERGED_TITLE"), JOptionPane.DEFAULT_OPTION,
+                JOptionPane.QUESTION_MESSAGE, null, options, options[0]) == 0;
+    }
+
+    private static void publishSettingsLoggingErrors(Map<String, @Nullable String> settings) {
+        settings.forEach((key, value) -> {
+            try {
+                Core.getProject().publishProjectSetting(key, value);
+            } catch (Exception ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                SwingUtilities.invokeLater(
+                        () -> Core.getMainWindow().displayErrorRB(ex, "TEAM_SETTING_SHARE_ERROR"));
+            }
+        });
     }
 
     public static void projectCompile() {

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -2318,6 +2318,18 @@ TEAM_HTTP_UNAUTHORIZED=Authentication error when trying to access {0}.
 TEAM_HTTP_NOT_FOUND=No content found at {0}.
 TEAM_HTTP_OTHER_ERRORS=HTTP connection {1} responded with code: {2}.
 
+TEAM_SETTING_DIVERGED_TITLE=Team Project Setting
+TEAM_SETTING_DIVERGED_MESSAGE=The project setting "{0}" is {1} on this computer but {2} in the team project. The team version is now active.\nWhat do you want to do with the local version?
+TEAM_SETTING_SHARE=Share with the team
+TEAM_SETTING_TAKE_TEAM=Use the team version
+TEAM_SETTING_KEEP_THIS_TIME=Use the local version this time
+TEAM_SETTING_CHANGED_MESSAGE=You changed the project setting "{0}" to {1}. Share the change with the team? Without sharing it stays local, and the next open of the project asks again.
+TEAM_SETTING_KEEP_FOR_NOW=Keep it local for now
+TEAM_SETTING_VALUE_ON=enabled
+TEAM_SETTING_VALUE_OFF=disabled
+TEAM_SETTING_SHARE_ERROR=The setting could not be committed to the team project.
+TEAM_SETTING_APPLY_ERROR=The local setting could not be applied.
+
 # Save options
 SAVE_DIALOG_TITLE=Saving and Output Options
 PREFS_TITLE_SAVING_AND_OUTPUT=Saving and Output

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -2187,6 +2187,18 @@ TEAM_HTTP_UNAUTHORIZED=Authentifizierungsfehler beim Zugriff auf {0}.
 TEAM_HTTP_NOT_FOUND=Kein Inhalt gefunden bei {0}.
 TEAM_HTTP_OTHER_ERRORS=HTTP-Verbindung {1} antwortet mit Code: {2}.
 
+TEAM_SETTING_DIVERGED_TITLE=Team-Projekteinstellung
+TEAM_SETTING_DIVERGED_MESSAGE=Die Projekteinstellung "{0}" ist auf diesem Rechner {1}, im Teamprojekt {2}. Die Team-Fassung ist jetzt aktiv.\nWas soll mit der lokalen Fassung geschehen?
+TEAM_SETTING_SHARE=Ans Team verteilen
+TEAM_SETTING_TAKE_TEAM=Team-Fassung \u00FCbernehmen
+TEAM_SETTING_KEEP_THIS_TIME=Diesmal die lokale Fassung verwenden
+TEAM_SETTING_CHANGED_MESSAGE=Die Projekteinstellung "{0}" wurde auf {1} ge\u00E4ndert. Soll die \u00C4nderung ans Team verteilt werden? Ohne Verteilung bleibt sie lokal, und das n\u00E4chste \u00D6ffnen des Projekts fragt erneut.
+TEAM_SETTING_KEEP_FOR_NOW=Vorerst lokal belassen
+TEAM_SETTING_VALUE_ON=aktiviert
+TEAM_SETTING_VALUE_OFF=deaktiviert
+TEAM_SETTING_SHARE_ERROR=Die Einstellung konnte nicht ins Teamprojekt \u00FCbertragen werden.
+TEAM_SETTING_APPLY_ERROR=Die lokale Einstellung konnte nicht angewendet werden.
+
 # Save options
 SAVE_DIALOG_TITLE=Speichern und Ausgabe
 PREFS_TITLE_SAVING_AND_OUTPUT=Speichern und Ausgabe

--- a/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
@@ -1,0 +1,274 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.team2.RemoteRepositoryProvider;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that sharing a team project setting commits the sidecar settings
+ * file and leaves omegat.project untouched, so team members on older OmegaT
+ * versions can still open the project.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectSettingsPublishTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "README").toPath(), "team project\n",
+                StandardCharsets.UTF_8);
+        commitAll("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    @Test
+    public void testPublishDeliversTheSettingsFileToTheTeam() throws Exception {
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("the team must receive the value", "true", loadDeliveredValue("member2"));
+        assertFalse("omegat.project must stay untouched for older versions",
+                new File(projectDir, OConsts.FILE_PROJECT).exists());
+    }
+
+    @Test
+    public void testPublishCanAlsoOverwriteAValue() throws Exception {
+        Files.createDirectories(new File(remoteDir, OConsts.DEFAULT_INTERNAL).toPath());
+        Files.writeString(remoteSettingsFile().toPath(), KEY + "=true\n", StandardCharsets.UTF_8);
+        commitAll("team with the option");
+
+        ProjectSettingsStorage.save(config, KEY, "false");
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("the team must receive the new value", "false", loadDeliveredValue("member2"));
+    }
+
+    @Test
+    public void testPublishingAnAlreadySharedValueIsNotAnError() throws Exception {
+        // Another team member shared the same value in the meantime: the git
+        // commit would be a no-op, which reports the same way as a rejected
+        // push - so publishing must recognise the identical file and skip.
+        Files.createDirectories(new File(remoteDir, OConsts.DEFAULT_INTERNAL).toPath());
+        Files.writeString(remoteSettingsFile().toPath(), KEY + "=true\n", StandardCharsets.UTF_8);
+        commitAll("team already carries the value");
+
+        ProjectSettingsStorage.save(config, KEY, "true");
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("true", loadDeliveredValue("member2"));
+    }
+
+    @Test
+    public void testStorageRoundTripAndDefaults() throws Exception {
+        assertNull("unconfigured project reads as null", ProjectSettingsStorage.load(config, KEY));
+        // removing an unset key must not materialise the file
+        ProjectSettingsStorage.save(config, KEY, null);
+        assertFalse("removing from an absent file must stay a no-op",
+                ProjectSettingsStorage.getFile(config).isFile());
+        ProjectSettingsStorage.save(config, KEY, "true");
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+        // deterministic content, so team no-op detection can compare bytes
+        assertEquals(KEY + "=true\n",
+                Files.readString(ProjectSettingsStorage.getFile(config).toPath(), StandardCharsets.UTF_8));
+        ProjectSettingsStorage.save(config, KEY, "false");
+        assertEquals("false", ProjectSettingsStorage.load(config, KEY));
+        // null removes the key but keeps the file and foreign keys
+        Files.writeString(ProjectSettingsStorage.getFile(config).toPath(),
+                "future_setting=x\n" + KEY + "=false\n", StandardCharsets.UTF_8);
+        ProjectSettingsStorage.save(config, KEY, null);
+        assertNull(ProjectSettingsStorage.load(config, KEY));
+        assertTrue(Files.readString(ProjectSettingsStorage.getFile(config).toPath(),
+                StandardCharsets.UTF_8).contains("future_setting=x"));
+    }
+
+    @Test
+    public void testResolveSettingTruthTable() {
+        // non-team / offline: the local file rules, never a question
+        assertResolved(null, null, RealProject.resolveSetting(null, null, false, false));
+        assertResolved("true", null, RealProject.resolveSetting(null, "true", false, false));
+        // team: remote delivered a value over an absent local file - first
+        // arrival activates and asks once
+        assertAsks("true", null, RealProject.resolveSetting(null, "true", true, true));
+        // team: remote delivered a differing value - team wins, asks
+        assertAsks("false", "true", RealProject.resolveSetting("true", "false", true, true));
+        // team: local-only survivor - team default stays active, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", "true", false, true));
+        // team: both agree (shared value) - quiet
+        assertResolved("true", null, RealProject.resolveSetting("true", "true", true, true));
+        // team: nothing anywhere - quiet
+        assertResolved(null, null, RealProject.resolveSetting(null, null, false, true));
+        // team: remote carries only foreign future keys - like absent, quiet
+        assertResolved(null, null, RealProject.resolveSetting(null, null, true, true));
+        // team: the sync deleted the key - team default wins, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", null, true, true));
+        // team: diverged and not identical - local-only, team default, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", "false", false, true));
+    }
+
+    private static void assertResolved(String effective, String superseded,
+            RealProject.SettingResolution state) {
+        assertEquals(effective, state.effective);
+        assertFalse("expected quiet resolution", state.asks);
+        assertEquals(superseded, state.supersededLocal);
+    }
+
+    private static void assertAsks(String effective, String superseded,
+            RealProject.SettingResolution state) {
+        assertEquals(effective, state.effective);
+        assertTrue("expected a question", state.asks);
+        assertEquals(superseded, state.supersededLocal);
+    }
+
+    @Test
+    public void testPersistSessionSettingsSkipsSupersededAndDefaults() throws Exception {
+        AtomicBoolean first = new AtomicBoolean(true);
+        AtomicBoolean second = new AtomicBoolean(true);
+        TeamSettingsRegistry.register(TeamSetting.ofBoolean("first_option",
+                "TEAM_SETTING_DIVERGED_TITLE", false, p -> first.get(), (p, v) -> first.set(v)));
+        TeamSettingsRegistry.register(TeamSetting.ofBoolean("second_option",
+                "TEAM_SETTING_DIVERGED_TITLE", false, p -> second.get(), (p, v) -> second.set(v)));
+        try {
+            // superseded key keeps the file untouched for its setting, the
+            // other one still persists
+            RealProject.persistSessionSettings(config, Collections.singleton("first_option"));
+            assertNull(ProjectSettingsStorage.load(config, "first_option"));
+            assertEquals("true", ProjectSettingsStorage.load(config, "second_option"));
+
+            // default values stay unmaterialised unless the file exists
+            Files.delete(ProjectSettingsStorage.getFile(config).toPath());
+            first.set(false);
+            second.set(false);
+            RealProject.persistSessionSettings(config, Collections.emptySet());
+            assertFalse("defaults must not materialise the file",
+                    ProjectSettingsStorage.getFile(config).isFile());
+        } finally {
+            TeamSettingsRegistry.unregister("first_option");
+            TeamSettingsRegistry.unregister("second_option");
+        }
+    }
+
+    @Test
+    public void testEscapingWriterRoundTripsForeignKeys() throws Exception {
+        Files.createDirectories(ProjectSettingsStorage.getFile(config).getParentFile().toPath());
+        Files.writeString(ProjectSettingsStorage.getFile(config).toPath(),
+                "future\\ key\\=x=va\\\\lue\\=1\n" + KEY + "=false\n", StandardCharsets.UTF_8);
+        Properties before = loadRaw();
+        ProjectSettingsStorage.save(config, KEY, "true");
+        Properties after = loadRaw();
+        assertEquals("foreign key must survive the rewrite unchanged", before.getProperty("future key=x"),
+                after.getProperty("future key=x"));
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    private Properties loadRaw() throws Exception {
+        Properties p = new Properties();
+        try (java.io.Reader in = Files.newBufferedReader(
+                ProjectSettingsStorage.getFile(config).toPath(), StandardCharsets.UTF_8)) {
+            p.load(in);
+        }
+        return p;
+    }
+
+    private File remoteSettingsFile() {
+        return new File(remoteDir,
+                OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+    }
+
+    private void commitAll(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    /** Fetch the settings file the way a second member's open does. */
+    private String loadDeliveredValue(String memberDirName) throws Exception {
+        File memberDir = folder.newFolder(memberDirName);
+        RemoteRepositoryProvider member = newProvider(memberDir, remoteDir);
+        member.switchAllToLatest();
+        member.copyFilesFromReposToProject("");
+        return ProjectSettingsStorage.load(new ProjectProperties(memberDir), KEY);
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}

--- a/src/test/java/org/omegat/core/data/TeamSettingTest.java
+++ b/src/test/java/org/omegat/core/data/TeamSettingTest.java
@@ -1,0 +1,122 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Contract of the boolean team setting descriptor and the registry: absent
+ * key means default, only the non-default value materialises, normalization
+ * folds explicit default values back to null so divergence detection never
+ * confuses "explicitly default" with "not configured".
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class TeamSettingTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @After
+    public final void tearDown() {
+        TeamSettingsRegistry.unregister(KEY);
+    }
+
+    @Test
+    public void testOptInBooleanContract() throws Exception {
+        AtomicBoolean holder = new AtomicBoolean(false);
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false,
+                config -> holder.get(), (config, value) -> holder.set(value));
+        ProjectProperties config = new ProjectProperties(folder.newFolder("p"));
+
+        assertNull("default reads as not configured", setting.read(config));
+        holder.set(true);
+        assertEquals("only the non-default value materialises", "true", setting.read(config));
+
+        setting.apply(config, null);
+        assertEquals("null applies the default", false, holder.get());
+        setting.apply(config, "true");
+        assertTrue(holder.get());
+
+        assertNull("explicit default folds back to null", setting.normalize("false"));
+        assertEquals("true", setting.normalize("true"));
+        assertNull(setting.normalize(null));
+    }
+
+    @Test
+    public void testOptOutBooleanContract() throws Exception {
+        AtomicBoolean holder = new AtomicBoolean(true);
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", true,
+                config -> holder.get(), (config, value) -> holder.set(value));
+        ProjectProperties config = new ProjectProperties(folder.newFolder("p"));
+
+        assertNull("default reads as not configured", setting.read(config));
+        holder.set(false);
+        assertEquals("false", setting.read(config));
+
+        setting.apply(config, null);
+        assertTrue("null applies the default", holder.get());
+        assertNull("explicit default folds back to null", setting.normalize("true"));
+        assertEquals("false", setting.normalize("false"));
+    }
+
+    @Test
+    public void testDisplayNameStripsMnemonicMarker() {
+        // existing label keys carry mnemonic markers; dialogs must not show them
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "PP_REMOVE_TAGS", false,
+                config -> false, (config, value) -> {
+                });
+        assertFalse("marker key must resolve to a non-empty name", setting.getDisplayName().isEmpty());
+        assertEquals("mnemonic marker must be stripped", -1, setting.getDisplayName().indexOf('&'));
+    }
+
+    @Test
+    public void testRegistryRejectsDuplicatesAndUnregisters() {
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false,
+                config -> false, (config, value) -> {
+                });
+        TeamSettingsRegistry.register(setting);
+        assertNotNull(TeamSettingsRegistry.byKey(KEY));
+        assertThrows(IllegalArgumentException.class, () -> TeamSettingsRegistry.register(setting));
+        TeamSettingsRegistry.unregister(KEY);
+        assertNull(TeamSettingsRegistry.byKey(KEY));
+        assertTrue(TeamSettingsRegistry.all().stream().noneMatch(s -> s.getKey().equals(KEY)));
+    }
+}

--- a/src/test/java/org/omegat/core/team2/ProjectSettingsTeamRoundTripTest.java
+++ b/src/test/java/org/omegat/core/team2/ProjectSettingsTeamRoundTripTest.java
@@ -1,0 +1,168 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectSettingsStorage;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that a per-project team setting survives the team project round
+ * trip in its sidecar file omegat/project_settings.properties: the routine
+ * full sync distributes and supersedes it like any other configuration file,
+ * a purely local file survives the sync and is recognisable as local-only
+ * divergence through the repository comparison.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectSettingsTeamRoundTripTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "readme.txt").toPath(), "team project",
+                StandardCharsets.UTF_8);
+        // the provider detects the repository type at construction time, so
+        // the remote must be a git repository before newProvider runs
+        commitRemote("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    @Test
+    public void testTeamOpenDeliversTheRemoteSettingsFile() throws Exception {
+        writeRemoteSettings(KEY + "=true\n");
+        commitRemote("team with the option");
+
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("the full sync must deliver the settings file", "true",
+                ProjectSettingsStorage.load(config, KEY));
+        assertTrue("a delivered file is identical to the repository copy",
+                provider.isIdenticalInRepositories(settingsPathUnderRoot()));
+    }
+
+    @Test
+    public void testRemoteFileSupersedesADivergingLocalFile() throws Exception {
+        writeRemoteSettings(KEY + "=false\n");
+        commitRemote("team without the option");
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        // the pre-sync snapshot is what the open uses to notice and report
+        // the superseded local value
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("on open, the team's file wins", "false", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    @Test
+    public void testLocalOnlyFileSurvivesTheSyncAndReadsAsDivergence() throws Exception {
+        commitRemote("team without a settings file");
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("a file the team never had survives the full sync", "true",
+                ProjectSettingsStorage.load(config, KEY));
+        assertFalse("the survivor is recognisable as local-only, so the open "
+                + "keeps the team default active and asks",
+                provider.isIdenticalInRepositories(settingsPathUnderRoot()));
+    }
+
+    private String settingsPathUnderRoot() {
+        return OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
+    }
+
+    private void writeRemoteSettings(String content) throws Exception {
+        File f = new File(remoteDir,
+                OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+        Files.createDirectories(f.getParentFile().toPath());
+        Files.writeString(f.toPath(), content, StandardCharsets.UTF_8);
+    }
+
+    private void commitRemote(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- (none — infrastructure base for SF-RFE-465 et al., some 'older' open PR's will be restacked onto this one to reuse the infrastructure)

## What does this PR change?

- Per-project settings a team should share had no home: project file parser of released OmegaT versions rejects unknown elements in omegat.project, locking team members on older versions out. Registered settings now live in `omegat/project_settings.properties`; older versions ignore extra file, file only materialises once setting is used, default projects stay byte-identical.
- Generic, feature-neutral machinery: `TeamSetting` descriptor + `TeamSettingsRegistry` (empty registry = every code path no-op), string-keyed `ProjectSettingsStorage` (deterministic write, byte-identity no-op detection on team commit), `IProject` default API (publish/useLocal/superseded), load flow activates team values and asks per superseded local value (share / take team / keep this time), properties dialog offers distribution on change; dialogs use generic {0} texts, en+de.
- 13 tests against real git repositories: publish/no-op guard, team round trip, resolution truth table, descriptor and persistence contracts.
- Follow-up PRs register concrete settings (fuzzy number matching, numeral value check, character equivalence) as thin one-line registrations.

## Other information

Extracted feature-neutrally from the number-substitution stack. Behavior unchanged until first setting registers.
