### PR TITLE
fix(gui): skip menu removal on shutdown when module never added its item

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerModule.java
@@ -50,7 +50,7 @@ public final class AlignerModule implements IApplicationEventListener {
     private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("org.omegat.gui.align.Bundle");
     private static @Nullable IApplicationEventListener alignerListener;
 
-    private AlignerModule() {
+    AlignerModule() {
     }
 
     /**
@@ -83,7 +83,12 @@ public final class AlignerModule implements IApplicationEventListener {
     }
 
     private void unregisterMenu() {
-        MenuExtender.removeMenuItems(MenuExtender.MenuKey.TOOLS, Collections.singletonList(alignerMenu));
+        // Menu item registers via invokeLater after startup; shutdown can
+        // arrive before that ran, leaving nothing to remove.
+        if (alignerMenu != null) {
+            MenuExtender.removeMenuItems(MenuExtender.MenuKey.TOOLS,
+                    Collections.singletonList(alignerMenu));
+        }
     }
 
     private void registerMenu() {

--- a/aligner/src/test/java/org/omegat/gui/align/AlignerModuleTest.java
+++ b/aligner/src/test/java/org/omegat/gui/align/AlignerModuleTest.java
@@ -1,0 +1,42 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.align;
+
+import org.junit.Test;
+
+/**
+ * Shutdown without prior menu registration must be no-op: startup registers
+ * menu item via invokeLater, so shutdown can arrive before it exists.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class AlignerModuleTest {
+
+    @Test
+    public void shutdownBeforeMenuRegistrationIsANoOp() {
+        new AlignerModule().onApplicationShutdown();
+    }
+}

--- a/tipoftheday/build.gradle
+++ b/tipoftheday/build.gradle
@@ -17,5 +17,7 @@ dependencies {
         compileOnly(libs.jspecify)
         compileOnly(libs.jackson.yaml)
     }
+    testImplementation(testFixtures(project.rootProject))
+    testImplementation(libs.junit4)
 }
 jar.dependsOn rootProject.tasks.named("tipsHtmls")

--- a/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/TipOfTheDayModule.java
+++ b/tipoftheday/src/main/java/org/omegat/gui/tipoftheday/TipOfTheDayModule.java
@@ -105,7 +105,9 @@ public final class TipOfTheDayModule {
 
         @Override
         public void onApplicationShutdown() {
-            if (ENABLED) {
+            // Menu item exists only when startup found tips index for UI
+            // language; nothing to remove otherwise.
+            if (ENABLED && totdMenu != null) {
                 MenuExtender.removeMenuItems(MenuExtender.MenuKey.HELP, Collections.singletonList(totdMenu));
             }
         }

--- a/tipoftheday/src/test/java/org/omegat/gui/tipoftheday/TipOfTheDayModuleTest.java
+++ b/tipoftheday/src/test/java/org/omegat/gui/tipoftheday/TipOfTheDayModuleTest.java
@@ -1,0 +1,43 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.tipoftheday;
+
+import org.junit.Test;
+
+/**
+ * Shutdown without prior startup must be no-op: without tips index for UI
+ * language, startup never creates the Help menu item, so shutdown has
+ * nothing to remove.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class TipOfTheDayModuleTest {
+
+    @Test
+    public void shutdownWithoutStartupIsANoOp() {
+        new TipOfTheDayModule.TipOfTheDayModuleListener().onApplicationShutdown();
+    }
+}


### PR DESCRIPTION
## Pull request type

- Bug fix -> [bug]

## Which ticket is resolved?

- No ticket; found by starting and ending development version in arabic

## What does this PR change?

- TipOfTheDay: app shutdown removed Help menu item unconditionally, but item exists only when tips index for UI language exists → NPE from JMenu.remove(null) everytime the app is shut down; null guard added
- Aligner: same pattern as race — menu registers via invokeLater, shutdown can run first; null guard added
- Regression tests for both modules; tipoftheday gains test infra
