### PR TITLE
feat(shortcuts): Apply shortcut changes without restart (SF-RFE-443)

### DIFF
--- a/src/main/java/org/omegat/gui/dialogs/KeyStrokeEditorDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/KeyStrokeEditorDialog.java
@@ -35,6 +35,8 @@ import javax.swing.JDialog;
 import javax.swing.KeyStroke;
 import javax.swing.WindowConstants;
 
+import org.jspecify.annotations.Nullable;
+
 import org.omegat.util.OStrings;
 import org.omegat.util.gui.StaticUIUtils;
 
@@ -69,7 +71,7 @@ public class KeyStrokeEditorDialog {
         dialog.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
-                keyStroke = KeyStroke.getKeyStrokeForEvent(e);
+                keyStroke = capture(e, keyStroke);
                 panel.shortcutLabel.setText(keyStrokeToString(keyStroke));
                 e.consume();
             }
@@ -102,6 +104,19 @@ public class KeyStrokeEditorDialog {
         dialog.setLocationRelativeTo(parent);
         dialog.setVisible(true);
         return userDidConfirm;
+    }
+
+    /**
+     * The keystroke a captured key event yields, or the current keystroke
+     * when the event carries no key code: macOS delivers the fn key as
+     * VK_UNDEFINED, which would otherwise display and store as
+     * "Unknown keyCode: 0x0".
+     */
+    static @Nullable KeyStroke capture(KeyEvent e, @Nullable KeyStroke current) {
+        if (e.getKeyCode() == KeyEvent.VK_UNDEFINED) {
+            return current;
+        }
+        return KeyStroke.getKeyStrokeForEvent(e);
     }
 
     String keyStrokeToString(KeyStroke ks) {

--- a/src/main/java/org/omegat/gui/editor/EditorTextArea3.java
+++ b/src/main/java/org/omegat/gui/editor/EditorTextArea3.java
@@ -88,40 +88,14 @@ import org.omegat.util.gui.UIDesignManager;
 @SuppressWarnings("serial")
 public class EditorTextArea3 extends JEditorPane {
 
-    private static final KeyStroke KEYSTROKE_CONTEXT_MENU = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorContextMenu");
-    private static final KeyStroke KEYSTROKE_NEXT = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorNextSegment");
-    private static final KeyStroke KEYSTROKE_PREV = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorPrevSegment");
-    private static final KeyStroke KEYSTROKE_NEXT_NOT_TAB = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorNextSegmentNotTab");
-    private static final KeyStroke KEYSTROKE_PREV_NOT_TAB = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorPrevSegmentNotTab");
-    private static final KeyStroke KEYSTROKE_INSERT_LF = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorInsertLineBreak");
-    private static final KeyStroke KEYSTROKE_SELECT_ALL = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorSelectAll");
-    private static final KeyStroke KEYSTROKE_DELETE_PREV_TOKEN = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorDeletePrevToken");
-    private static final KeyStroke KEYSTROKE_DELETE_NEXT_TOKEN = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorDeleteNextToken");
-    private static final KeyStroke KEYSTROKE_FIRST_SEG = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorFirstSegment");
-    private static final KeyStroke KEYSTROKE_LAST_SEG = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorLastSegment");
-    private static final KeyStroke KEYSTROKE_SKIP_NEXT_TOKEN = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorSkipNextToken");
-    private static final KeyStroke KEYSTROKE_SKIP_PREV_TOKEN = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorSkipPrevToken");
-    private static final KeyStroke KEYSTROKE_SKIP_NEXT_TOKEN_SEL = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorSkipNextTokenWithSelection");
-    private static final KeyStroke KEYSTROKE_SKIP_PREV_TOKEN_SEL = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorSkipPrevTokenWithSelection");
-    private static final KeyStroke KEYSTROKE_TOGGLE_CURSOR_LOCK = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorToggleCursorLock");
-    private static final KeyStroke KEYSTROKE_TOGGLE_OVERTYPE = PropertiesShortcuts.getEditorShortcuts()
-            .getKeyStroke("editorToggleOvertype");
+
+    /**
+     * The current keystroke of an editor function, read per event so edits
+     * from the shortcut preferences apply immediately.
+     */
+    private static KeyStroke editorKey(String key) {
+        return PropertiesShortcuts.getEditorShortcuts().getKeyStroke(key);
+    }
 
     /** Undo Manager to store edits */
     protected final TranslationUndoManager undoManager = new TranslationUndoManager(this);
@@ -396,7 +370,7 @@ public class EditorTextArea3 extends JEditorPane {
         if (autoCompleter.processKeys(e)) {
             // The AutoCompleter needs special treatment.
             processed = true;
-        } else if (s.equals(KEYSTROKE_CONTEXT_MENU)) {
+        } else if (s.equals(editorKey("editorContextMenu"))) {
             // Context Menu key for contextual (right-click) menu (Shift+Esc on
             // Mac)
             JPopupMenu popup = makePopupMenu(getCaretPosition());
@@ -405,19 +379,19 @@ public class EditorTextArea3 extends JEditorPane {
                         (int) getCaret().getMagicCaretPosition().getY());
                 processed = true;
             }
-        } else if (s.equals(KEYSTROKE_NEXT)) {
+        } else if (s.equals(editorKey("editorNextSegment"))) {
             // Advance when 'Use TAB to advance'
             if (controller.settings.isUseTabForAdvance()) {
                 controller.nextEntry();
                 processed = true;
             }
-        } else if (s.equals(KEYSTROKE_PREV)) {
+        } else if (s.equals(editorKey("editorPrevSegment"))) {
             // Go back when 'Use TAB to advance'
             if (controller.settings.isUseTabForAdvance()) {
                 controller.prevEntry();
                 processed = true;
             }
-        } else if (s.equals(KEYSTROKE_NEXT_NOT_TAB)) {
+        } else if (s.equals(editorKey("editorNextSegmentNotTab"))) {
             // Advance when not 'Use TAB to advance'
             if (!controller.settings.isUseTabForAdvance()) {
                 controller.nextEntry();
@@ -426,23 +400,23 @@ public class EditorTextArea3 extends JEditorPane {
                 Core.getMainWindow().showTimedStatusMessageRB("ETA_WARNING_TAB_ADVANCE");
                 processed = true;
             }
-        } else if (s.equals(KEYSTROKE_PREV_NOT_TAB)) {
+        } else if (s.equals(editorKey("editorPrevSegmentNotTab"))) {
             // Go back when not 'Use TAB to advance'
             if (!controller.settings.isUseTabForAdvance()) {
                 controller.prevEntry();
                 processed = true;
             }
-        } else if (s.equals(KEYSTROKE_INSERT_LF)) {
+        } else if (s.equals(editorKey("editorInsertLineBreak"))) {
             // Insert LF
             KeyEvent ke = new KeyEvent(e.getComponent(), e.getID(), e.getWhen(), 0, KeyEvent.VK_ENTER, '\n');
             super.processKeyEvent(ke);
             processed = true;
-        } else if (s.equals(KEYSTROKE_SELECT_ALL)) {
+        } else if (s.equals(editorKey("editorSelectAll"))) {
             // Select all
             setSelectionStart(doc.getTranslationStart());
             setSelectionEnd(doc.getTranslationEnd());
             processed = true;
-        } else if (s.equals(KEYSTROKE_DELETE_PREV_TOKEN)) {
+        } else if (s.equals(editorKey("editorDeletePrevToken"))) {
             // Delete previous token
             try {
                 processed = wholeTagDelete(false);
@@ -459,7 +433,7 @@ public class EditorTextArea3 extends JEditorPane {
             } catch (BadLocationException ex) {
                 // do nothing
             }
-        } else if (s.equals(KEYSTROKE_DELETE_NEXT_TOKEN)) {
+        } else if (s.equals(editorKey("editorDeleteNextToken"))) {
             // Delete next token
             try {
                 processed = wholeTagDelete(true);
@@ -480,34 +454,34 @@ public class EditorTextArea3 extends JEditorPane {
             } catch (BadLocationException ex) {
                 // do nothing
             }
-        } else if (s.equals(KEYSTROKE_FIRST_SEG)) {
+        } else if (s.equals(editorKey("editorFirstSegment"))) {
             // Jump to beginning of document
             int segNum = controller.m_docSegList[0].segmentNumberInProject;
             controller.gotoEntry(segNum);
             processed = true;
-        } else if (s.equals(KEYSTROKE_LAST_SEG)) {
+        } else if (s.equals(editorKey("editorLastSegment"))) {
             // Jump to end of document
             int lastSegIndex = controller.m_docSegList.length - 1;
             int segNum = controller.m_docSegList[lastSegIndex].segmentNumberInProject;
             controller.gotoEntry(segNum);
             processed = true;
-        } else if (s.equals(KEYSTROKE_SKIP_PREV_TOKEN)) {
+        } else if (s.equals(editorKey("editorSkipPrevToken"))) {
             // Skip over previous token
             processed = moveCursorOverTag(false, false);
-        } else if (s.equals(KEYSTROKE_SKIP_PREV_TOKEN_SEL)) {
+        } else if (s.equals(editorKey("editorSkipPrevTokenWithSelection"))) {
             // Skip over previous token while extending selection
             processed = moveCursorOverTag(true, false);
-        } else if (s.equals(KEYSTROKE_SKIP_NEXT_TOKEN)) {
+        } else if (s.equals(editorKey("editorSkipNextToken"))) {
             // Skip over next token
             processed = moveCursorOverTag(false, true);
-        } else if (s.equals(KEYSTROKE_SKIP_NEXT_TOKEN_SEL)) {
+        } else if (s.equals(editorKey("editorSkipNextTokenWithSelection"))) {
             // Skip over next token while extending selection
             processed = moveCursorOverTag(true, true);
-        } else if (s.equals(KEYSTROKE_TOGGLE_CURSOR_LOCK)) {
+        } else if (s.equals(editorKey("editorToggleCursorLock"))) {
             boolean lockEnabled = !lockCursorToInputArea;
             lockCursorToInputArea = lockEnabled;
             updateLockInsertMessage();
-        } else if (s.equals(KEYSTROKE_TOGGLE_OVERTYPE)) {
+        } else if (s.equals(editorKey("editorToggleOvertype"))) {
             processed = switchOvertypeMode();
             updateLockInsertMessage();
         }

--- a/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleter.java
+++ b/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleter.java
@@ -331,15 +331,17 @@ public class AutoCompleter implements IAutoCompleter {
         sb.append("</b>");
 
         if (views.size() != 1) {
+            // An explicitly unbound switch key (configurable since the
+            // shortcut preferences) simply drops its hint line.
             int nextViewN = nextViewNumber(currentView);
-            if (views.size() >= 2 && nextViewN != -1) {
+            if (views.size() >= 2 && nextViewN != -1 && keys.nextView != null) {
                 sb.append("<br>");
                 sb.append(OStrings.getString("AC_NEXT_VIEW", StaticUIUtils.getKeyStrokeText(keys.nextView),
                         views.get(nextViewN).getName()));
             }
 
             int prevViewN = prevViewNumber();
-            if (views.size() > 2 && prevViewN != -1) {
+            if (views.size() > 2 && prevViewN != -1 && keys.prevView != null) {
                 sb.append("<br>");
                 sb.append(OStrings.getString("AC_PREV_VIEW", StaticUIUtils.getKeyStrokeText(keys.prevView),
                         views.get(prevViewN).getName()));

--- a/src/main/java/org/omegat/gui/main/BaseMainWindowMenu.java
+++ b/src/main/java/org/omegat/gui/main/BaseMainWindowMenu.java
@@ -50,6 +50,7 @@ import java.util.logging.Logger;
 
 import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
+import javax.swing.InputMap;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
 import javax.swing.JMenu;
@@ -111,6 +112,9 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
 
     /** menu bar instance */
     protected final JMenuBar mainMenu = new JMenuBar();
+
+    /** The currently bound window-level find-in-project keystroke. */
+    private KeyStroke findInProjectStroke;
 
     /** MainWindow menu handler instance. */
     protected final BaseMainWindowMenuHandler mainWindowMenuHandler;
@@ -223,6 +227,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         createMenuBar();
         PropertiesShortcuts.getMainMenuShortcuts().bindKeyStrokes(mainMenu);
         configureActions();
+        PropertiesShortcuts.getMainMenuShortcuts().addChangeListener(this::updateShortcuts);
     }
 
     abstract void createMenuBar();
@@ -688,8 +693,7 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         });
 
         String key = "findInProjectReuseLastWindow";
-        KeyStroke stroke = PropertiesShortcuts.getMainMenuShortcuts().getKeyStroke(key);
-        mainWindow.getApplicationFrame().getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(stroke, key);
+        bindFindInProjectKey();
         mainWindow.getApplicationFrame().getRootPane().getActionMap().put(key, new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -799,6 +803,34 @@ public abstract class BaseMainWindowMenu implements ActionListener, MenuListener
         result.addActionListener(this);
         buttonGroup.add(result);
         return result;
+    }
+
+    /**
+     * (Re)binds the window-level find-in-project shortcut, replacing the
+     * previously bound keystroke.
+     */
+    private void bindFindInProjectKey() {
+        String key = "findInProjectReuseLastWindow";
+        InputMap inputMap = mainWindow.getApplicationFrame().getRootPane()
+                .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+        if (findInProjectStroke != null) {
+            inputMap.remove(findInProjectStroke);
+        }
+        findInProjectStroke = PropertiesShortcuts.getMainMenuShortcuts().getKeyStroke(key);
+        if (findInProjectStroke != null) {
+            inputMap.put(findInProjectStroke, key);
+        }
+    }
+
+    /**
+     * Re-reads the shortcut definitions and rebinds the menu accelerators
+     * and the window-level find-in-project binding; unbound functions lose
+     * their stale accelerator.
+     */
+    @Override
+    public void updateShortcuts() {
+        PropertiesShortcuts.getMainMenuShortcuts().bindKeyStrokes(mainMenu);
+        bindFindInProjectKey();
     }
 
     /**

--- a/src/main/java/org/omegat/gui/main/IMainMenu.java
+++ b/src/main/java/org/omegat/gui/main/IMainMenu.java
@@ -56,4 +56,12 @@ public interface IMainMenu {
     JMenu getMenu(MenuExtender.MenuKey marker);
 
     void invokeAction(String action, int modifiers);
+
+    /**
+     * Re-reads the shortcut definitions and rebinds the menu accelerators
+     * and window-level bindings; no operation for implementations without
+     * shortcut support.
+     */
+    default void updateShortcuts() {
+    }
 }

--- a/src/main/java/org/omegat/gui/shortcuts/PropertiesShortcuts.java
+++ b/src/main/java/org/omegat/gui/shortcuts/PropertiesShortcuts.java
@@ -26,14 +26,23 @@
 package org.omegat.gui.shortcuts;
 
 import java.awt.Component;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -42,6 +51,9 @@ import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
+import org.jspecify.annotations.Nullable;
 
 import org.omegat.util.Platform;
 import org.omegat.util.StaticUtils;
@@ -63,7 +75,7 @@ public class PropertiesShortcuts {
     private static final String EDITOR_SHORTCUTS_FILE = "EditorShortcuts.properties";
 
     private static class LoadedShortcuts {
-        static final PropertiesShortcuts MAIN_MENU_SHORTCUTS = loadBundled(BUNDLED_ROOT, MAIN_MENU_SHORTCUTS_FILE);;
+        static final PropertiesShortcuts MAIN_MENU_SHORTCUTS = loadBundled(BUNDLED_ROOT, MAIN_MENU_SHORTCUTS_FILE);
         static final PropertiesShortcuts EDITOR_SHORTCUTS = loadBundled(BUNDLED_ROOT, EDITOR_SHORTCUTS_FILE);
     }
 
@@ -75,7 +87,18 @@ public class PropertiesShortcuts {
         return LoadedShortcuts.EDITOR_SHORTCUTS;
     }
 
-    private final Map<String, String> data = new HashMap<>();
+    /** Bundled default values, from the classpath. */
+    private final Map<String, String> defaults = new HashMap<>();
+    /**
+     * Per-key user overrides, from the file in the config dir and from
+     * {@link #setShortcut}. An entry equal to its default is never held here.
+     */
+    private final Map<String, String> userOverrides = new HashMap<>();
+    private final List<Runnable> changeListeners = new CopyOnWriteArrayList<>();
+    /** Base name of the user file in the config dir; null for ad-hoc sets. */
+    private @Nullable String userFileName;
+    /** Classpath location of the bundled defaults; null for ad-hoc sets. */
+    private @Nullable String classpathPath;
 
     /**
      * Creates shortcut list with the specified defaults and user shortcuts.
@@ -95,6 +118,8 @@ public class PropertiesShortcuts {
      */
     static PropertiesShortcuts loadBundled(String classpathRoot, String filename) {
         PropertiesShortcuts result = new PropertiesShortcuts();
+        result.userFileName = filename;
+        result.classpathPath = classpathRoot + filename;
         try {
             result.loadFromClasspath(classpathRoot + filename);
             result.loadFromFile(new File(StaticUtils.getConfigDir(), filename));
@@ -115,6 +140,129 @@ public class PropertiesShortcuts {
         }
     }
 
+    /**
+     * The properties-file value for a keystroke, parseable by
+     * {@link KeyStroke#getKeyStroke(String)}; the empty string (= explicitly
+     * unbound) for null.
+     */
+    public static String toPropertyValue(@Nullable KeyStroke ks) {
+        return ks == null ? "" : ks.toString();
+    }
+
+    /** Keys of all known shortcutable functions, defaults and overrides. */
+    public Set<String> getKeys() {
+        Set<String> keys = new TreeSet<>(defaults.keySet());
+        keys.addAll(userOverrides.keySet());
+        return Collections.unmodifiableSet(keys);
+    }
+
+    /**
+     * Raw current value of the key ("" = explicitly unbound), or null when
+     * the key is unknown.
+     */
+    public @Nullable String getShortcutValue(String key) {
+        String override = userOverrides.get(key);
+        return override != null ? override : defaults.get(key);
+    }
+
+    /** Raw bundled default of the key, or null when the key is unknown. */
+    public @Nullable String getDefaultValue(String key) {
+        return defaults.get(key);
+    }
+
+    /** Whether the key currently differs from its bundled default. */
+    public boolean isModified(String key) {
+        return userOverrides.containsKey(key);
+    }
+
+    /**
+     * Sets the shortcut of the key for this session; null unbinds it
+     * explicitly. A value equal to the bundled default removes the override
+     * instead. Takes effect in consumers on the next (re)bind; persistent
+     * only after {@link #save()}.
+     */
+    public void setShortcut(String key, @Nullable KeyStroke ks) {
+        // Equality of the keystrokes, not of the raw strings: the canonical
+        // format ("ctrl pressed D") differs from the hand-written file
+        // syntax ("ctrl D") for the same keystroke.
+        if (defaults.containsKey(key) && Objects.equals(ks, parse(defaults.get(key)))) {
+            userOverrides.remove(key);
+        } else {
+            userOverrides.put(key, toPropertyValue(ks));
+        }
+    }
+
+    private static @Nullable KeyStroke parse(@Nullable String value) {
+        return value == null || value.isEmpty() ? null : KeyStroke.getKeyStroke(value);
+    }
+
+    /** Restores the bundled default of the key for this session. */
+    public void clearUserOverride(String key) {
+        userOverrides.remove(key);
+    }
+
+    /**
+     * Writes the current overrides to the user file in the config dir (on
+     * macOS the .mac.properties variant, matching the load preference) and
+     * notifies the change listeners. Keys at their bundled default are not
+     * written, so later default changes reach the user.
+     */
+    public void save() throws IOException {
+        String name = userFileName;
+        if (name == null) {
+            throw new IllegalStateException("This shortcut set is not backed by a user file");
+        }
+        if (Platform.isMacOSX()) {
+            name = getMacProperties(name);
+        }
+        File file = new File(StaticUtils.getConfigDir(), name);
+        try (BufferedWriter out = Files.newBufferedWriter(file.toPath(), StandardCharsets.ISO_8859_1)) {
+            out.write("# Shortcut overrides written by the OmegaT preferences dialog.");
+            out.newLine();
+            out.write("# Keys absent here follow the application defaults; comments are not preserved.");
+            out.newLine();
+            for (Map.Entry<String, String> entry : new TreeMap<>(userOverrides).entrySet()) {
+                out.write(escapeKey(entry.getKey()) + "=" + entry.getValue());
+                out.newLine();
+            }
+        }
+        // Consumers rebind Swing components, so they are notified on the EDT
+        // regardless of the calling thread (the preferences dialog saves
+        // from a worker).
+        SwingUtilities.invokeLater(() -> changeListeners.forEach(Runnable::run));
+    }
+
+    /** Escapes the properties-format metacharacters of a key. */
+    private static String escapeKey(String key) {
+        return key.replace("\\", "\\\\").replace(" ", "\\ ").replace("=", "\\=")
+                .replace(":", "\\:").replace("#", "\\#").replace("!", "\\!");
+    }
+
+    /**
+     * Discards unsaved session changes by reloading the bundled defaults and
+     * the user file.
+     */
+    public void reload() throws IOException {
+        String name = userFileName;
+        String classpath = classpathPath;
+        if (name == null || classpath == null) {
+            throw new IllegalStateException("This shortcut set is not backed by a user file");
+        }
+        defaults.clear();
+        userOverrides.clear();
+        loadFromClasspath(classpath);
+        loadFromFile(new File(StaticUtils.getConfigDir(), name));
+    }
+
+    /** Registers a listener notified after {@link #save()}, on the EDT. */
+    public void addChangeListener(Runnable listener) {
+        changeListeners.add(listener);
+    }
+
+    public void removeChangeListener(Runnable listener) {
+        changeListeners.remove(listener);
+    }
+
     private String getMacProperties(String properties) {
         return properties.replaceAll("\\.properties$", ".mac.properties");
     }
@@ -130,7 +278,7 @@ public class PropertiesShortcuts {
     private boolean loadFromClasspathImpl(String path) throws IOException {
         try (InputStream in = getClass().getResourceAsStream(path)) {
             if (in != null) {
-                loadProperties(in);
+                loadProperties(in, defaults);
                 return true;
             }
         }
@@ -153,18 +301,24 @@ public class PropertiesShortcuts {
 
     private void loadFromFileImpl(File file) throws IOException {
         try (FileInputStream fis = new FileInputStream(file)) {
-            loadProperties(fis);
+            loadProperties(fis, userOverrides);
         }
+        // Entries at their default are not overrides; without this, a saved
+        // file from an older default set would freeze those keys forever.
+        // Compared as keystrokes, so a differently spelled equal value does
+        // not count as an override either.
+        userOverrides.entrySet().removeIf(e -> defaults.containsKey(e.getKey())
+                && Objects.equals(parse(e.getValue()), parse(defaults.get(e.getKey()))));
     }
 
-    private void loadProperties(InputStream in) throws IOException {
+    private static void loadProperties(InputStream in, Map<String, String> target) throws IOException {
         Properties props = new Properties();
         props.load(in);
-        props.forEach((k, v) -> data.put(k.toString(), v.toString()));
+        props.forEach((k, v) -> target.put(k.toString(), v.toString()));
     }
 
     public KeyStroke getKeyStroke(String key) {
-        String shortcut = data.get(key);
+        String shortcut = getShortcutValue(key);
         if (shortcut == null) {
             throw new IllegalArgumentException("Keyboard shortcut not defined. Key=" + key);
         }
@@ -238,15 +392,17 @@ public class PropertiesShortcuts {
     }
 
     public boolean isEmpty() {
-        return data.isEmpty();
+        return defaults.isEmpty() && userOverrides.isEmpty();
     }
 
     /**
      * For testing purposes
      *
-     * @return Unmodifiable reference to data held by this instance
+     * @return Unmodifiable merged view of the data held by this instance
      */
     Map<String, String> getData() {
-        return Collections.unmodifiableMap(data);
+        Map<String, String> merged = new HashMap<>(defaults);
+        merged.putAll(userOverrides);
+        return Collections.unmodifiableMap(merged);
     }
 }

--- a/src/main/resources/org/omegat/gui/main/EditorShortcuts.mac.properties
+++ b/src/main/resources/org/omegat/gui/main/EditorShortcuts.mac.properties
@@ -6,7 +6,6 @@ editorNextSegmentNotTab=ENTER
 editorPrevSegmentNotTab=meta ENTER
 editorInsertLineBreak=shift ENTER
 editorSelectAll=meta A
-editorSwitchOrientation=ctrl shift O
 editorDeletePrevToken=alt BACK_SPACE
 editorDeleteNextToken=alt DELETE
 editorFirstSegment=meta PAGE_UP

--- a/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.mac.properties
+++ b/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.mac.properties
@@ -2,42 +2,40 @@
 # Project menu #
 ################
 projectNewMenuItem=meta shift N
-#	projectTeamNewMenuItem=
+projectTeamNewMenuItem=
 projectOpenMenuItem=meta O
-#	projectOpenRecentMenuItem=
+projectClearRecentMenuItem=
 #-separator-#
-#	projectImportMenuItem=
-#	projectWikiImportMenuItem=
+projectImportMenuItem=
+projectWikiImportMenuItem=
 projectReloadMenuItem=F5
 projectCloseMenuItem=meta shift W
 #-separator-#
 projectSaveMenuItem=meta S
 #-separator-#
-projectCommitSourceFiles
-projectCommitTargetFiles
+projectCommitSourceFiles=
+projectCommitTargetFiles=
 #-separator-#
 projectCompileMenuItem=meta D
 projectSingleCompileMenuItem=meta shift D
-#	projectMedOpenMenuItem=
-#	projectMedCreateMenuItem=
 #-separator-#
 projectEditMenuItem=meta E
 viewFileListMenuItem=meta L
 #>> Access Project Contents submenu >>#
-#	projectAccessRootMenuItem=
-#	projectAccessDictionaryMenuItem=
-#	projectAccessGlossaryMenuItem=
-#	projectAccessSourceMenuItem=
-#	projectAccessTargetMenuItem=
-#	projectAccessTMMenuItem=
-#	projectAccessExportTMMenuItem
+projectAccessRootMenuItem=
+projectAccessDictionaryMenuItem=
+projectAccessGlossaryMenuItem=
+projectAccessSourceMenuItem=
+projectAccessTargetMenuItem=
+projectAccessTMMenuItem=
+projectAccessExportTMMenuItem=
 #-separator-#
-#	projectAccessCurrentSourceDocumentMenuItem=
-#	projectAccessCurrentTargetDocumentMenuItem=
-#	projectAccessWritableGlossaryMenuItem=
+projectAccessCurrentSourceDocumentMenuItem=
+projectAccessCurrentTargetDocumentMenuItem=
+projectAccessWriteableGlossaryMenuItem=
 #<< End submenu <<#
 projectExitMenuItem=meta Q
-#	projectRestartMenuItem=
+projectRestartMenuItem=
 
 #############
 # Edit menu #
@@ -67,10 +65,10 @@ editReplaceInProjectMenuItem=meta K
 editSearchDictionaryMenuItem=alt shift D
 #-separator-#
 #>> Switch Case To submenu >>#
-#	lowerCaseMenuItem=
-#	upperCaseMenuItem=
-#	titleCaseMenuItem=
-#	sentenceCaseMenuItem=
+lowerCaseMenuItem=
+upperCaseMenuItem=
+titleCaseMenuItem=
+sentenceCaseMenuItem=
 #-separator-#
 cycleSwitchCaseMenuItem=shift F3
 #<< End submenu <<#
@@ -85,19 +83,19 @@ editSelectFuzzy4MenuItem=meta 4
 editSelectFuzzy5MenuItem=meta 5
 #<< End submenu <<#
 #>> Insert Unicode Control Character submenu >>#
-#	insertCharsLRM=
-#	insertCharsRLM=
+insertCharsLRM=
+insertCharsRLM=
 #-separator-#
-#	insertCharsLRE=
-#	insertCharsRLE=
-#	insertCharsPDF=
+insertCharsLRE=
+insertCharsRLE=
+insertCharsPDF=
 #<< End submenu <<#
 #-separator-#
-#	editMultipleDefault=
-#	editMultipleAlternate=
+editMultipleDefault=
+editMultipleAlternate=
 #-separator-#
 editRegisterUntranslatedMenuItem=meta shift X
-#	editRegisterEmptyMenuItem=
+editRegisterEmptyMenuItem=
 editRegisterIdenticalMenuItem=meta shift S
 
 ##############
@@ -129,74 +127,74 @@ gotoEditorPanelMenuItem=meta alt 0
 #############
 # View menu #
 #############
-#	viewMarkTranslatedSegmentsCheckBoxMenuItem=
-#	viewMarkUntranslatedSegmentsCheckBoxMenuItem=
-#	viewMarkParagraphStartCheckBoxMenuItem=
-#	viewDisplaySegmentSourceCheckBoxMenuItem=
-#	viewMarkNonUniqueSegmentsCheckBoxMenuItem=
-#	viewMarkNotedSegmentsCheckBoxMenuItem=
-#	viewMarkNBSPCheckBoxMenuItem=
-#	viewMarkWhitespaceCheckBoxMenuItem=
-#	viewMarkBidiCheckBoxMenuItem=
-#	viewMarkAutoPopulatedCheckBoxMenuItem=
-#	viewMarkGlossaryMatchesCheckBoxMenuItem=
-#	viewMarkLanguageCheckerCheckBoxMenuItem=
-#	viewMarkFontFallbackCheckBoxMenuItem=
+viewMarkTranslatedSegmentsCheckBoxMenuItem=
+viewMarkUntranslatedSegmentsCheckBoxMenuItem=
+viewMarkParagraphStartCheckBoxMenuItem=
+viewDisplaySegmentSourceCheckBoxMenuItem=
+viewMarkNonUniqueSegmentsCheckBoxMenuItem=
+viewMarkNotedSegmentsCheckBoxMenuItem=
+viewMarkNBSPCheckBoxMenuItem=
+viewMarkWhitespaceCheckBoxMenuItem=
+viewMarkBidiCheckBoxMenuItem=
+viewMarkAlternativeTranslationsCheckBoxMenuItem=
+viewMarkAutoPopulatedCheckBoxMenuItem=
+viewMarkGlossaryMatchesCheckBoxMenuItem=
+viewMarkLanguageCheckerCheckBoxMenuItem=
+viewMarkFontFallbackCheckBoxMenuItem=
 #>> Modification Info submenu >>#
-#	viewDisplayModificationInfoNoneRadioButtonMenuItem=
-#	viewDisplayModificationInfoSelectedRadioButtonMenuItem=
-#	viewDisplayModificationInfoAllRadioButtonMenuItem=
+viewDisplayModificationInfoNoneRadioButtonMenuItem=
+viewDisplayModificationInfoSelectedRadioButtonMenuItem=
+viewDisplayModificationInfoAllRadioButtonMenuItem=
 #<< End submenu <<#
 #-separator-#
-#	viewRestoreGUIMenuItem=
+viewRestoreGUIMenuItem=
 
 ##############
 # Tools menu #
 ##############
 toolsCheckIssuesMenuItem=meta shift V
-#	toolsCheckIssuesCurrentFileMenuItem=
-#	toolsShowStatisticsStandardMenuItem=
-#	toolsShowStatisticsMatchesMenuItem=
-#	toolsShowStatisticsMatchesPerFileMenuItem=
+toolsCheckIssuesCurrentFileMenuItem=
+toolsShowStatisticsStandardMenuItem=
+toolsShowStatisticsMatchesMenuItem=
+toolsShowStatisticsMatchesPerFileMenuItem=
 #-separator-#
-#	toolsAlignFilesMenuItem=
 
 ################
 # Options menu #
 ################
-#	optionsPreferencesMenuItem=
+optionsPreferencesMenuItem=
 #-separator-#
 #>> Machine Translate submenu >>#
-#	optionsMTAutoFetchCheckboxMenuItem=
+optionsMTAutoFetchCheckboxMenuItem=
 #-separator-#
 #<< End submenu <<#
 #>> Glossary submenu >>#
-#	optionsDictionaryFuzzyMatchingCheckBoxMenuItem=
+optionsGlossaryFuzzyMatchingCheckBoxMenuItem=
 #-separator-#
 #<< End submenu <<#
 #>> Dictionary submenu >>#
-#	optionsDictionaryFuzzyMatchingCheckBoxMenuItem=
+optionsDictionaryFuzzyMatchingCheckBoxMenuItem=
 #<< End submenu <<#
 #>> Auto-completion submenu >>#
-#	optionsAutoCompleteShowAutomaticallyItem=
-#	optionsAutoCompleteHistoryCompletionMenuItem=
-#	optionsAutoCompleteHistoryPredictionMenuItem=
+optionsAutoCompleteShowAutomaticallyItem=
+optionsAutoCompleteHistoryCompletionMenuItem=
+optionsAutoCompleteHistoryPredictionMenuItem=
 #<< End submenu <<#
 #-separator-#
-#	optionsSetupFileFiltersMenuItem=
-#	optionsSentsegMenuItem=
-#	optionsWorkflowMenuItem=
+optionsSetupFileFiltersMenuItem=
+optionsSentsegMenuItem=
+optionsWorkflowMenuItem=
 #-separator-#
-#	optionsAccessConfigDirMenuItem=
+optionsAccessConfigDirMenuItem=
 
 #############
 # Help menu #
 #############
 helpContentsMenuItem=F1
-#	helpAboutMenuItem=
-#	helpLastChangesMenuItem=
-#	helpLogMenuItem=
-#	helpUpdateCheckMenuItem
+helpAboutMenuItem=
+helpLastChangesMenuItem=
+helpLogMenuItem=
+helpUpdateCheckMenuItem=
 
 #################
 # Search Window #

--- a/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.properties
+++ b/src/main/resources/org/omegat/gui/main/MainMenuShortcuts.properties
@@ -2,42 +2,40 @@
 # Project menu #
 ################
 projectNewMenuItem=ctrl shift N
-#	projectTeamNewMenuItem=
+projectTeamNewMenuItem=
 projectOpenMenuItem=ctrl O
-#	projectOpenRecentMenuItem=
+projectClearRecentMenuItem=
 #-separator-#
-#	projectImportMenuItem=
-#	projectWikiImportMenuItem=
+projectImportMenuItem=
+projectWikiImportMenuItem=
 projectReloadMenuItem=F5
 projectCloseMenuItem=ctrl shift W
 #-separator-#
 projectSaveMenuItem=ctrl S
 #-separator-#
-projectCommitSourceFiles
-projectCommitTargetFiles
+projectCommitSourceFiles=
+projectCommitTargetFiles=
 #-separator-#
 projectCompileMenuItem=ctrl D
 projectSingleCompileMenuItem=ctrl shift D
-#	projectMedOpenMenuItem=
-#	projectMedCreateMenuItem=
 #-separator-#
 projectEditMenuItem=ctrl E
 viewFileListMenuItem=ctrl L
 #>> Access Project Contents submenu >>#
-#	projectAccessRootMenuItem=
-#	projectAccessDictionaryMenuItem=
-#	projectAccessGlossaryMenuItem=
-#	projectAccessSourceMenuItem=
-#	projectAccessTargetMenuItem=
-#	projectAccessTMMenuItem=
-#	projectAccessExportTMMenuItem
+projectAccessRootMenuItem=
+projectAccessDictionaryMenuItem=
+projectAccessGlossaryMenuItem=
+projectAccessSourceMenuItem=
+projectAccessTargetMenuItem=
+projectAccessTMMenuItem=
+projectAccessExportTMMenuItem=
 #-separator-#
-#	projectAccessCurrentSourceDocumentMenuItem=
-#	projectAccessCurrentTargetDocumentMenuItem=
-#	projectAccessWriteableGlossaryMenuItem=
+projectAccessCurrentSourceDocumentMenuItem=
+projectAccessCurrentTargetDocumentMenuItem=
+projectAccessWriteableGlossaryMenuItem=
 #<< End submenu <<#
 projectExitMenuItem=ctrl Q
-#	projectRestartMenuItem=
+projectRestartMenuItem=
 
 #############
 # Edit menu #
@@ -67,10 +65,10 @@ editReplaceInProjectMenuItem=ctrl K
 editSearchDictionaryMenuItem=alt shift D
 #-separator-#
 #>> Switch Case To submenu >>#
-#	lowerCaseMenuItem=
-#	upperCaseMenuItem=
-#	titleCaseMenuItem=
-#	sentenceCaseMenuItem=
+lowerCaseMenuItem=
+upperCaseMenuItem=
+titleCaseMenuItem=
+sentenceCaseMenuItem=
 #-separator-#
 cycleSwitchCaseMenuItem=shift F3
 #<< End submenu <<#
@@ -85,19 +83,19 @@ editSelectFuzzy4MenuItem=ctrl 4
 editSelectFuzzy5MenuItem=ctrl 5
 #<< End submenu <<#
 #>> Insert Unicode Control Character submenu >>#
-#	insertCharsLRM=
-#	insertCharsRLM=
+insertCharsLRM=
+insertCharsRLM=
 #-separator-#
-#	insertCharsLRE=
-#	insertCharsRLE=
-#	insertCharsPDF=
+insertCharsLRE=
+insertCharsRLE=
+insertCharsPDF=
 #<< End submenu <<#
 #-separator-#
-#	editMultipleDefault=
-#	editMultipleAlternate=
+editMultipleDefault=
+editMultipleAlternate=
 #-separator-#
 editRegisterUntranslatedMenuItem= ctrl shift X
-#	editRegisterEmptyMenuItem=
+editRegisterEmptyMenuItem=
 editRegisterIdenticalMenuItem=ctrl shift S
 
 ##############
@@ -129,74 +127,74 @@ gotoEditorPanelMenuItem=ctrl alt 0
 #############
 # View menu #
 #############
-#	viewMarkTranslatedSegmentsCheckBoxMenuItem=
-#	viewMarkUntranslatedSegmentsCheckBoxMenuItem=
-#	viewMarkParagraphStartCheckBoxMenuItem=
-#	viewDisplaySegmentSourceCheckBoxMenuItem=
-#	viewMarkNonUniqueSegmentsCheckBoxMenuItem=
-#	viewMarkNotedSegmentsCheckBoxMenuItem=
-#	viewMarkNBSPCheckBoxMenuItem=
-#	viewMarkWhitespaceCheckBoxMenuItem=
-#	viewMarkBidiCheckBoxMenuItem=
-#	viewMarkAutoPopulatedCheckBoxMenuItem=
-#	viewMarkGlossaryMatchesCheckBoxMenuItem=
-#	viewMarkLanguageCheckerCheckBoxMenuItem=
-#	viewMarkFontFallbackCheckBoxMenuItem=
+viewMarkTranslatedSegmentsCheckBoxMenuItem=
+viewMarkUntranslatedSegmentsCheckBoxMenuItem=
+viewMarkParagraphStartCheckBoxMenuItem=
+viewDisplaySegmentSourceCheckBoxMenuItem=
+viewMarkNonUniqueSegmentsCheckBoxMenuItem=
+viewMarkNotedSegmentsCheckBoxMenuItem=
+viewMarkNBSPCheckBoxMenuItem=
+viewMarkWhitespaceCheckBoxMenuItem=
+viewMarkBidiCheckBoxMenuItem=
+viewMarkAlternativeTranslationsCheckBoxMenuItem=
+viewMarkAutoPopulatedCheckBoxMenuItem=
+viewMarkGlossaryMatchesCheckBoxMenuItem=
+viewMarkLanguageCheckerCheckBoxMenuItem=
+viewMarkFontFallbackCheckBoxMenuItem=
 #>> Modification Info submenu >>#
-#	viewDisplayModificationInfoNoneRadioButtonMenuItem=
-#	viewDisplayModificationInfoSelectedRadioButtonMenuItem=
-#	viewDisplayModificationInfoAllRadioButtonMenuItem=
+viewDisplayModificationInfoNoneRadioButtonMenuItem=
+viewDisplayModificationInfoSelectedRadioButtonMenuItem=
+viewDisplayModificationInfoAllRadioButtonMenuItem=
 #<< End submenu <<#
 #-separator-#
-#	viewRestoreGUIMenuItem=
+viewRestoreGUIMenuItem=
 
 ##############
 # Tools menu #
 ##############
 toolsCheckIssuesMenuItem=ctrl shift V
-#	toolsCheckIssuesCurrentFileMenuItem=
-#	toolsShowStatisticsStandardMenuItem=
-#	toolsShowStatisticsMatchesMenuItem=
-#	toolsShowStatisticsMatchesPerFileMenuItem=
+toolsCheckIssuesCurrentFileMenuItem=
+toolsShowStatisticsStandardMenuItem=
+toolsShowStatisticsMatchesMenuItem=
+toolsShowStatisticsMatchesPerFileMenuItem=
 #-separator-#
-#	toolsAlignFilesMenuItem=
 
 ################
 # Options menu #
 ################
-#	optionsPreferencesMenuItem=
+optionsPreferencesMenuItem=
 #-separator-#
 #>> Machine Translate submenu >>#
-#	optionsMTAutoFetchCheckboxMenuItem=
+optionsMTAutoFetchCheckboxMenuItem=
 #-separator-#
 #<< End submenu <<#
 #>> Glossary submenu >>#
-#	optionsDictionaryFuzzyMatchingCheckBoxMenuItem=
+optionsGlossaryFuzzyMatchingCheckBoxMenuItem=
 #-separator-#
 #<< End submenu <<#
 #>> Dictionary submenu >>#
-#	optionsDictionaryFuzzyMatchingCheckBoxMenuItem=
+optionsDictionaryFuzzyMatchingCheckBoxMenuItem=
 #<< End submenu <<#
 #>> Auto-completion submenu >>#
-#	optionsAutoCompleteShowAutomaticallyItem=
-#	optionsAutoCompleteHistoryCompletionMenuItem=
-#	optionsAutoCompleteHistoryPredictionMenuItem=
+optionsAutoCompleteShowAutomaticallyItem=
+optionsAutoCompleteHistoryCompletionMenuItem=
+optionsAutoCompleteHistoryPredictionMenuItem=
 #<< End submenu <<#
 #-separator-#
-#	optionsSetupFileFiltersMenuItem=
-#	optionsSentsegMenuItem=
-#	optionsWorkflowMenuItem=
+optionsSetupFileFiltersMenuItem=
+optionsSentsegMenuItem=
+optionsWorkflowMenuItem=
 #-separator-#
-#	optionsAccessConfigDirMenuItem=
+optionsAccessConfigDirMenuItem=
 
 #############
 # Help menu #
 #############
 helpContentsMenuItem=F1
-#	helpAboutMenuItem=
-#	helpLastChangesMenuItem=
-#	helpLogMenuItem=
-#	helpUpdateCheckMenuItem
+helpAboutMenuItem=
+helpLastChangesMenuItem=
+helpLogMenuItem=
+helpUpdateCheckMenuItem=
 
 #################
 # Search Window #

--- a/src/test/java/org/omegat/gui/dialogs/KeyStrokeEditorDialogTest.java
+++ b/src/test/java/org/omegat/gui/dialogs/KeyStrokeEditorDialogTest.java
@@ -1,0 +1,70 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.dialogs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JLabel;
+import javax.swing.KeyStroke;
+
+import org.junit.Test;
+
+/**
+ * Proves that the keystroke capture ignores key events without a key code:
+ * macOS delivers the fn key as VK_UNDEFINED, which used to display and
+ * store as "Unknown keyCode: 0x0".
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class KeyStrokeEditorDialogTest {
+
+    @Test
+    public void testCaptureIgnoresEventsWithoutKeyCode() {
+        KeyStroke current = KeyStroke.getKeyStroke("ctrl S");
+        KeyEvent fnKey = keyEvent(KeyEvent.VK_UNDEFINED, 0);
+
+        assertEquals("an event without key code must keep the current keystroke", current,
+                KeyStrokeEditorDialog.capture(fnKey, current));
+        assertNull("an event without key code must not invent a keystroke",
+                KeyStrokeEditorDialog.capture(fnKey, null));
+    }
+
+    @Test
+    public void testCaptureTakesRegularKeyEvents() {
+        KeyEvent ctrlN = keyEvent(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK);
+        assertEquals(KeyStroke.getKeyStroke("ctrl pressed N"),
+                KeyStrokeEditorDialog.capture(ctrlN, null));
+    }
+
+    private static KeyEvent keyEvent(int keyCode, int modifiers) {
+        return new KeyEvent(new JLabel(), KeyEvent.KEY_PRESSED, System.currentTimeMillis(), modifiers,
+                keyCode, KeyEvent.CHAR_UNDEFINED);
+    }
+}

--- a/src/test/java/org/omegat/gui/shortcuts/PropertiesShortcutsFormatterTest.java
+++ b/src/test/java/org/omegat/gui/shortcuts/PropertiesShortcutsFormatterTest.java
@@ -1,0 +1,93 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.shortcuts;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.InputStream;
+import java.util.Properties;
+
+import javax.swing.KeyStroke;
+
+import org.junit.Test;
+
+/**
+ * Proves that {@link PropertiesShortcuts#toPropertyValue} yields the
+ * properties-file syntax: every produced value must parse back to the same
+ * keystroke, for every bundled shortcut and for the modifier matrix.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class PropertiesShortcutsFormatterTest {
+
+    @Test
+    public void testEveryBundledShortcutRoundtrips() throws Exception {
+        for (String file : new String[] { "MainMenuShortcuts.properties",
+                "MainMenuShortcuts.mac.properties", "EditorShortcuts.properties",
+                "EditorShortcuts.mac.properties" }) {
+            Properties props = new Properties();
+            try (InputStream in = PropertiesShortcuts.class
+                    .getResourceAsStream("/org/omegat/gui/main/" + file)) {
+                assertNotNull(file, in);
+                props.load(in);
+            }
+            for (String key : props.stringPropertyNames()) {
+                String value = props.getProperty(key);
+                if (value.isEmpty()) {
+                    continue;
+                }
+                KeyStroke ks = KeyStroke.getKeyStroke(value);
+                assertNotNull(file + ": unparseable bundled value " + key + "=" + value, ks);
+                assertEquals(file + ": " + key + " must roundtrip", ks,
+                        KeyStroke.getKeyStroke(PropertiesShortcuts.toPropertyValue(ks)));
+            }
+        }
+    }
+
+    @Test
+    public void testModifierMatrixRoundtrips() {
+        int[] modifiers = { 0, InputEvent.SHIFT_DOWN_MASK, InputEvent.CTRL_DOWN_MASK,
+                InputEvent.META_DOWN_MASK, InputEvent.ALT_DOWN_MASK, InputEvent.ALT_GRAPH_DOWN_MASK,
+                InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK,
+                InputEvent.META_DOWN_MASK | InputEvent.ALT_DOWN_MASK,
+                InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK | InputEvent.ALT_DOWN_MASK };
+        int[] keys = { KeyEvent.VK_A, KeyEvent.VK_F5, KeyEvent.VK_TAB, KeyEvent.VK_ENTER,
+                KeyEvent.VK_UP, KeyEvent.VK_DELETE, KeyEvent.VK_CONTEXT_MENU };
+        for (int mod : modifiers) {
+            for (int key : keys) {
+                KeyStroke ks = KeyStroke.getKeyStroke(key, mod);
+                assertEquals(ks, KeyStroke.getKeyStroke(PropertiesShortcuts.toPropertyValue(ks)));
+            }
+        }
+        KeyStroke typed = KeyStroke.getKeyStroke("typed +");
+        assertEquals(typed, KeyStroke.getKeyStroke(PropertiesShortcuts.toPropertyValue(typed)));
+        assertEquals("null must format as the explicit-unbind value", "",
+                PropertiesShortcuts.toPropertyValue(null));
+    }
+}

--- a/src/test/java/org/omegat/gui/shortcuts/PropertiesShortcutsTest.java
+++ b/src/test/java/org/omegat/gui/shortcuts/PropertiesShortcutsTest.java
@@ -263,4 +263,91 @@ public class PropertiesShortcutsTest {
         PropertiesShortcuts props = PropertiesShortcuts.loadBundled(BUNDLED_ROOT, USER_FILE_NAME);
         assertEquals(shortcuts.getData(), props.getData());
     }
+
+    @Test
+    public void testCatalogAndModificationState() {
+        assertTrue(shortcuts.getKeys().containsAll(
+                java.util.List.of(TEST_SAVE, TEST_CUT, TEST_DELETE, TEST_USER_1)));
+        assertFalse(shortcuts.getKeys().contains(OUT_OF_LIST));
+
+        // TEST_DELETE is overridden to empty by the user file, TEST_SAVE is
+        // at its bundled default
+        assertTrue(shortcuts.isModified(TEST_DELETE));
+        assertEquals("", shortcuts.getShortcutValue(TEST_DELETE));
+        assertFalse(shortcuts.isModified(TEST_SAVE));
+        assertEquals(shortcuts.getDefaultValue(TEST_SAVE), shortcuts.getShortcutValue(TEST_SAVE));
+
+        // setting a shortcut back to its default removes the override, even
+        // though the canonical format differs from the file syntax
+        shortcuts.setShortcut(TEST_DELETE, CTRL_D);
+        assertFalse(shortcuts.isModified(TEST_DELETE));
+        shortcuts.setShortcut(TEST_SAVE, CTRL_S);
+        assertFalse(shortcuts.isModified(TEST_SAVE));
+        shortcuts.setShortcut(TEST_SAVE, CTRL_P);
+        assertTrue(shortcuts.isModified(TEST_SAVE));
+        assertEquals(CTRL_P, shortcuts.getKeyStroke(TEST_SAVE));
+        shortcuts.clearUserOverride(TEST_SAVE);
+        assertFalse(shortcuts.isModified(TEST_SAVE));
+        assertEquals(CTRL_S, shortcuts.getKeyStroke(TEST_SAVE));
+
+        // null unbinds explicitly
+        shortcuts.setShortcut(TEST_CUT, null);
+        assertNull(shortcuts.getKeyStroke(TEST_CUT));
+        assertEquals("", shortcuts.getShortcutValue(TEST_CUT));
+    }
+
+    @Test
+    public void testSaveWritesOnlyOverridesAndReloadRestores() throws Exception {
+        PropertiesShortcuts props = PropertiesShortcuts.loadBundled(BUNDLED_ROOT, USER_FILE_NAME);
+        // The save target is the platform-specific user file, which on macOS
+        // shadows the plain one on the next load.
+        File savedFile = new File(StaticUtils.getConfigDir(),
+                org.omegat.util.Platform.isMacOSX() ? "test.mac.properties" : USER_FILE_NAME);
+        boolean[] notified = { false };
+        Runnable listener = () -> notified[0] = true;
+        props.addChangeListener(listener);
+        try {
+            props.setShortcut(TEST_SAVE, CTRL_P);
+            props.save();
+            // listeners are notified on the EDT
+            javax.swing.SwingUtilities.invokeAndWait(() -> {
+            });
+            assertTrue("save must notify the change listeners", notified[0]);
+
+            java.util.Properties written = new java.util.Properties();
+            try (InputStream in = new java.io.FileInputStream(savedFile)) {
+                written.load(in);
+            }
+            assertEquals("only the overrides may be written",
+                    java.util.Set.of(TEST_SAVE, TEST_DELETE, TEST_USER_1, "TEST_USER_2"),
+                    written.stringPropertyNames());
+            assertEquals(PropertiesShortcuts.toPropertyValue(CTRL_P), written.getProperty(TEST_SAVE));
+
+            // a fresh load sees the saved override; clearing and saving again
+            // removes it from the file
+            PropertiesShortcuts reloaded = PropertiesShortcuts.loadBundled(BUNDLED_ROOT, USER_FILE_NAME);
+            assertEquals(CTRL_P, reloaded.getKeyStroke(TEST_SAVE));
+
+            props.setShortcut(TEST_CUT, null);
+            assertNull(props.getKeyStroke(TEST_CUT));
+            props.reload();
+            assertEquals("reload must discard unsaved session changes", CTRL_X,
+                    props.getKeyStroke(TEST_CUT));
+            assertEquals("reload must keep saved overrides", CTRL_P, props.getKeyStroke(TEST_SAVE));
+
+            props.removeChangeListener(listener);
+            props.clearUserOverride(TEST_SAVE);
+            props.save();
+            PropertiesShortcuts finalState = PropertiesShortcuts.loadBundled(BUNDLED_ROOT, USER_FILE_NAME);
+            assertEquals(CTRL_S, finalState.getKeyStroke(TEST_SAVE));
+        } finally {
+            // The save target may be the shared fixture file itself (non-mac)
+            // - restore it for the other test methods and tearDownClass.
+            savedFile.delete();
+            try (InputStream in = PropertiesShortcutsTest.class
+                    .getResourceAsStream("test.user.properties")) {
+                FileUtils.copyInputStreamToFile(in, userFile);
+            }
+        }
+    }
 }

--- a/src/test/java/org/omegat/gui/shortcuts/ShortcutsCatalogTest.java
+++ b/src/test/java/org/omegat/gui/shortcuts/ShortcutsCatalogTest.java
@@ -1,0 +1,104 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.shortcuts;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+
+import org.junit.Test;
+
+import org.omegat.gui.main.BaseMainWindowMenu;
+import org.omegat.util.StaticUtils;
+
+/**
+ * Guards the shortcut catalog: the bundled shortcut files list every
+ * shortcutable function (menu items become shortcutable through their field
+ * name, see BaseMainWindowMenu#setActionCommands), and each platform pair
+ * carries identical keysets - on macOS the mac file fully replaces the other
+ * one, so a key missing there would silently lose its function.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ShortcutsCatalogTest {
+
+    /** Keys bound outside the menu bar, documented in the manual. */
+    private static final Set<String> NON_MENU_KEYS = Set.of("findInProjectReuseLastWindow",
+            "jumpToEntryInEditor");
+
+    @Test
+    public void testPlatformPairsCarryIdenticalKeysets() throws Exception {
+        assertEquals(keys("MainMenuShortcuts.properties"), keys("MainMenuShortcuts.mac.properties"));
+        assertEquals(keys("EditorShortcuts.properties"), keys("EditorShortcuts.mac.properties"));
+    }
+
+    @Test
+    public void testEveryMenuItemFieldIsCatalogued() throws Exception {
+        Set<String> catalog = keys("MainMenuShortcuts.properties");
+        Set<String> expected = new TreeSet<>(NON_MENU_KEYS);
+        for (Field f : StaticUtils.getAllModelFields(BaseMainWindowMenu.class)) {
+            // Menus themselves take no accelerator, see
+            // PropertiesShortcuts#bindKeyStrokes(JMenuItem).
+            if (JMenuItem.class.isAssignableFrom(f.getType())
+                    && !JMenu.class.isAssignableFrom(f.getType())) {
+                expected.add(f.getName());
+            }
+        }
+        assertEquals("the main menu catalog must list exactly the menu item fields "
+                + "plus the documented non-menu keys", expected, new TreeSet<>(catalog));
+    }
+
+    @Test
+    public void testCatalogFunctionsAreDistinctFromStructureComments() throws Exception {
+        // The structure markers must stay comments; a materialized marker
+        // would surface as a bogus function in the shortcut table.
+        for (String key : keys("MainMenuShortcuts.properties")) {
+            assertTrue("bogus key: " + key, key.matches("[A-Za-z0-9]+"));
+        }
+        for (String key : keys("EditorShortcuts.properties")) {
+            assertTrue("bogus key: " + key, key.matches("[A-Za-z0-9]+"));
+        }
+    }
+
+    private static Set<String> keys(String file) throws Exception {
+        Properties props = new Properties();
+        try (InputStream in = PropertiesShortcuts.class
+                .getResourceAsStream("/org/omegat/gui/main/" + file)) {
+            assertNotNull(file, in);
+            props.load(in);
+        }
+        return new TreeSet<>(props.stringPropertyNames());
+    }
+}


### PR DESCRIPTION
## Pull request type

[enhancement]

## Which ticket is resolved?

- Interface to access shortcuts
  * https://sourceforge.net/p/omegat/feature-requests/443/

## What does this PR change?

Second stacked PR, based on #2357.

- IMainMenu.updateShortcuts() default no-op; BaseMainWindowMenu rebinds menu accelerators + find-in-project binding via change listener
- EditorTextArea3 reads keystrokes per event instead of static finals
- AutoCompleter: null guards for unbound view-switch keys
- Open Search/Scripting windows rebind on reopen
