### PR TITLE
chore(build): parameterize runtime JRE version for integration tests

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.verification-conventions.gradle
@@ -22,6 +22,12 @@ sourceSets {
     }
 }
 
+def testExecJavaLauncher = javaToolchains.launcherFor {
+    languageVersion = JavaLanguageVersion.of(
+            (findProperty('org.omegat.test.runtimeJavaVersion') ?: '25') as int
+    )
+}
+
 configurations {
     testIntegrationImplementation.extendsFrom implementation
     testAcceptanceImplementation.extendsFrom testImplementation
@@ -100,10 +106,7 @@ tasks.register('runDebugger', JavaExec) {
 
 tasks.register('testIntegration', JavaExec) {
     description = 'Runs integration tests. Pass repo URL as -Domegat.test.repo=<repo>.'
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(21)
-        vendor = JvmVendorSpec.ADOPTIUM
-    }
+    javaLauncher = testExecJavaLauncher
     group = 'verification'
     mainClass = 'org.omegat.core.data.TestTeamIntegration'
     classpath = sourceSets.testIntegration.runtimeClasspath

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,11 @@ org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 runMaxHeapSize=1024M
 testMaxHeapSize=2048M
 
+# JVM used to execute a verification task (testIntegration).
+# Tracks the bundled runtime JRE, not the build toolchain (see org.omegat.java-conventions.gradle
+# for compile-time sourceCompatibility/targetCompatibility).
+org.omegat.test.runtimeJavaVersion=25
+
 # Gradle settings
 org.gradle.caching=true
 org.gradle.configuration-cache=true

--- a/src/docs/developer/34.IntegrationTest.md
+++ b/src/docs/developer/34.IntegrationTest.md
@@ -50,6 +50,35 @@ A test setup requires two containers.
 OmegaT project provide `compose.yml` configuration that orchestrate
 test setup and execution in one line command.
 
+### Java runtime used by integration tests
+
+The Java runtime used to execute the `testIntegration` verification task is configured by
+`org.omegat.test.runtimeJavaVersion` in the root `gradle.properties`.
+
+This value represents the runtime version used for integration testing and should track the
+bundled runtime JRE version. It is independent of the Java version used for compilation,
+which is defined by the Gradle Java convention settings.
+
+In CI container runs, the client image downloads and installs the matching JDK in
+`test-integration/docker/client/Dockerfile`, and `entrypoint.sh` uses that runtime when
+running the integration test. When changing `org.omegat.test.runtimeJavaVersion`, make sure
+the CI container configuration is updated to download the same Java major version.
+
+For Docker Compose based runs, the client image build arguments in `compose.yml` also need
+to match the runtime version, for example:
+
+```yaml
+ client:
+    build:
+       context: test-integration/docker/client
+       args:
+          JAVA: 25
+          JDKVER: jdk_25.0.3.0.0+9-1
+```
+
+Keep these values consistent so local Gradle configuration and CI container execution test
+the same Java runtime.
+
 The Server has FOUR individual contents.
 1. Git team: ssh+git and git https protocol provide omegat team repository
 2. SVN team 1: http-dav provide omegat team repository without authentication


### PR DESCRIPTION
Recent Weekly release failed with Integration Test execution.
It caused by multiple reasons. One is JRE version update to 25 in PR #2131 in Dockerfile but missing to synchronize with gradle convention configuration.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
 none; but #2131 breaks integ-test on CI.

## What does this PR change?

- define test Java version in `gradle.properties`
- update developer manual to notify the versions

## Other information
ref. another fix #2343
