### PR TITLE
chore(ci): update integration test server base image to debian:bookworm

### DIFF
--- a/src/docs/developer/changes/6.2.0.md
+++ b/src/docs/developer/changes/6.2.0.md
@@ -37,6 +37,12 @@ Architectural decisions are recorded in ADR -- please look at src/docs/developer
 - app title now shows commit sha + branch name for dev builds [PR#2222](https://github.com/omegat-org/omegat/pull/2222)
 - reduces distribution size by deduplication of shipped libraries [PR#2216](https://github.com/omegat-org/omegat/pull/2216)
 - Refactor functions defined in `ext.` into native build libraries.[PR#2209](https://github.com/omegat-org/omegat/pull/2209)
+- Integration test server Docker image base updated from `debian:bullseye` to
+  `debian:bookworm`, following Debian 11 "bullseye" LTS end-of-life (2026-08-31).
+  The `bullseye-security` package pool is no longer serving new fetches, causing
+  `apt-get install` failures (404) in the server-side test container. Client-side
+  image was already on `bookworm`; no functional changes to the SVN
+  (`mod_dav_svn`/`mod_authz_svn`) or git-over-SSH test setup were required.
 
 ## Dependencies
 

--- a/test-integration/docker/server/Dockerfile
+++ b/test-integration/docker/server/Dockerfile
@@ -23,7 +23,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #  **************************************************************************/
 #
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN apt-get -y update && apt-get -y upgrade \
     && apt-get install -y openssh-server git inotify-tools apache2 apache2-utils supervisor apache2-suexec-pristine subversion libapache2-mod-svn \
     && adduser --system --group --shell /bin/bash git && (echo 'git:gitpass' | chpasswd) \


### PR DESCRIPTION
Recent weekly release build failed with Integration test failure.
The integration test use docker for server and client.
A server image uses old debian base version so now it has been arachived then download become error.

## Pull request type
- Build and release changes -> [build/release]

## Which ticket is resolved?
None; but add note in developer/changes/6.2.0.md
## What does this PR change?

- bump to bookworm from bullseye debian version

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
