### PR TITLE
fix(gui): change table selection configuration and add test for row selection behavior

### DIFF
--- a/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -779,10 +779,20 @@ public class ProjectFilesListController implements IProjectFilesList {
 
     private void createTableFiles() {
         applyColors(list.tableFiles);
-        list.tableFiles.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-        list.tableFiles.setRowSelectionAllowed(true);
-        list.tableFiles.setColumnSelectionAllowed(false);
-        list.tableFiles.setCellSelectionEnabled(false);
+        configureProjectFilesTableSelection(list.tableFiles);
+    }
+
+    /**
+     * Configures the selection model of the project files table.
+     * <p>
+     * Important: do not call setCellSelectionEnabled(false) here.
+     * With rowSelectionAllowed == true and columnSelectionAllowed == false,
+     * JTable#cellSelectionEnabled is already effectively false.
+     */
+    static void configureProjectFilesTableSelection(JTable table) {
+        table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+        table.setRowSelectionAllowed(true);
+        table.setColumnSelectionAllowed(false);
     }
 
     private void propagateTableColumns() {

--- a/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerTest.java
+++ b/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerTest.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
 import javax.swing.table.DefaultTableColumnModel;
 import javax.swing.table.TableColumn;
 
@@ -46,6 +48,7 @@ import org.omegat.util.LocaleRule;
 import org.omegat.util.TestPreferencesInitializer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ProjectFilesListControllerTest {
@@ -161,6 +164,22 @@ public class ProjectFilesListControllerTest {
         ProjectFilesListController.syncTotalColumnsToFileColumns(filesColumns, totalsColumns);
 
         assertColumnOrder(totalsColumns, 0, 5, 1, 2, 3, 4, 6);
+    }
+
+    @Test
+    public void testProjectFilesTableKeepsRowSelectionEnabled() {
+        JTable table = new JTable();
+
+        ProjectFilesListController.configureProjectFilesTableSelection(table);
+
+        assertEquals(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION,
+                table.getSelectionModel().getSelectionMode());
+        assertTrue("Project files table must allow row selection.",
+                table.getRowSelectionAllowed());
+        assertFalse("Project files table must not allow column selection.",
+                table.getColumnSelectionAllowed());
+        assertFalse("Project files table should use row selection, not cell selection.",
+                table.getCellSelectionEnabled());
     }
 
     private static ProjectFilesListController.FileProgress fileProgress(int translated, int total) {


### PR DESCRIPTION

This PR fixes the regression caused by PR #2073 that file list table does not allow the user to select a file by cursol key and add the regression test to keep a configuration.

## Pull request type
- Bug fix -> [bug]

## Which ticket is resolved?
None; report in the mail list but issued the ticket.

## What does this PR change?

- A file list table properties to set properly seletion limitation.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
