### PR TITLE
chore(javadoc): fix errors from package-info.java license header

### DIFF
--- a/language-modules/ar/src/main/java/org/omegat/languages/ar/package-info.java
+++ b/language-modules/ar/src/main/java/org/omegat/languages/ar/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.ar;

--- a/language-modules/ast/src/main/java/org/omegat/languages/ast/package-info.java
+++ b/language-modules/ast/src/main/java/org/omegat/languages/ast/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.ast;

--- a/language-modules/be/src/main/java/org/omegat/languages/be/package-info.java
+++ b/language-modules/be/src/main/java/org/omegat/languages/be/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.be;

--- a/language-modules/br/src/main/java/org/omegat/languages/br/package-info.java
+++ b/language-modules/br/src/main/java/org/omegat/languages/br/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.br;

--- a/language-modules/ca/src/main/java/org/omegat/languages/ca/package-info.java
+++ b/language-modules/ca/src/main/java/org/omegat/languages/ca/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.ca;

--- a/language-modules/da/src/main/java/org/omegat/languages/da/package-info.java
+++ b/language-modules/da/src/main/java/org/omegat/languages/da/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.da;

--- a/language-modules/de/src/main/java/org/omegat/languages/de/package-info.java
+++ b/language-modules/de/src/main/java/org/omegat/languages/de/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.de;

--- a/language-modules/el/src/main/java/org/omegat/languages/el/package-info.java
+++ b/language-modules/el/src/main/java/org/omegat/languages/el/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.el;

--- a/language-modules/en/src/main/java/org/omegat/languages/en/package-info.java
+++ b/language-modules/en/src/main/java/org/omegat/languages/en/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.en;

--- a/language-modules/eo/src/main/java/org/omegat/languages/eo/package-info.java
+++ b/language-modules/eo/src/main/java/org/omegat/languages/eo/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.eo;

--- a/language-modules/es/src/main/java/org/omegat/languages/es/package-info.java
+++ b/language-modules/es/src/main/java/org/omegat/languages/es/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.es;

--- a/language-modules/fa/src/main/java/org/omegat/languages/fa/package-info.java
+++ b/language-modules/fa/src/main/java/org/omegat/languages/fa/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.fa;

--- a/language-modules/fr/src/main/java/org/omegat/languages/fr/package-info.java
+++ b/language-modules/fr/src/main/java/org/omegat/languages/fr/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.fr;

--- a/language-modules/ga/src/main/java/org/omegat/languages/ga/package-info.java
+++ b/language-modules/ga/src/main/java/org/omegat/languages/ga/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.ga;

--- a/language-modules/gl/src/main/java/org/omegat/languages/gl/package-info.java
+++ b/language-modules/gl/src/main/java/org/omegat/languages/gl/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.gl;

--- a/language-modules/it/src/main/java/org/omegat/languages/it/package-info.java
+++ b/language-modules/it/src/main/java/org/omegat/languages/it/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.it;

--- a/language-modules/ja/src/main/java/org/omegat/languages/ja/package-info.java
+++ b/language-modules/ja/src/main/java/org/omegat/languages/ja/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.ja;

--- a/language-modules/km/src/main/java/org/omegat/languages/km/package-info.java
+++ b/language-modules/km/src/main/java/org/omegat/languages/km/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.km;

--- a/language-modules/nl/src/main/java/org/omegat/languages/nl/package-info.java
+++ b/language-modules/nl/src/main/java/org/omegat/languages/nl/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.nl;

--- a/language-modules/pl/src/main/java/org/omegat/languages/pl/package-info.java
+++ b/language-modules/pl/src/main/java/org/omegat/languages/pl/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.pl;

--- a/language-modules/pt/src/main/java/org/omegat/languages/pt/package-info.java
+++ b/language-modules/pt/src/main/java/org/omegat/languages/pt/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.pt;

--- a/language-modules/ro/src/main/java/org/omegat/languages/ro/package-info.java
+++ b/language-modules/ro/src/main/java/org/omegat/languages/ro/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.ro;

--- a/language-modules/ru/src/main/java/org/omegat/languages/ru/package-info.java
+++ b/language-modules/ru/src/main/java/org/omegat/languages/ru/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.ru;

--- a/language-modules/sk/src/main/java/org/omegat/languages/sk/package-info.java
+++ b/language-modules/sk/src/main/java/org/omegat/languages/sk/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.sk;

--- a/language-modules/sl/src/main/java/org/omegat/languages/sl/package-info.java
+++ b/language-modules/sl/src/main/java/org/omegat/languages/sl/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.sl;

--- a/language-modules/sv/src/main/java/org/omegat/languages/sv/package-info.java
+++ b/language-modules/sv/src/main/java/org/omegat/languages/sv/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.sv;

--- a/language-modules/ta/src/main/java/org/omegat/languages/ta/package-info.java
+++ b/language-modules/ta/src/main/java/org/omegat/languages/ta/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.ta;

--- a/language-modules/tl/src/main/java/org/omegat/languages/tl/package-info.java
+++ b/language-modules/tl/src/main/java/org/omegat/languages/tl/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.tl;

--- a/language-modules/uk/src/main/java/org/omegat/languages/uk/package-info.java
+++ b/language-modules/uk/src/main/java/org/omegat/languages/uk/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.uk;

--- a/language-modules/zh/src/main/java/org/omegat/languages/zh/package-info.java
+++ b/language-modules/zh/src/main/java/org/omegat/languages/zh/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.languages.zh;

--- a/machinetranslators/apertium/src/main/java/org/omegat/machinetranslators/apertium/package-info.java
+++ b/machinetranslators/apertium/src/main/java/org/omegat/machinetranslators/apertium/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.machinetranslators.apertium;

--- a/machinetranslators/belazar/src/main/java/org/omegat/machinetranslators/belazar/package-info.java
+++ b/machinetranslators/belazar/src/main/java/org/omegat/machinetranslators/belazar/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.machinetranslators.belazar;

--- a/machinetranslators/google/src/main/java/org/omegat/machinetranslators/google/package-info.java
+++ b/machinetranslators/google/src/main/java/org/omegat/machinetranslators/google/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.machinetranslators.google;

--- a/machinetranslators/ibmwatson/src/main/java/org/omegat/machinetranslators/ibmwatson/package-info.java
+++ b/machinetranslators/ibmwatson/src/main/java/org/omegat/machinetranslators/ibmwatson/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.machinetranslators.ibmwatson;

--- a/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/package-info.java
+++ b/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.machinetranslators.mymemory;

--- a/machinetranslators/yandex/src/main/java/org/omegat/machinetranslators/yandex/package-info.java
+++ b/machinetranslators/yandex/src/main/java/org/omegat/machinetranslators/yandex/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.machinetranslators.yandex;

--- a/spellchecker/hunspell/src/main/java/org/omegat/spellchecker/hunspell/package-info.java
+++ b/spellchecker/hunspell/src/main/java/org/omegat/spellchecker/hunspell/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.spellchecker.hunspell;

--- a/spellchecker/lucene/src/main/java/org/omegat/spellchecker/lucene/package-info.java
+++ b/spellchecker/lucene/src/main/java/org/omegat/spellchecker/lucene/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.spellchecker.lucene;

--- a/spellchecker/morfologik/src/main/java/org/omegat/spellchecker/morfologik/package-info.java
+++ b/spellchecker/morfologik/src/main/java/org/omegat/spellchecker/morfologik/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.spellchecker.morfologik;

--- a/src/main/java/org/omegat/cli/package-info.java
+++ b/src/main/java/org/omegat/cli/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.cli;

--- a/src/main/java/org/omegat/core/machinetranslators/package-info.java
+++ b/src/main/java/org/omegat/core/machinetranslators/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.core.machinetranslators;

--- a/src/main/java/org/omegat/core/search/package-info.java
+++ b/src/main/java/org/omegat/core/search/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.core.search;

--- a/src/main/java/org/omegat/externalfinder/gui/package-info.java
+++ b/src/main/java/org/omegat/externalfinder/gui/package-info.java
@@ -24,6 +24,6 @@
  */
 
 @NullMarked
-package org.omegat.filters2.text.ilias;
+package org.omegat.externalfinder.gui;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/externalfinder/item/package-info.java
+++ b/src/main/java/org/omegat/externalfinder/item/package-info.java
@@ -24,6 +24,6 @@
  */
 
 @NullMarked
-package org.omegat.filters2.text.ilias;
+package org.omegat.externalfinder.item;
 
 import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/omegat/filters2/hhc/package-info.java
+++ b/src/main/java/org/omegat/filters2/hhc/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.hhc;

--- a/src/main/java/org/omegat/filters2/html2/package-info.java
+++ b/src/main/java/org/omegat/filters2/html2/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.html2;

--- a/src/main/java/org/omegat/filters2/latex/package-info.java
+++ b/src/main/java/org/omegat/filters2/latex/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.latex;

--- a/src/main/java/org/omegat/filters2/master/package-info.java
+++ b/src/main/java/org/omegat/filters2/master/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.master;

--- a/src/main/java/org/omegat/filters2/moodlephp/package-info.java
+++ b/src/main/java/org/omegat/filters2/moodlephp/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.moodlephp;

--- a/src/main/java/org/omegat/filters2/mozdtd/package-info.java
+++ b/src/main/java/org/omegat/filters2/mozdtd/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.mozdtd;

--- a/src/main/java/org/omegat/filters2/mozlang/package-info.java
+++ b/src/main/java/org/omegat/filters2/mozlang/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.mozlang;

--- a/src/main/java/org/omegat/filters2/package-info.java
+++ b/src/main/java/org/omegat/filters2/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2;

--- a/src/main/java/org/omegat/filters2/pdf/package-info.java
+++ b/src/main/java/org/omegat/filters2/pdf/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.pdf;

--- a/src/main/java/org/omegat/filters2/po/package-info.java
+++ b/src/main/java/org/omegat/filters2/po/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.po;

--- a/src/main/java/org/omegat/filters2/rc/package-info.java
+++ b/src/main/java/org/omegat/filters2/rc/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.rc;

--- a/src/main/java/org/omegat/filters2/subtitles/package-info.java
+++ b/src/main/java/org/omegat/filters2/subtitles/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.subtitles;

--- a/src/main/java/org/omegat/filters2/text/bundles/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/bundles/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.text.bundles;

--- a/src/main/java/org/omegat/filters2/text/dokuwiki/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/dokuwiki/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.text.dokuwiki;

--- a/src/main/java/org/omegat/filters2/text/ini/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/ini/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.text.ini;

--- a/src/main/java/org/omegat/filters2/text/magento/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/magento/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.text.magento;

--- a/src/main/java/org/omegat/filters2/text/mozftl/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/mozftl/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.text.mozftl;

--- a/src/main/java/org/omegat/filters2/text/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.text;

--- a/src/main/java/org/omegat/filters2/text/yaml/package-info.java
+++ b/src/main/java/org/omegat/filters2/text/yaml/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.text.yaml;

--- a/src/main/java/org/omegat/filters2/xtagqxp/package-info.java
+++ b/src/main/java/org/omegat/filters2/xtagqxp/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters2.xtagqxp;

--- a/src/main/java/org/omegat/filters3/package-info.java
+++ b/src/main/java/org/omegat/filters3/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3;

--- a/src/main/java/org/omegat/filters3/xml/android/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/android/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.android;

--- a/src/main/java/org/omegat/filters3/xml/camtasiawindows/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/camtasiawindows/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.camtasiawindows;

--- a/src/main/java/org/omegat/filters3/xml/docbook/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/docbook/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.docbook;

--- a/src/main/java/org/omegat/filters3/xml/flash/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/flash/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.flash;

--- a/src/main/java/org/omegat/filters3/xml/helpandmanual/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/helpandmanual/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.helpandmanual;

--- a/src/main/java/org/omegat/filters3/xml/infix/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/infix/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.infix;

--- a/src/main/java/org/omegat/filters3/xml/l10nmgr/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/l10nmgr/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.l10nmgr;

--- a/src/main/java/org/omegat/filters3/xml/opendoc/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/opendoc/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.opendoc;

--- a/src/main/java/org/omegat/filters3/xml/openxml/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/openxml/package-info.java
@@ -1,9 +1,9 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
 
- Copyright (C) 2025 Hiroshi Miura
+ Copyright (C) 2026 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -21,8 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
-
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.openxml;

--- a/src/main/java/org/omegat/filters3/xml/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/package-info.java
@@ -1,9 +1,9 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
 
- Copyright (C) 2025 Hiroshi Miura
+ Copyright (C) 2026 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml;

--- a/src/main/java/org/omegat/filters3/xml/properties/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/properties/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.properties;

--- a/src/main/java/org/omegat/filters3/xml/relaxng/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/relaxng/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.relaxng;

--- a/src/main/java/org/omegat/filters3/xml/resx/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/resx/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.resx;

--- a/src/main/java/org/omegat/filters3/xml/schematron/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/schematron/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.schematron;

--- a/src/main/java/org/omegat/filters3/xml/scribus/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/scribus/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.scribus;

--- a/src/main/java/org/omegat/filters3/xml/svg/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/svg/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.svg;

--- a/src/main/java/org/omegat/filters3/xml/txml/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/txml/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.txml;

--- a/src/main/java/org/omegat/filters3/xml/typo3/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/typo3/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.typo3;

--- a/src/main/java/org/omegat/filters3/xml/visio/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/visio/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.visio;

--- a/src/main/java/org/omegat/filters3/xml/wix/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/wix/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.wix;

--- a/src/main/java/org/omegat/filters3/xml/wordpress/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/wordpress/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.wordpress;

--- a/src/main/java/org/omegat/filters3/xml/xhtml/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/xhtml/package-info.java
@@ -1,9 +1,9 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
 
- Copyright (C) 2025 Hiroshi Miura
+ Copyright (C) 2026 Hiroshi Miura
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.xhtml;

--- a/src/main/java/org/omegat/filters3/xml/xliff/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/xliff/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.xliff;

--- a/src/main/java/org/omegat/filters3/xml/xmlspreadsheet/package-info.java
+++ b/src/main/java/org/omegat/filters3/xml/xmlspreadsheet/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters3.xml.xmlspreadsheet;

--- a/src/main/java/org/omegat/filters4/package-info.java
+++ b/src/main/java/org/omegat/filters4/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters4;

--- a/src/main/java/org/omegat/filters4/xml/openxml/package-info.java
+++ b/src/main/java/org/omegat/filters4/xml/openxml/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters4.xml.openxml;

--- a/src/main/java/org/omegat/filters4/xml/package-info.java
+++ b/src/main/java/org/omegat/filters4/xml/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters4.xml;

--- a/src/main/java/org/omegat/filters4/xml/xliff/package-info.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.filters4.xml.xliff;

--- a/src/main/java/org/omegat/gui/comments/package-info.java
+++ b/src/main/java/org/omegat/gui/comments/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.gui.comments;

--- a/src/main/java/org/omegat/gui/common/package-info.java
+++ b/src/main/java/org/omegat/gui/common/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.gui.common;

--- a/src/main/java/org/omegat/gui/dictionaries/package-info.java
+++ b/src/main/java/org/omegat/gui/dictionaries/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.gui.dictionaries;

--- a/src/main/java/org/omegat/gui/editor/package-info.java
+++ b/src/main/java/org/omegat/gui/editor/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.gui.editor;

--- a/src/main/java/org/omegat/gui/exttrans/package-info.java
+++ b/src/main/java/org/omegat/gui/exttrans/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.gui.exttrans;

--- a/src/main/java/org/omegat/gui/search/package-info.java
+++ b/src/main/java/org/omegat/gui/search/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.gui.search;

--- a/theme/src/main/java/org/omegat/gui/theme/package-info.java
+++ b/theme/src/main/java/org/omegat/gui/theme/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.gui.theme;

--- a/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/package-info.java
+++ b/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -21,7 +21,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- **************************************************************************/
+ */
 
 @NullMarked
 package org.omegat.gui.tipoftheday;


### PR DESCRIPTION
This fix the Gradle task javadoc error which cause weekly release failed.

## Pull request type

- Bug fix -> [bug]
- Documentation -> [documentation]
- Build and release changes -> [build/release]

## Which ticket is resolved?
none; last two weekly release failed.
## What does this PR change?

- make license header to a comment not javadoc in package-info.java
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
