### PR TITLE
refactor(core, gui): replace nullable `IMainWindow` with default `ConsoleWindow` fallback

### DIFF
--- a/src/main/java/org/omegat/cli/StartCommand.java
+++ b/src/main/java/org/omegat/cli/StartCommand.java
@@ -136,7 +136,7 @@ public class StartCommand implements Callable<Integer> {
         SwingUtilities.invokeLater(() -> {
             // setVisible can't be executed directly, because we need to
             // call all application startup listeners for initialize UI
-            Objects.requireNonNull(Core.getMainWindow()).getApplicationFrame().setVisible(true);
+            Objects.requireNonNull(Core.getMainWindow().getApplicationFrame()).setVisible(true);
             if (params != null && params.projectLocation != null) {
                 if (isProjectRemote(params.projectLocation)) {
                     ProjectUICommands.projectRemote(params.projectLocation);

--- a/src/main/java/org/omegat/core/Core.java
+++ b/src/main/java/org/omegat/core/Core.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
@@ -124,7 +125,7 @@ public final class Core {
     }
 
     /** Get main window instance. */
-    public static @Nullable IMainWindow getMainWindow() {
+    public static IMainWindow getMainWindow() {
         return CoreState.getInstance().getMainWindow();
     }
 
@@ -273,7 +274,7 @@ public final class Core {
         // window.
         coreState.setEditor(new EditorController(me));
         coreState.setTagValidation(new TagValidationTool());
-        coreState.setIssuesWindow(new IssuesPanelController(me.getApplicationFrame()));
+        coreState.setIssuesWindow(new IssuesPanelController(Objects.requireNonNull(me.getApplicationFrame())));
         coreState.setMatcher(new MatchesTextArea(me));
         GlossaryTextArea glossaryArea = new GlossaryTextArea(me);
         coreState.setGlossaries(glossaryArea);

--- a/src/main/java/org/omegat/core/data/CoreState.java
+++ b/src/main/java/org/omegat/core/data/CoreState.java
@@ -46,6 +46,7 @@ import org.omegat.gui.glossary.GlossaryManager;
 import org.omegat.gui.glossary.IGlossaries;
 import org.omegat.gui.issues.IIssues;
 import org.omegat.gui.issues.IIssueProvider;
+import org.omegat.gui.main.ConsoleWindow;
 import org.omegat.gui.main.IMainWindow;
 import org.omegat.gui.matches.IMatcher;
 import org.omegat.gui.notes.INotes;
@@ -110,7 +111,7 @@ public class CoreState {
     private MachineTranslatorsManager machineTranslatorsManager;
 
     // GUI panes
-    private IMainWindow mainWindow;
+    private IMainWindow mainWindow = new ConsoleWindow();
     private IEditor editor;
     private IGlossaries glossaries;
     private INotes notes;
@@ -150,7 +151,7 @@ public class CoreState {
         this.project = project;
     }
 
-    public @Nullable IMainWindow getMainWindow() {
+    public IMainWindow getMainWindow() {
         return mainWindow;
     }
 
@@ -161,7 +162,7 @@ public class CoreState {
      *                   Can be null when testing.
      */
     public void setMainWindow(@Nullable IMainWindow mainWindow) {
-        this.mainWindow = mainWindow;
+        this.mainWindow = mainWindow == null ? new ConsoleWindow() : mainWindow;
     }
 
     public IEditor getEditor() {

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -53,7 +53,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -849,7 +849,7 @@ public class RealProject implements IProject {
                         tmxPrepared = null;
                         glossaryPrepared = null;
                         remoteRepositoryProvider.cleanPrepared();
-                        Objects.requireNonNull(Core.getMainWindow()).showStatusMessageRB("TEAM_SYNCHRONIZE");
+                        Core.getMainWindow().showStatusMessageRB("TEAM_SYNCHRONIZE");
                         rebaseAndCommitProject(true);
                         setOnlineMode();
                     }
@@ -865,7 +865,7 @@ public class RealProject implements IProject {
                     }
                 } catch (Exception e) {
                     Log.logErrorRB(e, "CT_ERROR_SAVING_PROJ");
-                    Objects.requireNonNull(Core.getMainWindow()).displayErrorRB(e, "CT_ERROR_SAVING_PROJ");
+                    Core.getMainWindow().displayErrorRB(e, "CT_ERROR_SAVING_PROJ");
                 }
 
                 LastSegmentManager.saveLastSegment();
@@ -888,11 +888,8 @@ public class RealProject implements IProject {
     }
 
     private void setProjectMenuEnabled(boolean enabled) {
-        JMenu projectMenu = Objects.requireNonNull(CoreState.getInstance().getMainWindow()).getMainMenu()
-                .getProjectMenu();
-        if (projectMenu != null) {
-            projectMenu.setEnabled(enabled);
-        }
+        JMenu projectMenu = CoreState.getInstance().getMainWindow().getMainMenu().getProjectMenu();
+        projectMenu.setEnabled(enabled);
     }
 
     /**

--- a/src/main/java/org/omegat/gui/dialogs/NewTeamProjectController.java
+++ b/src/main/java/org/omegat/gui/dialogs/NewTeamProjectController.java
@@ -38,6 +38,7 @@ import javax.swing.SwingWorker;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.Core;
 import org.omegat.core.team2.RemoteRepositoryFactory;
 import org.omegat.gui.main.IMainWindow;
@@ -63,7 +64,7 @@ public class NewTeamProjectController {
         mw = mainWindow;
     }
 
-    public File show() {
+    public @Nullable File show() {
         ok = false;
         initComponents();
 

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
@@ -47,6 +47,7 @@ import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.externalfinder.ExternalFinder;
@@ -666,8 +667,8 @@ public class ProjectPropertiesDialogController {
         dialog.setVisible(false);
     }
 
-    public static ProjectProperties showDialog(Frame parent, ProjectProperties projectProperties,
-            String projFileName, ProjectPropertiesDialog.Mode dialogTypeValue) {
+    public static @Nullable ProjectProperties showDialog(Frame parent, ProjectProperties projectProperties,
+                                                         String projFileName, ProjectPropertiesDialog.@Nullable Mode dialogTypeValue) {
         if (dialogTypeValue == null) {
             throw new RuntimeException("Unexpected null argument");
         }

--- a/src/main/java/org/omegat/gui/exttrans/MachineTranslateFindThread.java
+++ b/src/main/java/org/omegat/gui/exttrans/MachineTranslateFindThread.java
@@ -41,7 +41,8 @@ import org.omegat.util.Language;
 import org.omegat.util.Log;
 import org.omegat.util.Preferences;
 
-import java.util.Objects;
+import java.io.Serial;
+
 
 class MachineTranslateFindThread extends EntryInfoSearchThread<MachineTranslationInfo> {
     private final IMachineTranslation translator;
@@ -116,8 +117,7 @@ class MachineTranslateFindThread extends EntryInfoSearchThread<MachineTranslatio
                 tr = translator.getTranslation(source, target, src);
             } catch (MachineTranslateError e) {
                 Log.log(e);
-                Objects.requireNonNull(Core.getMainWindow())
-                        .showTimedStatusMessageRB("MT_ENGINE_ERROR", translator.getName(),
+                Core.getMainWindow().showTimedStatusMessageRB("MT_ENGINE_ERROR", translator.getName(),
                         e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getMessage());
                 return null;
             } catch (Exception e) {
@@ -139,6 +139,7 @@ class MachineTranslateFindThread extends EntryInfoSearchThread<MachineTranslatio
      * Exception thrown when processing should stop.
      */
     static class StoppedException extends Exception {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         StoppedException() {

--- a/src/main/java/org/omegat/gui/exttrans/MachineTranslateTextArea.java
+++ b/src/main/java/org/omegat/gui/exttrans/MachineTranslateTextArea.java
@@ -119,11 +119,9 @@ public class MachineTranslateTextArea extends EntryInfoThreadPane<MachineTransla
         // re-render the shown translation. Guarded: first called from the
         // superclass constructor, before the controller is initialised.
         initDocument();
-        if (controller != null) {
-            MachineTranslationInfo current = controller.getDisplayedResult();
-            if (current != null) {
-                controller.setFoundResult(current);
-            }
+        MachineTranslationInfo current = controller.getDisplayedResult();
+        if (current != null) {
+            controller.setFoundResult(current);
         }
     }
 
@@ -200,7 +198,7 @@ public class MachineTranslateTextArea extends EntryInfoThreadPane<MachineTransla
     public void populatePaneMenu(JPopupMenu menu) {
         final JMenuItem prefs = new JMenuItem(OStrings.getString("GUI_MACHINETRANSLATESWINDOW_OPEN_PREFS"));
         prefs.addActionListener(e -> new PreferencesWindowController().show(
-                Objects.requireNonNull(Core.getMainWindow()).getApplicationFrame(), MachineTranslationPreferencesController.class));
+                Objects.requireNonNull(Core.getMainWindow().getApplicationFrame()), MachineTranslationPreferencesController.class));
         menu.add(prefs);
     }
 }

--- a/src/main/java/org/omegat/gui/main/ConsoleWindow.java
+++ b/src/main/java/org/omegat/gui/main/ConsoleWindow.java
@@ -31,6 +31,7 @@ import java.awt.HeadlessException;
 
 import javax.swing.JFrame;
 
+import org.jspecify.annotations.Nullable;
 import org.omegat.core.data.RuntimePreferenceStore;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
@@ -47,7 +48,7 @@ import com.vlsolutions.swing.docking.DockingDesktop;
 public class ConsoleWindow implements IMainWindow {
 
     @Override
-    public void displayErrorRB(Throwable ex, String errorKey, Object... params) {
+    public void displayErrorRB(@Nullable Throwable ex, @Nullable String errorKey, Object@Nullable... params) {
         String msg;
         if (params != null) {
             msg = StringUtil.format(OStrings.getString(errorKey), params);
@@ -58,7 +59,7 @@ public class ConsoleWindow implements IMainWindow {
         System.err.println(msg);
         String fulltext = msg;
         if (ex != null) {
-            fulltext += "\n" + ex.toString();
+            fulltext += "\n" + ex;
         }
         System.err.println(OStrings.getString("TF_ERROR"));
         System.err.println(fulltext);
@@ -69,7 +70,7 @@ public class ConsoleWindow implements IMainWindow {
      * {@inheritDoc} Nothing is shown in quiet mode.
      */
     @Override
-    public void showStatusMessageRB(String messageKey, Object... params) {
+    public void showStatusMessageRB(@Nullable String messageKey, Object@Nullable... params) {
         if (RuntimePreferenceStore.getInstance().isQuietMode()) {
             return;
         }
@@ -87,27 +88,27 @@ public class ConsoleWindow implements IMainWindow {
     }
 
     @Override
-    public void showTimedStatusMessageRB(String messageKey, Object... params) {
+    public void showTimedStatusMessageRB(@Nullable String messageKey, Object@Nullable... params) {
         showStatusMessageRB(messageKey, params);
     }
 
     @Override
-    public void displayWarningRB(String message, Object... args) {
+    public void displayWarningRB(@Nullable String message, Object@Nullable... args) {
         displayWarningRB(message, null, args);
     }
 
     @Override
-    public void displayWarningRB(String message, String supercedesKey, Object... args) {
+    public void displayWarningRB(@Nullable String message, @Nullable String supercedesKey, Object@Nullable... args) {
         System.err.println(StringUtil.format(OStrings.getString(message), args));
     }
 
     @Override
-    public void showErrorDialogRB(String title, String message, Object... args) {
+    public void showErrorDialogRB(@Nullable String title, @Nullable String message, Object@Nullable... args) {
         System.err.println(StringUtil.format(OStrings.getString(message), args));
     }
 
     @Override
-    public void addDockable(Dockable pane) {
+    public void addDockable(@Nullable Dockable pane) {
         throw new NoSuchMethodError("Invalid call of ConsoleWindow");
     }
 
@@ -117,7 +118,7 @@ public class ConsoleWindow implements IMainWindow {
     }
 
     @Override
-    public JFrame getApplicationFrame() {
+    public @Nullable JFrame getApplicationFrame() {
         return null;
     }
 
@@ -127,12 +128,12 @@ public class ConsoleWindow implements IMainWindow {
     }
 
     @Override
-    public void showLengthMessage(String messageText) {
+    public void showLengthMessage(@Nullable String messageText) {
         throw new NoSuchMethodError("Invalid call of ConsoleWindow");
     }
 
     @Override
-    public void showProgressMessage(String messageText) {
+    public void showProgressMessage(@Nullable String messageText) {
         throw new NoSuchMethodError("Invalid call of ConsoleWindow");
     }
 
@@ -147,7 +148,7 @@ public class ConsoleWindow implements IMainWindow {
     }
 
     @Override
-    public DockingDesktop getDesktop() {
+    public @Nullable DockingDesktop getDesktop() {
         return null;
     }
 
@@ -161,7 +162,7 @@ public class ConsoleWindow implements IMainWindow {
     }
 
     @Override
-    public int showConfirmDialog(Object message, String title, int optionType, int messageType)
+    public int showConfirmDialog(Object message, @Nullable String title, int optionType, int messageType)
             throws HeadlessException {
 
         System.out.println(title);
@@ -176,7 +177,7 @@ public class ConsoleWindow implements IMainWindow {
     }
 
     @Override
-    public void showLockInsertMessage(String messageText, String toolTip) {
+    public void showLockInsertMessage(@Nullable String messageText, @Nullable String toolTip) {
         /* empty */
     }
 

--- a/src/main/java/org/omegat/gui/main/IMainWindow.java
+++ b/src/main/java/org/omegat/gui/main/IMainWindow.java
@@ -33,6 +33,7 @@ import javax.swing.JFrame;
 
 import com.vlsolutions.swing.docking.Dockable;
 import com.vlsolutions.swing.docking.DockingDesktop;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for access to main window functionality.
@@ -43,16 +44,19 @@ public interface IMainWindow {
     /**
      * Get application frame.
      */
+    @Nullable
     JFrame getApplicationFrame();
 
     /**
      * Lock UI for long-term operations.
      */
+    @Deprecated
     void lockUI();
 
     /**
      * Unlock UI after locking.
      */
+    @Deprecated
     void unlockUI();
 
     /**
@@ -68,7 +72,7 @@ public interface IMainWindow {
      * @param params
      *            message parameters for formatting
      */
-    void showStatusMessageRB(String messageKey, Object... params);
+    void showStatusMessageRB(@Nullable String messageKey, Object@Nullable... params);
 
     /**
      * Same as {@link #showStatusMessageRB(String, Object...)} but this will
@@ -79,7 +83,7 @@ public interface IMainWindow {
      * @param params
      *            message parameters for formatting
      */
-    void showTimedStatusMessageRB(String messageKey, Object... params);
+    void showTimedStatusMessageRB(@Nullable String messageKey, Object@Nullable... params);
 
     /**
      * Show message in progress bar. Progress bar shows the translation
@@ -88,7 +92,7 @@ public interface IMainWindow {
      * @param messageText
      *            message text
      */
-    void showProgressMessage(String messageText);
+    void showProgressMessage(@Nullable String messageText);
 
     /**
      * Show message in length label. Length label shows length (in nr of
@@ -97,7 +101,7 @@ public interface IMainWindow {
      * @param messageText
      *            message text
      */
-    void showLengthMessage(String messageText);
+    void showLengthMessage(@Nullable String messageText);
 
     /**
      * Show message indicating the state of the Lock cursor and Insert/overwrite
@@ -106,7 +110,7 @@ public interface IMainWindow {
      * @param messageText
      *            message text
      */
-    void showLockInsertMessage(String messageText, String toolTip);
+    void showLockInsertMessage(@Nullable String messageText, @Nullable String toolTip);
 
     /**
      * Display warning.
@@ -116,7 +120,7 @@ public interface IMainWindow {
      * @param params
      *            warning text parameters
      */
-    void displayWarningRB(String warningKey, Object... params);
+    void displayWarningRB(@Nullable String warningKey, Object@Nullable ... params);
 
     /**
      * Same as {@link #displayWarningRB(String, Object...)} but this will close
@@ -130,7 +134,7 @@ public interface IMainWindow {
      * @param params
      *            warning text parameters
      */
-    void displayWarningRB(String warningKey, String supercedesKey, Object... params);
+    void displayWarningRB(@Nullable String warningKey, @Nullable String supercedesKey, Object@Nullable... params);
 
     /**
      * Display error.
@@ -142,7 +146,7 @@ public interface IMainWindow {
      * @param params
      *            error text parameters
      */
-    void displayErrorRB(Throwable ex, String errorKey, Object... params);
+    void displayErrorRB(@Nullable Throwable ex, @Nullable String errorKey, Object@Nullable... params);
 
     /**
      * Show message in an ErrorDialog
@@ -156,7 +160,7 @@ public interface IMainWindow {
      *            title of dialog. message key in resource bundle of title that
      *            is to be displayed
      */
-    void showErrorDialogRB(String title, String message, Object... args);
+    void showErrorDialogRB(@Nullable String title, @Nullable String message, Object@Nullable... args);
 
     /**
      * shows a confirm dialog. For a GUI main window, this can be implemented as
@@ -179,7 +183,7 @@ public interface IMainWindow {
      * @throws HeadlessException
      *             if GraphicsEnvironment.isHeadless returns true
      */
-    int showConfirmDialog(Object message, String title, int optionType, int messageType)
+    int showConfirmDialog(@Nullable Object message, @Nullable String title, int optionType, int messageType)
             throws HeadlessException;
 
     /**
@@ -188,7 +192,7 @@ public interface IMainWindow {
      * @param message
      *            the message to show
      */
-    void showMessageDialog(String message);
+    void showMessageDialog(@Nullable String message);
 
     /**
      * Add new dockable pane into application frame. This method called on
@@ -197,7 +201,7 @@ public interface IMainWindow {
      * @param pane
      *            dockable pane
      */
-    void addDockable(Dockable pane);
+    void addDockable(@Nullable Dockable pane);
 
     /**
      * Sets cursor of window
@@ -205,7 +209,7 @@ public interface IMainWindow {
      * @param cursor
      *            the new cursor
      */
-    void setCursor(Cursor cursor);
+    void setCursor(@Nullable Cursor cursor);
 
     /**
      * Retrieves current cursor of window

--- a/src/main/java/org/omegat/gui/main/IMainWindow.java
+++ b/src/main/java/org/omegat/gui/main/IMainWindow.java
@@ -120,7 +120,7 @@ public interface IMainWindow {
      * @param params
      *            warning text parameters
      */
-    void displayWarningRB(@Nullable String warningKey, Object@Nullable ... params);
+    void displayWarningRB(@Nullable String warningKey, Object@Nullable... params);
 
     /**
      * Same as {@link #displayWarningRB(String, Object...)} but this will close

--- a/src/main/java/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/main/java/org/omegat/gui/main/ProjectUICommands.java
@@ -139,11 +139,10 @@ public final class ProjectUICommands {
                 ProjectProperties props = new ProjectProperties(dir);
                 props.setSourceLanguage(Preferences.getPreferenceDefault(Preferences.SOURCE_LOCALE, "AR-LB"));
                 props.setTargetLanguage(Preferences.getPreferenceDefault(Preferences.TARGET_LOCALE, "UK-UA"));
-                final ProjectProperties newProps = ProjectPropertiesDialogController.showDialog(
-                        Core.getMainWindow().getApplicationFrame(), props, dir.getAbsolutePath(),
-                        ProjectPropertiesDialog.Mode.NEW_PROJECT);
-
                 IMainWindow mainWindow = Core.getMainWindow();
+                final ProjectProperties newProps = ProjectPropertiesDialogController.showDialog(
+                        Objects.requireNonNull(mainWindow.getApplicationFrame()), props, dir.getAbsolutePath(),
+                        ProjectPropertiesDialog.Mode.NEW_PROJECT);
                 Cursor hourglassCursor = Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR);
                 Cursor oldCursor = mainWindow.getCursor();
                 mainWindow.setCursor(hourglassCursor);
@@ -188,7 +187,7 @@ public final class ProjectUICommands {
 
             @Override
             protected Void doInBackground() throws Exception {
-                mainWindow = Objects.requireNonNull(Core.getMainWindow());
+                mainWindow = Core.getMainWindow();
                 mainWindow.showStatusMessageRB("");
                 NewTeamProjectController newTeamProjectController = new NewTeamProjectController(mainWindow);
                 File dir = newTeamProjectController.show();

--- a/src/main/java/org/omegat/gui/search/SearchWindowController.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowController.java
@@ -53,7 +53,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.swing.AbstractAction;
 import javax.swing.ButtonModel;
@@ -131,7 +130,7 @@ public class SearchWindowController {
     public SearchWindowController(SearchMode mode) {
         form = new SearchWindowForm();
         form.setJMenuBar(new SearchWindowMenu(this));
-        Font f = Objects.requireNonNull(Core.getMainWindow()).getApplicationFont();
+        Font f = Core.getMainWindow().getApplicationFont();
         setFont(f);
 
         this.mode = mode;
@@ -968,8 +967,7 @@ public class SearchWindowController {
         handle.completion().whenComplete((result, error) -> {
             if (error != null) {
                 Log.logErrorRB(error, "ST_SEARCH_COMPLETE_ERROR");
-                Objects.requireNonNull(Core.getMainWindow()).displayErrorRB(error,
-                        "ST_SEARCH_COMPLETE_ERROR");
+                Core.getMainWindow().displayErrorRB(error, "ST_SEARCH_COMPLETE_ERROR");
             }
             form.dispose();
         });

--- a/src/testFixtures/java/org/omegat/core/data/TestCoreState.java
+++ b/src/testFixtures/java/org/omegat/core/data/TestCoreState.java
@@ -78,14 +78,12 @@ public class TestCoreState extends CoreState {
 
         // Check if main window exists and has a frame
         IMainWindow mainWindow = CoreState.getInstance().getMainWindow();
-        if (mainWindow != null) {
-            try {
-                if (mainWindow.getApplicationFrame() != null) {
-                    return true;
-                }
-            } catch (HeadlessException ignored) {
-                return false;
+        try {
+            if (mainWindow.getApplicationFrame() != null) {
+                return true;
             }
+        } catch (HeadlessException ignored) {
+            return false;
         }
 
         // Check if any GUI components are registered in CoreState


### PR DESCRIPTION
This is refactor to make `Core.getMainWindow` Non-Null. It is always MainWindow object in real execution but could be nullable for test environment. Now I try to fallback to ConsoleWindow object and avoid null.
This make every call to be clean.

Here is no functional change.

## Pull request type

- Other (describe below)
refactor

## Which ticket is resolved?

None; there are many warning of nullaway for the `Core.getMainWindow` may be null. this aovid it.
## What does this PR change?

- Annotate IMainWindow and ConsoleWindow
- Change non-null return of the Core.getMainWindow
- Update CoreState.setMainWindow to store ConsoleWindow when got null as argument

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
