### PR TITLE
feat(filters): add support for `note` in XLIFF target (RFE-1621)

### DIFF
--- a/src/main/java/org/omegat/core/data/TranslateEntry.java
+++ b/src/main/java/org/omegat/core/data/TranslateEntry.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.core.segmentation.Rule;
 import org.omegat.filters2.ITranslateCallback;
@@ -41,7 +42,7 @@ import org.omegat.util.TagUtil;
 
 /**
  * Base class for entry translation.
- *
+ * <p>
  * This class collects all segments which should be translated, for ability to link prev/next segments for the
  * seconds pass.
  *
@@ -56,7 +57,7 @@ public abstract class TranslateEntry implements ITranslateCallback {
     private int pass;
 
     /** Collected segments. */
-    private List<TranslateEntryQueueItem> translateQueue = new ArrayList<TranslateEntryQueueItem>();
+    private final List<TranslateEntryQueueItem> translateQueue = new ArrayList<>();
 
     /**
      * Index of currently processed segment. It required for multiple translation for use right segment.
@@ -89,11 +90,8 @@ public abstract class TranslateEntry implements ITranslateCallback {
         translateQueue.clear();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public String getTranslation(final String id, final String origSource, final String path) {
+    public String getTranslation(@Nullable String id, String origSource, @Nullable String path) {
         ParseEntry.ParseEntryResult spr = new ParseEntry.ParseEntryResult();
 
         // fix for bug 3487497;
@@ -112,8 +110,8 @@ public abstract class TranslateEntry implements ITranslateCallback {
 
         if (config.isSentenceSegmentingEnabled()) {
             boolean translated = false;
-            List<StringBuilder> spaces = new ArrayList<StringBuilder>();
-            List<Rule> brules = new ArrayList<Rule>();
+            List<StringBuilder> spaces = new ArrayList<>();
+            List<Rule> brules = new ArrayList<>();
             Language sourceLang = config.getSourceLanguage();
             Language targetLang = config.getTargetLanguage();
             List<String> segments = Core.getSegmenter().segment(sourceLang, source, spaces, brules);
@@ -196,17 +194,12 @@ public abstract class TranslateEntry implements ITranslateCallback {
         return r;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
+    @Deprecated
     public String getTranslation(final String id, final String origSource) {
         return getTranslation(id, origSource, null);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void linkPrevNextSegments() {
         for (int i = 0; i < translateQueue.size(); i++) {
@@ -226,14 +219,9 @@ public abstract class TranslateEntry implements ITranslateCallback {
         }
     }
 
-    /**
+    /*
      * This method calls real method for empty prev/next on the first pass, then with real prev/next on the
      * second pass.
-     *
-     * @param id
-     * @param segmentIndex
-     * @param segmentSource
-     * @return
      */
     private String internalGetSegmentTranslation(String id, int segmentIndex, String segmentSource, String path) {
         if (segmentSource.trim().isEmpty()) {

--- a/src/main/java/org/omegat/filters2/ITranslateCallback.java
+++ b/src/main/java/org/omegat/filters2/ITranslateCallback.java
@@ -59,7 +59,8 @@ public interface ITranslateCallback {
      *            path of segment
      * @return translation or null if translation not exist
      */
-    @Nullable String getTranslation(@Nullable String id, String source, @Nullable String path);
+    @Nullable
+    String getTranslation(@Nullable String id, String source, @Nullable String path);
 
     /**
      * Old call without path, for compatibility
@@ -69,6 +70,11 @@ public interface ITranslateCallback {
      *              source entry text
      * @return translation or null if translation not exist
      */
-    @Nullable String getTranslation(@Nullable String id, String source);
+    @Deprecated
+    @Nullable
+    String getTranslation(@Nullable String id, String source);
 
+    default @Nullable String getNote(@Nullable String id, String source, @Nullable String path) {
+        return null;
+    }
 }

--- a/src/main/java/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -327,8 +327,10 @@ public class Xliff2Filter extends AbstractXliffFilter {
 
         String src = buildTags(source, false);
         String tra = null;
+        String note = null;
         if (entryTranslateCallback != null) {
             tra = entryTranslateCallback.getTranslation(segId, src, path);
+            note = entryTranslateCallback.getNote(segId, src, path);
         }
         if (tra != null) {
             writer.writeStartElement(namespace, "target");
@@ -348,6 +350,11 @@ public class Xliff2Filter extends AbstractXliffFilter {
             }
         }
         writer.writeEndElement(/* target */);
+        if (note !=null) {
+            writer.writeStartElement(namespace, "note");
+            fromEventToWriter(eFactory.createCharacters(note), writer) ;
+            writer.writeEndElement();
+        }
         flushedSegment = true;
     }
 

--- a/src/main/java/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -350,9 +350,9 @@ public class Xliff2Filter extends AbstractXliffFilter {
             }
         }
         writer.writeEndElement(/* target */);
-        if (note !=null) {
+        if (note != null) {
             writer.writeStartElement(namespace, "note");
-            fromEventToWriter(eFactory.createCharacters(note), writer) ;
+            fromEventToWriter(eFactory.createCharacters(note), writer);
             writer.writeEndElement();
         }
         flushedSegment = true;

--- a/src/test/java/org/omegat/filters4/Xliff2FilterTest.java
+++ b/src/test/java/org/omegat/filters4/Xliff2FilterTest.java
@@ -4,6 +4,7 @@
           glossaries, and translation leveraging into updated projects.
 
  Copyright (C) 2022 Thomas Cordonnier
+               2026 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -32,11 +33,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.junit.Test;
 
 import org.omegat.filters2.ITranslateCallback;
 import org.omegat.filters4.xml.xliff.Xliff2Filter;
 
+@NullMarked
 public class Xliff2FilterTest extends org.omegat.filters.TestFilterBase {
     @Test
     public void testParse() throws Exception {
@@ -60,7 +64,7 @@ public class Xliff2FilterTest extends org.omegat.filters.TestFilterBase {
     public void testKey() throws Exception {
         List<ParsedEntry> entries = parse3(new Xliff2Filter(), "src/test/resources/data/filters/xliff/filters4-xliff2/ex.9.5.xlf",
             java.util.Collections.emptyMap());
-        ParsedEntry firstEntry = entries.get(0);
+        ParsedEntry firstEntry = entries.getFirst();
         assertEquals("1", firstEntry.id); // <segment> has no id, not mandatory
         assertEquals("//groups/N65541xdocument/N65541bxmarksection-1/title-2", firstEntry.path);
         ParsedEntry secondEntry = entries.get(2);
@@ -74,21 +78,34 @@ public class Xliff2FilterTest extends org.omegat.filters.TestFilterBase {
         filter.translateFile(new File("src/test/resources/data/filters/xliff/filters4-xliff2/ex.9.5.xlf"), 
             outFile, java.util.Collections.emptyMap(), context,
                 new ITranslateCallback() {
-                    public String getTranslation(String id, String source, String path) {
+                    @Override
+                    public @Nullable String getTranslation(@Nullable String id, String source, @Nullable String path) {
                         if ("Birds in Oregon".equals(source)) {
                             return "Oiseaux en Oregon";
                         }
                         return null; // not translated
                     }
 
-                    public String getTranslation(String id, String source) {
+                    @Deprecated
+                    @Override
+                    public @Nullable String getTranslation(@Nullable String id, String source) {
                         return getTranslation(id, source, "");
                     }
 
+                    @Override
                     public void linkPrevNextSegments() {
                     }
 
+                    @Override
                     public void setPass(int pass) {
+                    }
+
+                    @Override
+                    public @Nullable String getNote(@Nullable String id, String source, @Nullable String path) {
+                        if ("Birds in Oregon".equals(source)) {
+                            return "Oregon notes.";
+                        }
+                        return null;
                     }
                 });
         // Check that it correctly translates
@@ -97,7 +114,7 @@ public class Xliff2FilterTest extends org.omegat.filters.TestFilterBase {
         // entry translated in the source file, not in the Callback
         assertEquals("<t0>Oiseaux de haute altitude", entries.get(2).translation);
         // entry translated in the callback, not in the source file
-        assertEquals("Oiseaux en Oregon", entries.get(0).translation); 
+        assertEquals("Oiseaux en Oregon", entries.get(0).translation);
     }
 
     @Test


### PR DESCRIPTION

## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- Add notes as <note> in target XLIFF file
- https://sourceforge.net/p/omegat/feature-requests/1621/

## What does this PR change?

- Introduced `getNote()` default method in `ITranslateCallback` for handling translator/reviewer notes.
- Adjusted outdated API usage and streamlined callback methods in filters.


## Other information

This requires API extention so we need an architectural decision on dev list.
