### PR TITLE
docs(devel/codingstyles): fix broken link markups in the Spotless code formatter section

### DIFF
--- a/src/docs/developer/30.CodingStyles.md
+++ b/src/docs/developer/30.CodingStyles.md
@@ -119,9 +119,9 @@ It will help you to format your changed code just a command
 ./gradlew spotlessChangedApply
 ```
 
-OmegaT uses Spotless plugin for gradle and configured with [eclipse formatting configuration](assets/eclipse-formatting.
-xml)
+OmegaT uses Spotless plugin for gradle and configured with
+[eclipse formatting configuration](assets/eclipse-formatting.xml)
 This XML file is project-standard indent configuration for Eclipse IDE, but also uses as spotless formatting rule.
 
-There is other sample config file for IDE such as [JetBrains IntelliJ Project configuration](assets/intellij-Project.
-xml).
+There is other sample config file for IDE such as
+[JetBrains IntelliJ Project configuration](assets/intellij-Project.xml).


### PR DESCRIPTION
## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

- Broken link markups in the Coding styles chapter of the OmegaT contribution guide
  * https://sourceforge.net/p/omegat/bugs/1336/
 
## What does this PR change?

This PR changes the linkbreak location to fix the validity of the link and also complies with the line limit requirement in [Code Style Basics - Coding styles - OmegaT documentation](https://omegat.readthedocs.io/en/latest/30.CodingStyles.html#code-style-basics) 

## Other information

N/A