### PR TITLE
docs(adr): propose team-negotiated project settings design (SF-RFE-926)

### DIFF
--- a/src/docs/developer/adr/2026011.TeamNegotiatedProjectSettings.md
+++ b/src/docs/developer/adr/2026011.TeamNegotiatedProjectSettings.md
@@ -1,0 +1,30 @@
+# ADR: Team-Negotiated Project Settings
+
+## Status
+
+**Proposed** (Date: 2026-09-02)
+
+## Context
+
+- Team sync overwrites local per-project configuration silently (`filters.xml`, segmentation rules); OmegaT never commits configuration files itself — no supported way to distribute project setting to team.
+- Several features need distribution with user consent: file filters, segmentation rules, project tag definitions (SF-926), planned fuzzy-match number option.
+- Constraint: older OmegaT versions must open project unchanged — `omegat.project` schema rejects unknown elements, extra files under `omegat/` are ignored.
+- Core API change requires dev list consensus and ADR (maintainer requirement, PR #2248 review).
+
+## Decision
+
+- Sidecar file `omegat/project_settings.properties` carries scalar team-negotiated settings; separate file keeps `omegat.project` untouched.
+- Registry instead of per-feature core API: `TeamSettingsRegistry` + `TeamSetting` descriptor (key, localized name, session reader/applier, value describer, normalizer, pluggable `Storage`). Factories: `of` (sidecar scalar), `ofBoolean`, `ofStoredFile` (whole configuration file, canonical serialized content as value).
+- `IProject` gains exactly three default methods: `publishProjectSetting(key, value)`, `useLocalProjectSetting(key, value)`, `getSupersededLocalSettings()`. No per-feature interface additions; empty registry keeps every code path no-op.
+- Generic negotiation in `RealProject`: load compares pre-sync local value with team value (canonical content, not bytes); team value wins, superseded local value raises question after open — share / take team version / use locally this session; asks again each open until settled. Publish commits through `RemoteRepositoryProvider`, skips no-op commit, detects rejected push, distributes file removal for file-backed settings.
+- `RemoteRepositoryProvider` gains generic file primitives: `existsInRepositories`, `isIdenticalInRepositories` (+ EOL-tolerant variant), `commitFilesChecked`, `deleteFilesFromRepos`, `repositoryFileViews`.
+- GUI: one generic dialog pair (diverged-on-open question, share offer after properties dialog change) driven by descriptor metadata; no per-setting dialogs.
+- Built-in registrations: file filters, segmentation rules, tag definitions (`omegat/tag_patterns.xml`).
+
+## Consequences
+
+- New per-project setting = one registry entry; `IProject` and provider stay stable afterwards.
+- Older OmegaT versions unaffected: unknown files ignored, `omegat.project` unchanged.
+- Configuration files become committable through OmegaT for first time; every write to team repository guarded by explicit user consent.
+- Plugins may register own settings; `unregister` supports unload and tests.
+- Reference implementations: PR #2319 (sidecar + registry), PR #2335 (filters, segmentation), PR #2248 (tag definitions).

--- a/src/docs/developer/adr/index.md
+++ b/src/docs/developer/adr/index.md
@@ -13,6 +13,7 @@
 - 2025013 [Machine Translation SPI with multi-level context](2025013.MultiLevelContextSupportForMT.md)
 - 2026002 [Preferences Architecture and Testable Store Injection](2026002.PreferencesArchitecture.md)
 - 2026004 [EditorColor Registry Consistency](2026004.EditorColorRegistryConsistency.md)
+- 2026011 [Team-Negotiated Project Settings](2026011.TeamNegotiatedProjectSettings.md)
 
 ## Core features
 


### PR DESCRIPTION
## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

- Make Regular expression for custom tags project-specific
  * https://sourceforge.net/p/omegat/feature-requests/926/

## What does this PR change?

- Adds ADR 2026011 "Team-Negotiated Project Settings" (status: Proposed) — core API design requested in #2248 review.
- Covers settings registry (`TeamSetting`/`TeamSettingsRegistry`), sidecar file `omegat/project_settings.properties`, three `IProject` default methods, generic `RemoteRepositoryProvider` file primitives, negotiation semantics.
- Reference implementations: #2319 (sidecar + registry), #2335 (filters, segmentation), #2248 (tag definitions).
- Dev list proposal thread follows.
