### PR TITLE
fix(gui): give Forward in History its own shortcut

### DIFF
--- a/src/docs/manual/en/Menus_GoTo.xml
+++ b/src/docs/manual/en/Menus_GoTo.xml
@@ -305,6 +305,7 @@
             
             <keycombo>
                <keycap>C</keycap>
+               <keycap>A</keycap>
                <keycap>S</keycap>
                <keycap>N</keycap>
             </keycombo>

--- a/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.mac.properties
+++ b/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.mac.properties
@@ -120,7 +120,7 @@ gotoNextXEnforcedMenuItem=meta alt PERIOD
 gotoPrevXEnforcedMenuItem=meta alt shift PERIOD
 #<< End submenu <<#
 #-separator-#
-gotoHistoryForwardMenuItem=meta shift N
+gotoHistoryForwardMenuItem=meta alt shift N
 gotoHistoryBackMenuItem=meta shift P
 #-separator-#
 gotoNotesPanelMenuItem=meta alt 9

--- a/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.properties
+++ b/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.properties
@@ -120,7 +120,7 @@ gotoNextXEnforcedMenuItem=ctrl alt PERIOD
 gotoPrevXEnforcedMenuItem=ctrl alt shift PERIOD
 #<< End submenu <<#
 #-separator-#
-gotoHistoryForwardMenuItem=ctrl shift N
+gotoHistoryForwardMenuItem=ctrl alt shift N
 gotoHistoryBackMenuItem=ctrl shift P
 #-separator-#
 gotoNotesPanelMenuItem=ctrl alt 9


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- No ticket; found by conflict analysis of the bundled shortcut files.

## What does this PR change?

- Forward in History ships with the same shortcut as New Project (`ctrl/cmd shift N`) in both platform shortcut files - one of the two is silently shadowed; the manual documents the duplication
- Forward in History moves to `ctrl/cmd alt shift N` (`ctrl/cmd alt N/P` are taken by unique-segment navigation, `ctrl/cmd shift F` by find-in-project). Back in History keeps `ctrl/cmd shift P`.
- Manual shortcut updated (Menus_GoTo.xml).
