### PR TITLE
[6.1] fix(glossary): search performance

### DIFF
--- a/src/org/omegat/gui/common/EntryInfoPane.java
+++ b/src/org/omegat/gui/common/EntryInfoPane.java
@@ -30,6 +30,8 @@ import java.awt.Rectangle;
 
 import javax.swing.JTextPane;
 
+import javax.swing.text.Document;
+
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.events.IProjectEventListener;
@@ -61,7 +63,19 @@ public abstract class EntryInfoPane<T> extends JTextPane implements IProjectEven
         if (!GraphicsEnvironment.isHeadless()) {
             setDragEnabled(true);
         }
-        getDocument().addDocumentListener(new FontFallbackListener(this));
+        FontFallbackListener fontFallback = new FontFallbackListener(this);
+        getDocument().addDocumentListener(fontFallback);
+        // Subclasses may swap in a prebuilt document (SF bug #981): move the
+        // fallback listener along and style the arriving content once.
+        addPropertyChangeListener("document", evt -> {
+            if (evt.getOldValue() instanceof Document) {
+                ((Document) evt.getOldValue()).removeDocumentListener(fontFallback);
+            }
+            if (evt.getNewValue() instanceof Document) {
+                ((Document) evt.getNewValue()).addDocumentListener(fontFallback);
+                fontFallback.styleWholeDocument((Document) evt.getNewValue());
+            }
+        });
         setForeground(Styles.EditorColor.COLOR_FOREGROUND.getColor());
         setCaretColor(Styles.EditorColor.COLOR_FOREGROUND.getColor());
         setBackground(Styles.EditorColor.COLOR_BACKGROUND.getColor());

--- a/src/org/omegat/gui/glossary/GlossaryManager.java
+++ b/src/org/omegat/gui/glossary/GlossaryManager.java
@@ -300,15 +300,30 @@ public class GlossaryManager implements DirectoryMonitor.Callback {
      * @return A list of tokens matching the supplied glossary entry
      */
     public List<Token[]> searchSourceMatchTokens(SourceTextEntry ste, GlossaryEntry entry) {
+        return searchSourceMatchTokens(ste, Collections.singletonList(entry)).get(0);
+    }
+
+    /**
+     * Get tokens of the source text that match the supplied glossary entries;
+     * the source text is tokenized only once (SF bug #981).
+     *
+     * @param ste
+     *            The entry to search
+     * @param entries
+     *            The glossary entries to match against
+     * @return One (possibly empty) token list per glossary entry, in the
+     *         order of {@code entries}; empty lists are immutable
+     */
+    public List<List<Token[]>> searchSourceMatchTokens(SourceTextEntry ste, List<GlossaryEntry> entries) {
         CoreState coreState = CoreState.getInstance();
         ITokenizer tok = coreState.getProject().getSourceTokenizer();
         if (tok == null) {
-            return Collections.emptyList();
+            return Collections.nCopies(entries.size(), Collections.emptyList());
         }
         GlossarySearcher searcher = buildSearcher(tok,
                 coreState.getProject().getProjectProperties().getSourceLanguage());
 
-        return searcher.searchSourceMatchTokens(ste, entry);
+        return searcher.searchSourceMatchTokens(ste, entries);
     }
 
     /**

--- a/src/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/org/omegat/gui/glossary/GlossarySearcher.java
@@ -30,10 +30,12 @@ import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.VisibleForTesting;
@@ -87,10 +89,26 @@ public class GlossarySearcher {
         Token[] strTokens = tokenize(ste.getSrcText(),
                 TagUtil.buildTagList(ste.getSrcText(), ste.getProtectedParts()));
 
+        // Cheap necessary conditions, computed once per search: a term can
+        // only match when every term token occurs among the source tokens
+        // (token equality is the text hash), and a CJK term can only be a
+        // substring when each of its chars occurs in the source text. Both
+        // prefilters skip the expensive per-entry scans for the vast majority
+        // of a large glossary (SF bug #981); hash collisions merely fall
+        // through to the full check.
+        Set<Integer> srcTokenHashes = new HashSet<>();
+        for (Token token : strTokens) {
+            srcTokenHashes.add(token.hashCode());
+        }
+        Set<Integer> srcChars = new HashSet<>();
+        for (int i = 0; i < ste.getSrcText().length(); i++) {
+            srcChars.add((int) ste.getSrcText().charAt(i));
+        }
+
         for (GlossaryEntry glosEntry : entries) {
             checkCancelled();
-            if (isTokenMatch(strTokens, ste.getSrcText(), glosEntry.getSrcText())
-                    || isCjkMatch(ste.getSrcText(), glosEntry.getSrcText())) {
+            if (isTokenMatch(strTokens, srcTokenHashes, ste.getSrcText(), glosEntry.getSrcText())
+                    || isCjkMatch(srcChars, ste.getSrcText(), glosEntry.getSrcText())) {
                 result.add(glosEntry);
             }
         }
@@ -128,15 +146,35 @@ public class GlossarySearcher {
      *           tokens between the source text entry and the glossary entry
      */
     public List<Token[]> searchSourceMatchTokens(SourceTextEntry ste, GlossaryEntry entry) {
+        return searchSourceMatchTokens(ste, Collections.singletonList(entry)).get(0);
+    }
+
+    /**
+     * Matching tokens for several glossary entries against one source text
+     * entry; the source text is tokenized only once (SF bug #981).
+     *
+     * @param ste
+     *              the source text entry containing the text to be tokenized
+     *              and matched
+     * @param entries
+     *              the glossary entries to match against
+     * @return   one (possibly empty) token list per glossary entry, in the
+     *           order of {@code entries}
+     */
+    public List<List<Token[]>> searchSourceMatchTokens(SourceTextEntry ste, List<GlossaryEntry> entries) {
         // Compute source entry tokens
         Token[] strTokens = tokenize(ste.getSrcText(),
                 TagUtil.buildTagList(ste.getSrcText(), ste.getProtectedParts()));
 
-        List<Token[]> toks = getMatchingTokens(strTokens, ste.getSrcText(), entry.getSrcText());
-        if (toks.isEmpty()) {
-            toks = getCjkMatchingTokens(ste.getSrcText(), entry.getSrcText());
+        List<List<Token[]>> result = new ArrayList<>(entries.size());
+        for (GlossaryEntry entry : entries) {
+            List<Token[]> toks = getMatchingTokens(strTokens, ste.getSrcText(), entry.getSrcText());
+            if (toks.isEmpty()) {
+                toks = getCjkMatchingTokens(ste.getSrcText(), entry.getSrcText());
+            }
+            result.add(toks);
         }
-        return toks;
+        return result;
     }
 
     public List<String> searchTargetMatches(String trg, ProtectedPart[] protectedParts, GlossaryEntry entry) {
@@ -167,6 +205,29 @@ public class GlossarySearcher {
         return !getMatchingTokens(fullTextTokens, fullText, term).isEmpty();
     }
 
+    private boolean isTokenMatch(Token[] fullTextTokens, Set<Integer> fullTextTokenHashes,
+            String fullText, String term) {
+        Token[] glosTokens = tokenize(term);
+        if (glosTokens.length == 0) {
+            return false;
+        }
+        for (Token glosToken : glosTokens) {
+            if (!fullTextTokenHashes.contains(glosToken.hashCode())) {
+                return false;
+            }
+        }
+        return !getMatchingTokens(fullTextTokens, glosTokens, fullText, term).isEmpty();
+    }
+
+    private static boolean isCjkMatch(Set<Integer> fullTextChars, String fullText, String term) {
+        for (int i = 0; i < term.length(); i++) {
+            if (!fullTextChars.contains((int) term.charAt(i))) {
+                return false;
+            }
+        }
+        return isCjkMatch(fullText, term);
+    }
+
     @VisibleForTesting
     boolean isGlossaryNotExactMatch() {
         return Preferences.isPreferenceDefault(Preferences.GLOSSARY_NOT_EXACT_MATCH,
@@ -179,6 +240,11 @@ public class GlossarySearcher {
         if (glosTokens.length == 0) {
             return Collections.emptyList();
         }
+        return getMatchingTokens(fullTextTokens, glosTokens, fullText, term);
+    }
+
+    private List<Token[]> getMatchingTokens(Token[] fullTextTokens, Token[] glosTokens, String fullText,
+            String term) {
         boolean notExact = isGlossaryNotExactMatch();
         List<Token[]> foundTokens = DefaultTokenizer.searchAll(fullTextTokens, glosTokens, notExact);
         foundTokens.removeIf(toks -> !keepMatch(toks, fullText, term));

--- a/src/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -58,6 +58,8 @@ import javax.swing.KeyStroke;
 import javax.swing.ToolTipManager;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Caret;
+import javax.swing.text.DefaultEditorKit;
+import javax.swing.text.DefaultStyledDocument;
 import javax.swing.text.Element;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.StyledDocument;
@@ -241,9 +243,18 @@ public class GlossaryTextArea extends EntryInfoThreadPane<List<GlossaryEntry>>
         }
 
         IGlossaryRenderer entryRenderer = GlossaryRenderers.getPreferredGlossaryRenderer();
+        // Render into an offline document and swap it in whole: every insert
+        // into the displayed document costs time proportional to the document
+        // length, which stalls the EDT for seconds once a large glossary
+        // produces hundreds of matches (SF bug #981).
+        StyledDocument newDoc = new DefaultStyledDocument();
+        // getText() falls back to the platform line separator without this
+        // property; setText-created documents carry it, so match them.
+        newDoc.putProperty(DefaultEditorKit.EndOfLineStringProperty, "\n");
         for (GlossaryEntry entry : entries) {
-            entryRenderer.render(entry, getStyledDocument());
+            entryRenderer.render(entry, newDoc);
         }
+        setStyledDocument(newDoc);
 
         firePropertyChange("entries", oldEntries, entries);
     }

--- a/src/org/omegat/gui/glossary/TransTipsMarker.java
+++ b/src/org/omegat/gui/glossary/TransTipsMarker.java
@@ -71,9 +71,14 @@ public class TransTipsMarker implements IMarker {
         List<Mark> marks = new ArrayList<>();
 
         IGlossaryRenderer renderer = GlossaryRenderers.getPreferredGlossaryRenderer();
-        for (GlossaryEntry ent : glossaryEntries) {
-            String tooltip = renderer.renderToHtml(ent);
-            List<Token[]> tokens = Core.getGlossaryManager().searchSourceMatchTokens(ste, ent);
+        List<List<Token[]>> matchTokens = Core.getGlossaryManager().searchSourceMatchTokens(ste,
+                glossaryEntries);
+        for (int i = 0; i < glossaryEntries.size(); i++) {
+            List<Token[]> tokens = matchTokens.get(i);
+            if (tokens.isEmpty()) {
+                continue;
+            }
+            String tooltip = renderer.renderToHtml(glossaryEntries.get(i));
             marks.addAll(getMarksForTokens(tokens, ste.getSrcText(), tooltip));
         }
         return marks;

--- a/src/org/omegat/util/gui/FontFallbackListener.java
+++ b/src/org/omegat/util/gui/FontFallbackListener.java
@@ -64,6 +64,14 @@ public class FontFallbackListener implements DocumentListener {
         doStyling(e.getDocument(), e.getOffset(), e.getLength());
     }
 
+    /**
+     * Style the supplied document as a whole. Needed once when a pane swaps
+     * in a prebuilt document, where no insert event fires (SF bug #981).
+     */
+    public void styleWholeDocument(Document document) {
+        doStyling(document, 0, document.getLength());
+    }
+
     private void doStyling(Document document, final int offset, final int length) {
         if (!Preferences.isPreference(Preferences.FONT_FALLBACK)) {
             return;

--- a/src/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -83,21 +83,27 @@ public final class JTextPaneLinkifier {
         jTextPane.addMouseMotionListener(mouseAdapter);
 
         // Those are the main called points from user's activities.
-        setDocumentFilter(jTextPane, extended);
+        setDocumentFilter(jTextPane, extended, false);
 
         jTextPane.addPropertyChangeListener("document", evt -> {
             Object source = evt.getSource();
             if (source instanceof JTextPane) {
-                setDocumentFilter((JTextPane) source, extended);
+                setDocumentFilter((JTextPane) source, extended, true);
             }
         });
     }
 
-    private static void setDocumentFilter(JTextPane textPane, boolean extended) {
+    private static void setDocumentFilter(JTextPane textPane, boolean extended, boolean refreshExisting) {
         final StyledDocument doc = textPane.getStyledDocument();
         if (doc instanceof AbstractDocument) {
             final AbstractDocument abstractDocument = (AbstractDocument) doc;
-            abstractDocument.setDocumentFilter(new AttributeInserterDocumentFilter(doc, extended));
+            AttributeInserterDocumentFilter filter = new AttributeInserterDocumentFilter(doc, extended);
+            abstractDocument.setDocumentFilter(filter);
+            if (refreshExisting && doc.getLength() > 0) {
+                // A swapped-in document arrives fully built, so no insert will
+                // trigger the refresh: style its links once now.
+                SwingUtilities.invokeLater(filter::refreshPane);
+            }
         }
     }
 

--- a/test-acceptance/src/org/omegat/gui/glossary/GlossaryPaneSegmentSwitchTest.java
+++ b/test-acceptance/src/org/omegat/gui/glossary/GlossaryPaneSegmentSwitchTest.java
@@ -1,0 +1,173 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.glossary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.beans.PropertyChangeListener;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.swing.SwingUtilities;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.gui.main.TestCoreGUI;
+import org.omegat.util.Preferences;
+
+/**
+ * End-to-end guard for the glossary pane half of SF bug #981 ("5.2.0
+ * painfully slow"): a segment switch against a glossary that yields hundreds
+ * of matches must search and render the pane through the real GUI and EDT
+ * within a time budget. Since 5.x every entry was inserted separately into
+ * the live StyledDocument, which grew superlinearly with the match count
+ * (400 matches = 1.1 s, 800 = 4.5 s); the fix renders into an offline
+ * document and swaps it in whole. The searcher and tokenization budgets are
+ * guarded unit-level by {@code GlossarySearchLoadTest}.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class GlossaryPaneSegmentSwitchTest extends TestCoreGUI {
+
+    private static final Path PROJECT_PATH = Paths.get("test-acceptance/data/project/");
+
+    /** Match count a long segment reaches against a 12 MB glossary file. */
+    private static final int ERROR_MATCHES = 800;
+    /** Match count of the second segment, so both switch directions render. */
+    private static final int SENTENCE_MATCHES = 400;
+    /**
+     * Budget for one end-to-end segment switch (glossary search plus pane
+     * rendering), best of three rounds, with headroom for loaded CI runners;
+     * the unfixed rendering needed 4.5 s for the same match count.
+     */
+    private static final long SWITCH_RENDER_BUDGET_MS = 1_000;
+
+    @Test
+    public void glossaryPaneFollowsSegmentSwitchesWithManyMatches() throws Exception {
+        // Merging would collapse the same-source variants into one rendered
+        // entry; the reported freeze scales with the rendered entry count.
+        Preferences.setPreference(Preferences.GLOSSARY_MERGE_ALTERNATE_DEFINITIONS, false);
+        openSampleProjectWaitGlossary(prepareProjectWithLargeGlossary());
+        robot().waitForIdle();
+        assertNotNull(window);
+
+        GlossaryTextArea pane = (GlossaryTextArea) Core.getGlossary();
+        // last_entry.properties activates the "Error {0}: {1}" segment
+        assertEquals("initially active segment must show every matching variant", ERROR_MATCHES,
+                pane.getDisplayedEntries().size());
+
+        int errorEntry = entryNumberContaining("Error {0}");
+        int sentenceEntry = entryNumberContaining("sentence one");
+
+        long best = Long.MAX_VALUE;
+        for (int round = 0; round < 3; round++) {
+            switchAndWaitMs(pane, sentenceEntry);
+            assertEquals("pane must follow to the other segment's matches", SENTENCE_MATCHES,
+                    pane.getDisplayedEntries().size());
+            best = Math.min(best, switchAndWaitMs(pane, errorEntry));
+            assertEquals("pane must follow back to the many-match segment", ERROR_MATCHES,
+                    pane.getDisplayedEntries().size());
+        }
+
+        String text = window.textBox("glossary_text_area").text();
+        assertNotNull(text);
+        assertTrue("pane must render the variants", text.contains("Error = variant 0"));
+        assertTrue("pane must render every variant",
+                text.contains("variant " + (ERROR_MATCHES - 1)));
+
+        System.out.println(String.format(Locale.ROOT,
+                "SF-981 end-to-end segment switch: %d rendered matches, best of 3 rounds = %d ms",
+                ERROR_MATCHES, best));
+        assertTrue("one segment switch rendered " + ERROR_MATCHES + " glossary matches in " + best
+                + " ms end to end; time budget is " + SWITCH_RENDER_BUDGET_MS + " ms (SF bug #981)",
+                best <= SWITCH_RENDER_BUDGET_MS);
+
+        closeProject();
+    }
+
+    /**
+     * Copy of the sample project whose glossary yields SF-981-magnitude match
+     * counts: many target variants of terms the sample segments contain.
+     */
+    private static Path prepareProjectWithLargeGlossary() throws IOException {
+        Path fixture = Files.createTempDirectory("omegat-glossary-load-");
+        FileUtils.copyDirectory(PROJECT_PATH.toFile(), fixture.toFile());
+        FileUtils.forceDeleteOnExit(fixture.toFile());
+        StringBuilder glossary = new StringBuilder("# Glossary in tab-separated format\n");
+        for (int i = 0; i < ERROR_MATCHES; i++) {
+            glossary.append("Error\tvariant ").append(i).append('\n');
+        }
+        for (int i = 0; i < SENTENCE_MATCHES; i++) {
+            glossary.append("sentence\tphrase ").append(i).append('\n');
+        }
+        Files.writeString(fixture.resolve("glossary").resolve("glossary.txt"), glossary.toString(),
+                StandardCharsets.UTF_8);
+        return fixture;
+    }
+
+    /** Entry number of the first segment whose source contains the text. */
+    private static int entryNumberContaining(String text) {
+        for (SourceTextEntry ste : Core.getProject().getAllEntries()) {
+            if (ste.getSrcText().contains(text)) {
+                return ste.entryNum();
+            }
+        }
+        throw new AssertionError("no segment contains: " + text);
+    }
+
+    /**
+     * Activates the given segment in the real editor and waits until the
+     * glossary pane rendered the segment's matches; the elapsed time is the
+     * user-visible switch latency (background search plus EDT rendering).
+     */
+    private long switchAndWaitMs(GlossaryTextArea pane, int entryNum) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        PropertyChangeListener listener = evt -> latch.countDown();
+        pane.addPropertyChangeListener("entries", listener);
+        try {
+            long t0 = System.nanoTime();
+            SwingUtilities.invokeLater(() -> Core.getEditor().gotoEntry(entryNum));
+            assertTrue("glossary pane must follow the segment switch",
+                    latch.await(timeout, TimeUnit.SECONDS));
+            // drain the one-time link refresh the document swap queued
+            robot().waitForIdle();
+            return (System.nanoTime() - t0) / 1_000_000;
+        } finally {
+            pane.removePropertyChangeListener("entries", listener);
+        }
+    }
+}

--- a/test/src/org/omegat/gui/glossary/GlossarySearchLoadTest.java
+++ b/test/src/org/omegat/gui/glossary/GlossarySearchLoadTest.java
@@ -1,0 +1,368 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.glossary;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.omegat.core.Core;
+import org.omegat.core.TestCore;
+import org.omegat.core.data.EntryKey;
+import org.omegat.core.data.NotLoadedProject;
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.SourceTextEntry;
+import org.omegat.tokenizer.ITokenizer;
+import org.omegat.tokenizer.ITokenizer.StemmingMode;
+import org.omegat.tokenizer.LuceneJapaneseTokenizer;
+import org.omegat.util.Language;
+import org.omegat.util.Token;
+
+/**
+ * Reproduction of SF bug #981 ("5.2.0 painfully slow"): with large glossaries
+ * (reporter: ~55 files, ~40 MB total, largest 12 MB, ja&rarr;en) every segment
+ * switch stalls for seconds from OmegaT 5.x on, long segments (150+
+ * characters) freeze longest; 4.3.2 was fine.
+ *
+ * Each test times or counts one {@link GlossarySearcher} or tokenization code
+ * path with a glossary of the reported magnitude and asserts a time budget.
+ * Before the SF #981 fixes (per-search token prefilter, one tokenization per
+ * marker pass) one segment switch scanned 300k entries in 1.6 s; a failure
+ * here means one of those regressions is back. The prints document the
+ * measured magnitudes. Rendering of the glossary pane is covered end-to-end,
+ * through the real GUI, by {@code GlossaryPaneSegmentSwitchTest} in
+ * testAcceptance.
+ *
+ * The paths mirror production wiring: one long-lived source tokenizer whose
+ * per-instance token cache stays warm across segment switches (as in
+ * {@code GlossaryManager#buildSearcher}), while every switch presents a new
+ * segment text.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class GlossarySearchLoadTest extends TestCore {
+
+    /**
+     * Glossary size in the reported magnitude: reporter had ~40 MB of
+     * glossary files; at typical TSV line lengths that is roughly 300k
+     * entries.
+     */
+    private static final int LARGE_GLOSSARY = 300_000;
+    /** Entries displayed in the glossary pane while typing. */
+    private static final int DISPLAYED_ENTRIES = 50;
+    /** Budget for one segment switch, with headroom for loaded CI runners. */
+    private static final long SWITCH_BUDGET_MS = 750;
+    /** Budget for one TransTips marker pass (recalculated per keystroke). */
+    private static final long MARKER_PASS_BUDGET_MS = 100;
+    /** Accepted slowdown of the stemming-off configuration. */
+    private static final int STEMMING_OFF_FACTOR = 4;
+
+    /**
+     * Real Japanese segments in the reported length class; cycled so that
+     * every measured switch tokenizes a fresh segment while the glossary term
+     * cache stays warm, as in production.
+     */
+    private static final String[] SEGMENTS = {
+            "OmegaTのユーザーインターフェースやヘルプテキストを、さまざまな言語へ翻訳してくださった方々に感謝します。"
+                    + "そして、翻訳がなされていない言語がまだ数千残っています！OmegaT の多言語への地域化は、持続的な作業でもあります。"
+                    + "なぜなら、新しい機能が絶えず追加されているからです。",
+            "翻訳メモリーと用語集を併用すると、文書全体の用語の統一と品質の管理が容易になります。"
+                    + "大きな案件では数十の用語集ファイルを同時に参照することも珍しくなく、"
+                    + "編集画面の応答速度は作業の効率に直接影響します。設定を変更した場合は、必ず検査を実行してください。",
+            "このプロジェクトの原文ファイルは複数の形式で提供されており、変換と保存の手順は開発環境の構成によって異なります。"
+                    + "出力の品質を確認するために、対象の文書を選択し、表示された項目を編集してから、"
+                    + "状態と情報を資料として保存してください。",
+            "辞書と用語集の検索は、入力のたびに実行されるため、処理の速度が遅いと編集そのものが困難になります。"
+                    + "特に長い文では、機能の追加や更新のたびに再検索が発生し、画面の表示が数秒間固まることがあります。"
+                    + "これがこの試験で再現しようとしている問題です。",
+    };
+
+    /**
+     * Real two-kanji morphemes; compounds of two or three of them form the
+     * synthetic glossary terms (Japanese compounding is productive, so the
+     * terms stay plausible while scaling to any size).
+     */
+    private static final String[] JA_MORPHEMES = { "翻訳", "言語", "地域", "設定", "品質", "管理", "検査", "辞書",
+            "用語", "資料", "出力", "入力", "変換", "保存", "形式", "構成", "環境", "開発", "試験", "手順", "画面", "文書",
+            "項目", "対象", "機能", "作業", "追加", "削除", "更新", "検索", "表示", "編集", "選択", "状態", "情報", "処理" };
+    private static final String[] EN_WORDS = { "translation", "language", "region", "setting", "quality",
+            "management", "inspection", "dictionary", "term", "material", "output", "input", "conversion",
+            "storage", "format", "configuration", "environment", "development", "test", "procedure", "screen",
+            "document", "item", "target", "feature", "work", "addition", "deletion", "update", "search",
+            "display", "editing", "selection", "state", "information", "processing" };
+
+    private ITokenizer tokenizer;
+
+    @Before
+    public final void setUpGlossaryLoad() {
+        Language srcLang = new Language("ja");
+        Core.setProject(new NotLoadedProject() {
+            @Override
+            public boolean isProjectLoaded() {
+                return true;
+            }
+
+            @Override
+            public ProjectProperties getProjectProperties() {
+                try {
+                    return new ProjectProperties(new File("stub")) {
+                        @Override
+                        public Language getSourceLanguage() {
+                            return srcLang;
+                        }
+
+                        @Override
+                        public Language getTargetLanguage() {
+                            return new Language("en");
+                        }
+                    };
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        });
+        tokenizer = new LuceneJapaneseTokenizer();
+    }
+
+    /**
+     * One segment switch (FindGlossaryThread's searchSourceMatches) must stay
+     * within its time budget with a glossary of the reported size.
+     */
+    @Test
+    public void segmentSwitchWithLargeGlossaryStaysWithinBudget() {
+        List<GlossaryEntry> entries = buildEntries(LARGE_GLOSSARY);
+        GlossarySearcherTest.MockGlossarySearcher searcher = productionSearcher(tokenizer, true);
+
+        for (String segment : SEGMENTS) {
+            searcher.searchSourceMatches(ste(segment), entries); // warm-up
+        }
+        long best = Long.MAX_VALUE;
+        for (int round = 0; round < 3; round++) {
+            for (String segment : SEGMENTS) {
+                long t0 = System.nanoTime();
+                List<GlossaryEntry> result = searcher.searchSourceMatches(ste(segment), entries);
+                best = Math.min(best, (System.nanoTime() - t0) / 1_000_000);
+                assertFalse("segments contain glossary terms", result.isEmpty());
+            }
+        }
+        System.out.println(String.format(Locale.ROOT,
+                "SF-981 segment switch: %d entries, best of %d switches = %d ms",
+                LARGE_GLOSSARY, 3 * SEGMENTS.length, best));
+        assertTrue("segment switch with " + LARGE_GLOSSARY + " glossary entries took " + best
+                + " ms, time budget is " + SWITCH_BUDGET_MS + " ms (SF bug #981)",
+                best <= SWITCH_BUDGET_MS);
+    }
+
+    /**
+     * TransTipsMarker matches every displayed entry against the segment; the
+     * pass is recalculated on every keystroke, so it must fit a small time
+     * budget even with a well-filled glossary pane.
+     */
+    @Test
+    public void transTipsMarkerPassPerKeystrokeStaysWithinBudget() {
+        List<GlossaryEntry> displayed = matchingEntries(DISPLAYED_ENTRIES);
+        GlossarySearcherTest.MockGlossarySearcher searcher = productionSearcher(tokenizer, true);
+
+        markerPass(searcher, ste(SEGMENTS[0]), displayed); // warm-up
+        long best = Long.MAX_VALUE;
+        // Each keystroke changes the segment text, so every marker pass sees
+        // an uncached string, as in EditorController.onTextChanged.
+        for (int keystroke = 0; keystroke < 5; keystroke++) {
+            SourceTextEntry ste = ste(SEGMENTS[0] + "追加の入力".substring(0, keystroke + 1));
+            long t0 = System.nanoTime();
+            int hits = markerPass(searcher, ste, displayed);
+            best = Math.min(best, (System.nanoTime() - t0) / 1_000_000);
+            assertTrue("displayed entries must match", hits > 0);
+        }
+        System.out.println(String.format(Locale.ROOT,
+                "SF-981 marker pass: %d displayed entries, best of 5 keystrokes = %d ms",
+                DISPLAYED_ENTRIES, best));
+        assertTrue("one TransTips marker pass (" + DISPLAYED_ENTRIES + " displayed entries) took " + best
+                + " ms on data of SF bug #981; per-keystroke budget is " + MARKER_PASS_BUDGET_MS + " ms",
+                best <= MARKER_PASS_BUDGET_MS);
+    }
+
+    /**
+     * With glossary stemming off (plain user setting) the searcher falls back
+     * to uncached tokenizeVerbatim, which rebuilds the Kuromoji analyzer per
+     * glossary entry; that configuration must stay within a small factor of
+     * the stemming path.
+     */
+    @Test
+    public void stemmingOffStaysComparableToStemmingOn() {
+        List<GlossaryEntry> entries = buildEntries(2_000);
+        long onMs = timeSwitches(productionSearcher(tokenizer, true), entries);
+        long offMs = timeSwitches(productionSearcher(tokenizer, false), entries);
+        System.out.println(String.format(Locale.ROOT,
+                "SF-981 stemming: %d entries, on=%d ms, off=%d ms, factor=%.1f", 2_000, onMs, offMs,
+                onMs == 0 ? 0.0 : (double) offMs / onMs));
+        assertTrue("stemming-off search took " + offMs + " ms vs " + onMs
+                + " ms with stemming (SF bug #981); accepted factor is " + STEMMING_OFF_FACTOR,
+                offMs <= Math.max(1_000, onMs * STEMMING_OFF_FACTOR));
+    }
+
+    /**
+     * One segment activation should tokenize the segment text a bounded
+     * number of times: once for searchSourceMatches and once for the batched
+     * marker pass. Before the batch API every displayed entry tokenized the
+     * segment again.
+     */
+    @Test
+    public void segmentTokenizedBoundedOftenPerActivation() {
+        CountingJapaneseTokenizer counting = new CountingJapaneseTokenizer(SEGMENTS[0]);
+        List<GlossaryEntry> displayed = matchingEntries(10);
+        GlossarySearcherTest.MockGlossarySearcher searcher = productionSearcher(counting, true);
+        SourceTextEntry ste = ste(SEGMENTS[0]);
+
+        searcher.searchSourceMatches(ste, displayed);
+        markerPass(searcher, ste, displayed);
+        System.out.println(String.format(Locale.ROOT,
+                "SF-981 tokenizations of one segment per activation (search + marker pass over %d entries): %d",
+                displayed.size(), counting.segmentTokenizations));
+        assertTrue("segment text was tokenized " + counting.segmentTokenizations
+                + " times for one activation; budget is 2 (SF bug #981)",
+                counting.segmentTokenizations <= 2);
+    }
+
+    private static int markerPass(GlossarySearcher searcher, SourceTextEntry ste,
+            List<GlossaryEntry> displayed) {
+        int hits = 0;
+        for (List<Token[]> tokens : searcher.searchSourceMatchTokens(ste, displayed)) {
+            if (!tokens.isEmpty()) {
+                hits++;
+            }
+        }
+        return hits;
+    }
+
+    private long timeSwitches(GlossarySearcher searcher, List<GlossaryEntry> entries) {
+        for (String segment : SEGMENTS) {
+            searcher.searchSourceMatches(ste(segment), entries); // warm-up
+        }
+        long best = Long.MAX_VALUE;
+        for (int round = 0; round < 2; round++) {
+            long total = 0;
+            for (String segment : SEGMENTS) {
+                long t0 = System.nanoTime();
+                searcher.searchSourceMatches(ste(segment), entries);
+                total += System.nanoTime() - t0;
+            }
+            best = Math.min(best, total / 1_000_000);
+        }
+        return best;
+    }
+
+    /** Searcher with shipped defaults (stemming on, inexact matching on). */
+    private static GlossarySearcherTest.MockGlossarySearcher productionSearcher(ITokenizer tok,
+            boolean stemming) {
+        GlossarySearcherTest.MockGlossarySearcher searcher = new GlossarySearcherTest.MockGlossarySearcher(
+                tok, new Language("ja"), new Language("en"), false);
+        searcher.enableGlossaryStemming(stemming);
+        searcher.setGlossaryNotExactMatch(true);
+        return searcher;
+    }
+
+    private static SourceTextEntry ste(String sourceText) {
+        EntryKey key = new EntryKey("file", sourceText, "id", "prev", "next", "path");
+        return new SourceTextEntry(key, 1, new String[0], sourceText, Collections.emptyList());
+    }
+
+    /** Synthetic ja&rarr;en glossary of real-morpheme compounds. */
+    private static List<GlossaryEntry> buildEntries(int count) {
+        List<GlossaryEntry> entries = new ArrayList<>(count);
+        int n = JA_MORPHEMES.length;
+        for (int i = 0; entries.size() < count; i++) {
+            String src;
+            String loc;
+            if (i < n * n) {
+                src = JA_MORPHEMES[i / n] + JA_MORPHEMES[i % n];
+                loc = EN_WORDS[i / n] + " " + EN_WORDS[i % n];
+            } else if (i < n * n + n * n * n) {
+                int j = i - n * n;
+                src = JA_MORPHEMES[j / (n * n)] + JA_MORPHEMES[(j / n) % n] + JA_MORPHEMES[j % n];
+                loc = EN_WORDS[j / (n * n)] + " " + EN_WORDS[(j / n) % n] + " " + EN_WORDS[j % n];
+            } else {
+                int j = i - n * n - n * n * n;
+                src = JA_MORPHEMES[j / (n * n * n)] + JA_MORPHEMES[(j / (n * n)) % n]
+                        + JA_MORPHEMES[(j / n) % n] + JA_MORPHEMES[j % n];
+                loc = EN_WORDS[j / (n * n * n)] + " " + EN_WORDS[(j / (n * n)) % n] + " "
+                        + EN_WORDS[(j / n) % n] + " " + EN_WORDS[j % n];
+            }
+            entries.add(new GlossaryEntry(src, loc, "", true, "load-test"));
+        }
+        return entries;
+    }
+
+    /**
+     * Entries whose terms occur in SEGMENTS[0], several target variants per
+     * term, as displayed by the glossary pane.
+     */
+    private static List<GlossaryEntry> matchingEntries(int count) {
+        String[] present = { "翻訳", "言語", "地域化", "機能", "作業" };
+        List<GlossaryEntry> entries = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            entries.add(new GlossaryEntry(present[i % present.length],
+                    EN_WORDS[i % EN_WORDS.length] + " variant " + (i / present.length), "", true,
+                    "load-test"));
+        }
+        return entries;
+    }
+
+    /** Counts how often the observed segment text reaches the tokenizer. */
+    private static final class CountingJapaneseTokenizer extends LuceneJapaneseTokenizer {
+        private final String segment;
+        private int segmentTokenizations;
+
+        CountingJapaneseTokenizer(String segment) {
+            // GlossarySearcher.tokenize lowercases before tokenizing.
+            this.segment = segment.toLowerCase(Locale.JAPANESE);
+        }
+
+        @Override
+        public Token[] tokenizeWords(String strOrig, StemmingMode stemmingMode) {
+            if (segment.equalsIgnoreCase(strOrig)) {
+                segmentTokenizations++;
+            }
+            return super.tokenizeWords(strOrig, stemmingMode);
+        }
+
+        @Override
+        public Token[] tokenizeVerbatim(String strOrig) {
+            if (segment.equalsIgnoreCase(strOrig)) {
+                segmentTokenizations++;
+            }
+            return super.tokenizeVerbatim(strOrig);
+        }
+    }
+}

--- a/test/src/org/omegat/gui/glossary/TransTipsMarkerTest.java
+++ b/test/src/org/omegat/gui/glossary/TransTipsMarkerTest.java
@@ -25,6 +25,7 @@
 
 package org.omegat.gui.glossary;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.omegat.core.TestCore;
@@ -54,6 +55,13 @@ public class TransTipsMarkerTest extends TestCore {
         Preferences.setPreference(Preferences.MARK_GLOSSARY_MATCHES, true);
         initEditor(null);
         TestCoreState.getInstance().getEditor().getSettings().setMarkGlossaryMatches(true);
+    }
+
+    @After
+    public final void resetPreferredRenderer() {
+        // The mock renderer is stored statically; later tests in the same JVM
+        // must get the real one again.
+        GlossaryRenderers.setPreferredGlossaryRenderer(GlossaryRenderers.DEFAULT_RENDERER);
     }
 
     /**
@@ -135,8 +143,8 @@ public class TransTipsMarkerTest extends TestCore {
         List<Token[]> tokenMatches = new ArrayList<>();
         tokenMatches.add(new Token[]{new Token("text", 7)});
         tokenMatches.add(new Token[]{new Token("source", 0)});
-        when(glossaryManagerMock.searchSourceMatchTokens(any(SourceTextEntry.class), eq(glossaryEntry)))
-                .thenReturn(tokenMatches);
+        when(glossaryManagerMock.searchSourceMatchTokens(any(SourceTextEntry.class), eq(glossaryEntries)))
+                .thenReturn(Collections.singletonList(tokenMatches));
         TestCoreState.getInstance().setGlossaryManager(glossaryManagerMock);
 
         SourceTextEntry ste = mock(SourceTextEntry.class);
@@ -171,8 +179,8 @@ public class TransTipsMarkerTest extends TestCore {
         GlossaryRenderers.setPreferredGlossaryRenderer(rendererMock);
 
         GlossaryManager glossaryManagerMock = mock(GlossaryManager.class);
-        when(glossaryManagerMock.searchSourceMatchTokens(any(SourceTextEntry.class), eq(glossaryEntry)))
-                .thenReturn(Collections.emptyList());
+        when(glossaryManagerMock.searchSourceMatchTokens(any(SourceTextEntry.class), eq(glossaryEntries)))
+                .thenReturn(Collections.singletonList(Collections.emptyList()));
         TestCoreState.getInstance().setGlossaryManager(glossaryManagerMock);
 
         SourceTextEntry ste = mock(SourceTextEntry.class);


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- Backport of #2318 to `releases/6.1`
  * https://sourceforge.net/p/omegat/bugs/981/

## What does this PR change?

- Renders the Glossary pane into an offline document swapped in at once instead of per-entry inserts on the EDT.
- Tokenizes the segment once per TransTips marker pass and prefilters the glossary entry scan with token hashes.
- Adds load tests pinning interactive budgets for large glossaries.

## Other information

Cherry-picks of d0cfb94d0, 415ae0ba4, b0d68a3fb; base branch `releases/6.1`.
see also #2318
