### PR TITLE
fix(manual): Fix typo in the Appendices > Application Folder chapter(preferred)

### DIFF
--- a/src/docs/manual/en/App_ApplicationFolder.xml
+++ b/src/docs/manual/en/App_ApplicationFolder.xml
@@ -140,7 +140,7 @@
       <varlistentry xml:id="application.folder.plugins">
          <term xml:id="application.folder.plugins.title">plugins/</term>
          <listitem>
-            <para>The folder where you can install external plugins. The prefered
+            <para>The folder where you can install external plugins. The preferred
                		location for plugin manual installs is the 
                <link linkend="configuration.folder.extra.contents.plugin" endterm="configuration.folder.extra.contents.plugin.title"></link> folder
                		located in the 


### PR DESCRIPTION
## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

- Typo in the Appendices > Application Folder chapter of the manual (preferred)
- https://sourceforge.net/p/omegat/documentation/457/

## What does this PR change?

This PR fixes the typo.

## Other information

N/A