### PR TITLE
[6.1] chore(test integ): fix server docker failures

### DIFF
--- a/test-integration/docker/client/entrypoint.sh
+++ b/test-integration/docker/client/entrypoint.sh
@@ -100,7 +100,7 @@ CACHE_SIZE=$(du -sh /gradle-cache 2>/dev/null | cut -f1 || echo "unknown")
 CACHED_CONFIGS=$(find /gradle-cache -name ".deps-*" | wc -l)
 echo "Gradle cache size: $CACHE_SIZE, cached configurations: $CACHED_CONFIGS"
 
-exec /opt/gradle/bin/gradle testIntegration --scan \
+exec /opt/gradle/bin/gradle testIntegration --scan -Dscan.uploadInBackground=false \
    -Djava.util.logging.config.file=/workdir/test-integration/logger.properties \
    -Domegat.test.duration=${DURATION} -Domegat.test.repo=${REPO} \
    -Domegat.test.repo.alt=${REPO2} -Domegat.test.map.repo=http://server/ -Domegat.test.map.file=README

--- a/test-integration/docker/server/Dockerfile
+++ b/test-integration/docker/server/Dockerfile
@@ -23,7 +23,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #  **************************************************************************/
 #
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN apt-get -y update && apt-get -y upgrade \
     && apt-get install -y openssh-server git inotify-tools apache2 apache2-utils supervisor apache2-suexec-pristine subversion libapache2-mod-svn \
     && adduser --system --group --shell /bin/bash git && (echo 'git:gitpass' | chpasswd) \

--- a/test-integration/docker/server/Dockerfile
+++ b/test-integration/docker/server/Dockerfile
@@ -26,7 +26,7 @@
 FROM debian:bookworm-slim
 RUN apt-get -y update && apt-get -y upgrade \
     && apt-get install -y openssh-server git inotify-tools apache2 apache2-utils supervisor apache2-suexec-pristine subversion libapache2-mod-svn \
-    && adduser --system --group --shell /bin/bash git && (echo 'git:gitpass' | chpasswd) \
+    && adduser --system --group --shell /bin/bash --home /home/git git && (echo 'git:gitpass' | chpasswd) \
     && mkdir -p /home/git/.ssh && chmod 700 /home/git/.ssh \
     && adduser --system --group --shell /bin/bash svn && (echo 'svn:svnpass' | chpasswd) \
     && mkdir -p /home/svn/.ssh && chmod 700 /home/svn/.ssh \

--- a/test-integration/docker/server/entrypoint.sh
+++ b/test-integration/docker/server/entrypoint.sh
@@ -29,6 +29,6 @@ chmod 777 /keys
 ssh-keygen -q -t rsa -m PEM -b 4096 -N '' -f /tmp/id_rsa && ssh-keygen -A
 install -m 666 /tmp/id_rsa /tmp/id_rsa.pub /keys/
 cat /keys/id_rsa.pub >> /home/git/.ssh/authorized_keys
-rm -rf /var/run/apache2/* || true
+rm -f /var/run/apache2/apache2.pid
 echo "start servers"
 exec /usr/bin/supervisord -c /root/supervisord.conf

--- a/test-integration/src/org/omegat/util/logging/TestLogFileHandler.java
+++ b/test-integration/src/org/omegat/util/logging/TestLogFileHandler.java
@@ -75,7 +75,7 @@ public class TestLogFileHandler extends StreamHandler {
      */
     @SuppressWarnings("resource")
     private void openFiles(final File dir) throws IOException {
-        boolean dirCreated = dir.mkdirs();
+        boolean dirCreated = dir.isDirectory() || dir.mkdirs();
         if (!dirCreated) {
             throw new IOException("Cannot create directory: " + dir.getAbsolutePath());
         }


### PR DESCRIPTION
Docker configuration of the Integration test become unworked because of debian base image retirement.
This is backport from PR#2343 and PR#2360

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?
none; weekly release blocked from 29 Aug.

## What does this PR change?

- migrate base image debian:bookworm
- fix ssh connection problem
- improve logging setting 

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
