### PR TITLE
chore(ci): improve lftp upload commands in publish_weekly workflow

### DIFF
--- a/ci/azure-pipelines/publish_weekly.yml
+++ b/ci/azure-pipelines/publish_weekly.yml
@@ -37,17 +37,19 @@ steps:
         echo "Push OmegaT files to SourceForge file manager"
         dest=sftp://$(SOURCEFORGE_CI_USER)@$SF_HOST
         srcdir=$(Pipeline.Workspace)/build/distributions/
-        ls -l $srcdir/*
+        ls -l "$srcdir/*"
         destdir=/home/frs/project/omegat/Weekly
-        cmd="set net:max-retries 10; mkdir -p '$destdir'; lcd $srcdir; cd '$destdir'; mirror -R --verbose=3; bye"
-        lftp --env-password -e "$cmd" $dest
+        # Weekly keeps older builds on SourceForge, so upload only newer local files.
+        # Without --only-newer, lftp mirror may fail on remote-only old files.
+        cmd="set net:max-retries 10; mkdir -p '$destdir'; lcd '$srcdir'; cd '$destdir'; mirror -R --only-newer --verbose=3; bye"
+        lftp --env-password -e "$cmd" "$dest"
         # Upload manuals
         echo "Push manuals to sourceforge project web"
         srcdir=$(Pipeline.Workspace)/build/docs/manual/
         destdir=/home/project-web/omegat/htdocs/manual/${OMEGAT_VERSION}-snapshot/
         target=/home/project-web/omegat/htdocs/manual-snapshot
-        cmd="set net:max-retries 10; mkdir -p $destdir ; lcd $srcdir ; cd $destdir ; mirror -Re --parallel=4 --verbose=3 ; rm $target ; ln -s $destdir $target ; bye"
-        lftp --env-password -e "$cmd" $dest
+        cmd="set net:max-retries 10; mkdir -p '$destdir' ; lcd '$srcdir' ; cd '$destdir' ; mirror -Re --parallel=4 --verbose=3 ; rm $target ; ln -s '$destdir' '$target' ; bye"
+        lftp --env-password -e "$cmd" "$dest"
     env:
       OMEGAT_VERSION: ${{ parameters.omegatVersion }}
       SF_HOST: frs.sourceforge.net

--- a/ci/azure-pipelines/publish_weekly.yml
+++ b/ci/azure-pipelines/publish_weekly.yml
@@ -39,10 +39,17 @@ steps:
         srcdir=$(Pipeline.Workspace)/build/distributions/
         ls -l "$srcdir/*"
         destdir=/home/frs/project/omegat/Weekly
-        # Weekly keeps older builds on SourceForge, so upload only newer local files.
-        # Without --only-newer, lftp mirror may fail on remote-only old files.
-        cmd="set net:max-retries 10; mkdir -p '$destdir'; lcd '$srcdir'; cd '$destdir'; mirror -R --only-newer --verbose=3; bye"
-        lftp --env-password -e "$cmd" "$dest"
+        # Keep mirror: weekly builds reuse filenames and must replace existing files.
+        # Retry because SourceForge SFTP may fail during replacement and leave a partial file.
+        cmd="set net:max-retries 10; mkdir -p '$destdir'; lcd '$srcdir'; cd '$destdir'; mirror -R --verbose=3; bye"
+        for attempt in 1 2 3; do
+          lftp --env-password -e "$cmd" "$dest" && break
+          if [[ "$attempt" == 3 ]]; then
+            exit 1
+          fi
+          echo "lftp upload failed; retrying in 30 seconds..."
+          sleep 30
+        done
         # Upload manuals
         echo "Push manuals to sourceforge project web"
         srcdir=$(Pipeline.Workspace)/build/docs/manual/


### PR DESCRIPTION
Latest weekly release failed to upload snapshot manual because lftp command exit with 1 when upload failed with partial file upload. this makes archive broken.

this PR to fix the error.

## Pull request type
- Build and release changes -> 
## Which ticket is resolved?

## What does this PR change?

- When lftp failed, retry it in weekly release.
-
-

## Other information
Package upload succeeded but lftp found other files and then exit 1 to notify.

The error is observed as follows;
```
=== Pre-flight check ===
✅ LFTP_PASSWORD is set
✅ Key + passphrase OK
Push OmegaT files to SourceForge file manager
-rw-r--r-- 1 vsts vsts 396820425 Sep  8 21:41 /home/vsts/work/1/build/distributions//OmegaT_6.2.0_Beta_Source.zip
-rw-r--r-- 1 vsts vsts 349292834 Sep  8 21:41 /home/vsts/work/1/build/distributions//OmegaT_6.2.0_Beta_Windows_64.exe
-rw-r--r-- 1 vsts vsts 336368675 Sep  8 21:41 /home/vsts/work/1/build/distributions//OmegaT_6.2.0_Beta_Windows_aarch64.exe
-rw-r--r-- 1 vsts vsts 313721774 Sep  8 21:41 /home/vsts/work/1/build/distributions//OmegaT_6.2.0_Beta_Windows_without_JRE.exe
-rw-r--r-- 1 vsts vsts 317308294 Sep  8 21:41 /home/vsts/work/1/build/distributions//OmegaT_6.2.0_Beta_Without_JRE.zip
mkdir: Access failed: Failure (/home/frs/project/omegat/Weekly)
Removing old file `OmegaT_6.2.0_Beta_Source.zip'
Transferring file `OmegaT_6.2.0_Beta_Source.zip'
Finished transfer `OmegaT_6.2.0_Beta_Source.zip' (2.95 MiB/s)
Removing old file `OmegaT_6.2.0_Beta_Windows_64.exe'
Transferring file `OmegaT_6.2.0_Beta_Windows_64.exe'
Finished transfer `OmegaT_6.2.0_Beta_Windows_64.exe' (2.94 MiB/s)
Removing old file `OmegaT_6.2.0_Beta_Windows_aarch64.exe'
Transferring file `OmegaT_6.2.0_Beta_Windows_aarch64.exe'
Finished transfer `OmegaT_6.2.0_Beta_Windows_aarch64.exe' (2.83 MiB/s)
Removing old file `OmegaT_6.2.0_Beta_Windows_without_JRE.exe'
Transferring file `OmegaT_6.2.0_Beta_Windows_without_JRE.exe'
mirror: Access failed: Failure (OmegaT_6.2.0_Beta_Windows_without_JRE.exe)
Removing old file `OmegaT_6.2.0_Beta_Without_JRE.zip'
Transferring file `OmegaT_6.2.0_Beta_Without_JRE.zip'
Finished transfer `OmegaT_6.2.0_Beta_Without_JRE.zip' (2.85 MiB/s)

Old file `OmegaT_6.0.2_Windows.exe' is not removed
Old file `OmegaT_6.0.2_Windows_64.exe' is not removed
Old file `omegat_6.2.0-3_arm64.deb' is not removed
(.. snip)
##[error]Bash exited with code '1'.
Finishing: 📂upload to sourceforge file management via SFTP
```
