### PR TITLE
chore(build): drop resolved icu4j entry from dependency skew baseline

### DIFF
--- a/tool/known_dependency_skews.txt
+++ b/tool/known_dependency_skews.txt
@@ -4,7 +4,6 @@
 # checker errors on stale entries.
 error_prone_annotations
 guava
-icu4j
 j2objc-annotations
 jackson-core
 jackson-databind


### PR DESCRIPTION
## Pull request type

Build and release changes -> [build/release]

## Which ticket is resolved?

- none, CI hotfix

## What does this PR change?

- #2313 dropped the bundled icu4j copy, but the duplicate dependency check revived in #2315 still lists icu4j in its baseline. The checker flags the resolved entry, so the Source Distribution Test workflow fails on master and on every pull request since eaa27895c.
- Remove the stale baseline line; the check passes again (`OK: 184 core jars, 94 module jars, no new redundancy`).
