### PR TITLE
chore(CI/test-integ): fix ssh login error in the integration test

### DIFF
--- a/test-integration/docker/client/entrypoint.sh
+++ b/test-integration/docker/client/entrypoint.sh
@@ -100,8 +100,7 @@ CACHE_SIZE=$(du -sh /gradle-cache 2>/dev/null | cut -f1 || echo "unknown")
 CACHED_CONFIGS=$(find /gradle-cache -name ".deps-*" | wc -l)
 echo "Gradle cache size: $CACHE_SIZE, cached configurations: $CACHED_CONFIGS"
 
-exec /opt/gradle/bin/gradle testIntegration --scan \
-   --stacktrace -Dscan.uploadInBackground=false \
+exec /opt/gradle/bin/gradle testIntegration --scan -Dscan.uploadInBackground=false \
    -Djava.util.logging.config.file=/workdir/test-integration/logger.properties \
    -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
    -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README

--- a/test-integration/docker/server/Dockerfile
+++ b/test-integration/docker/server/Dockerfile
@@ -26,7 +26,7 @@
 FROM debian:bookworm-slim
 RUN apt-get -y update && apt-get -y upgrade \
     && apt-get install -y openssh-server git inotify-tools apache2 apache2-utils supervisor apache2-suexec-pristine subversion libapache2-mod-svn \
-    && adduser --system --group --shell /bin/bash git && (echo 'git:gitpass' | chpasswd) \
+    && adduser --system --group --shell /bin/bash --home /home/git git && (echo 'git:gitpass' | chpasswd) \
     && mkdir -p /home/git/.ssh && chmod 700 /home/git/.ssh \
     && adduser --system --group --shell /bin/bash svn && (echo 'svn:svnpass' | chpasswd) \
     && mkdir -p /home/svn/.ssh && chmod 700 /home/svn/.ssh \

--- a/test-integration/docker/server/entrypoint.sh
+++ b/test-integration/docker/server/entrypoint.sh
@@ -29,6 +29,6 @@ chmod 777 /keys
 ssh-keygen -q -t rsa -m PEM -b 4096 -N '' -f /tmp/id_rsa && ssh-keygen -A
 install -m 666 /tmp/id_rsa /tmp/id_rsa.pub /keys/
 cat /keys/id_rsa.pub >> /home/git/.ssh/authorized_keys
-rm -rf /var/run/apache2/* || true
+rm -f /var/run/apache2/apache2.pid
 echo "start servers"
 exec /usr/bin/supervisord -c /root/supervisord.conf

--- a/test-integration/src/org/omegat/util/logging/TestLogFileHandler.java
+++ b/test-integration/src/org/omegat/util/logging/TestLogFileHandler.java
@@ -75,7 +75,7 @@ public class TestLogFileHandler extends StreamHandler {
      */
     @SuppressWarnings("resource")
     private void openFiles(final File dir) throws IOException {
-        boolean dirCreated = dir.mkdirs();
+        boolean dirCreated = dir.isDirectory() || dir.mkdirs();
         if (!dirCreated) {
             throw new IOException("Cannot create directory: " + dir.getAbsolutePath());
         }


### PR DESCRIPTION
We recently change docker image base to bookworm from bullseye for server side.
The server image configuration lacks home directly and depends on an implicit behavior of useradd.
Also logging configuration can be broken in client side.

## Pull request type


- Build and release changes -> [build/release]

## Which ticket is resolved?
none; recent weekly release failed with integration test failure
## What does this PR change?

- server/Dockerfile: add '--home /home/git' in useradd shell
- TestLogFileHanlder.java: check logging folder exists
- client/entrypoint.sh simplify command line

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
