### PR TITLE
chore(ci): set scan.uploadInBackground=false in testIntegration script

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -17,7 +17,7 @@ services:
       args:
         JAVA: 25
         JDKVER: jdk_25.0.3.0.0+9-1
-        GRADLE: 9.6.0
+        GRADLE: 9.7.1
     depends_on:
       server:
         condition: service_started

--- a/test-integration/docker/client/Dockerfile
+++ b/test-integration/docker/client/Dockerfile
@@ -29,7 +29,7 @@ ARG TARGETARCH
 ARG CAVER=1.0.3-1
 ARG JAVA=25
 ARG JDKVER=jdk_25.0.3.0.0+9-1
-ARG GRADLE=9.6.0
+ARG GRADLE=9.7.1
 RUN apt-get -y update && apt-get upgrade -y && apt-get install -y openssh-client git inotify-tools curl subversion unzip rsync  \
  java-common libasound2 libfontconfig1 libfreetype6 libxi6 libxrender1 libxtst6 p11-kit locales
 RUN adduser --disabled-password --gecos "" --home /home/omegat --shell /bin/bash omegat && mkdir -p /home/omegat/.ssh

--- a/test-integration/docker/client/entrypoint.sh
+++ b/test-integration/docker/client/entrypoint.sh
@@ -101,6 +101,7 @@ CACHED_CONFIGS=$(find /gradle-cache -name ".deps-*" | wc -l)
 echo "Gradle cache size: $CACHE_SIZE, cached configurations: $CACHED_CONFIGS"
 
 exec /opt/gradle/bin/gradle testIntegration --scan \
+   --stacktrace -Dscan.uploadInBackground=false /
    -Djava.util.logging.config.file=/workdir/test-integration/logger.properties \
    -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
    -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README


### PR DESCRIPTION
Add gradle option to show stacktrace and guarantee uploading gradle scan data.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
none; recent weekly release failed with integ-test execution

## What does this PR change?

-
-
-

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
