### PR TITLE
chore(style/javadoc): make copyright header as normal comment in all java files

### DIFF
--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePicker.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePicker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignFilePickerController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/AlignMenuFrame.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignMenuFrame.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanel.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignPanelController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/Aligner.java
+++ b/aligner/src/main/java/org/omegat/gui/align/Aligner.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/AlignerCommand.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/AlignerPrefs.java
+++ b/aligner/src/main/java/org/omegat/gui/align/AlignerPrefs.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/EditingPanel.java
+++ b/aligner/src/main/java/org/omegat/gui/align/EditingPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/EditingPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/EditingPanelController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/MutableBead.java
+++ b/aligner/src/main/java/org/omegat/gui/align/MutableBead.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/PatternPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/PatternPanelController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/SplittingPanelController.java
+++ b/aligner/src/main/java/org/omegat/gui/align/SplittingPanelController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/main/java/org/omegat/gui/align/Util.java
+++ b/aligner/src/main/java/org/omegat/gui/align/Util.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/test/java/org/omegat/gui/align/AlignSettingsPersistenceTest.java
+++ b/aligner/src/test/java/org/omegat/gui/align/AlignSettingsPersistenceTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/aligner/src/test/java/org/omegat/gui/align/AlignerTest.java
+++ b/aligner/src/test/java/org/omegat/gui/align/AlignerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/firsttime-wizard/src/main/java/org/omegat/gui/firsttime/FirstTimeConfigWizard.java
+++ b/firsttime-wizard/src/main/java/org/omegat/gui/firsttime/FirstTimeConfigWizard.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
          with fuzzy matching, translation memory, keyword search,
          glossaries, and translation leveraging into updated projects.

--- a/firsttime-wizard/src/main/java/org/omegat/gui/firsttime/FirstTimeConfigurationWizardUtil.java
+++ b/firsttime-wizard/src/main/java/org/omegat/gui/firsttime/FirstTimeConfigurationWizardUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
          with fuzzy matching, translation memory, keyword search,
          glossaries, and translation leveraging into updated projects.

--- a/language-modules/ar/src/test/java/org/omegat/languages/ar/HunspellTest.java
+++ b/language-modules/ar/src/test/java/org/omegat/languages/ar/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/ast/src/test/java/org/omegat/languages/ast/MorfologikTest.java
+++ b/language-modules/ast/src/test/java/org/omegat/languages/ast/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/be/src/test/java/org/omegat/languages/be/MorfologikTest.java
+++ b/language-modules/be/src/test/java/org/omegat/languages/be/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/br/src/test/java/org/omegat/languages/br/MorfologikTest.java
+++ b/language-modules/br/src/test/java/org/omegat/languages/br/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/ca/src/test/java/org/omegat/languages/ca/HunspellTest.java
+++ b/language-modules/ca/src/test/java/org/omegat/languages/ca/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/da/src/test/java/org/omegat/languages/da/HunspellTest.java
+++ b/language-modules/da/src/test/java/org/omegat/languages/da/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/de/src/test/java/org/omegat/languages/de/HunspellTest.java
+++ b/language-modules/de/src/test/java/org/omegat/languages/de/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/de/src/test/java/org/omegat/languages/de/MorfologikTest.java
+++ b/language-modules/de/src/test/java/org/omegat/languages/de/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/el/src/test/java/org/omegat/languages/el/MorfologikTest.java
+++ b/language-modules/el/src/test/java/org/omegat/languages/el/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/en/src/test/java/org/omegat/languages/en/MorfologikTest.java
+++ b/language-modules/en/src/test/java/org/omegat/languages/en/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/eo/src/test/java/org/omegat/languages/eo/HunspellTest.java
+++ b/language-modules/eo/src/test/java/org/omegat/languages/eo/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/es/src/test/java/org/omegat/languages/es/HunspellTest.java
+++ b/language-modules/es/src/test/java/org/omegat/languages/es/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/fa/src/test/java/org/omegat/languages/fa/HunspellTest.java
+++ b/language-modules/fa/src/test/java/org/omegat/languages/fa/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/fr/src/test/java/org/omegat/languages/fr/HunspellTest.java
+++ b/language-modules/fr/src/test/java/org/omegat/languages/fr/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/ga/src/test/java/org/omegat/languages/ga/HunspellTest.java
+++ b/language-modules/ga/src/test/java/org/omegat/languages/ga/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/gl/src/test/java/org/omegat/languages/gl/HunspellTest.java
+++ b/language-modules/gl/src/test/java/org/omegat/languages/gl/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/it/src/test/java/org/omegat/languages/it/MorfologikTest.java
+++ b/language-modules/it/src/test/java/org/omegat/languages/it/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/ja/src/test/java/org/omegat/languages/ja/IcuNfkcCompatibilityTest.java
+++ b/language-modules/ja/src/test/java/org/omegat/languages/ja/IcuNfkcCompatibilityTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/ja/src/test/java/org/omegat/languages/ja/JapaneseLanguageToolTest.java
+++ b/language-modules/ja/src/test/java/org/omegat/languages/ja/JapaneseLanguageToolTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/km/src/test/java/org/omegat/languages/km/HunspellTest.java
+++ b/language-modules/km/src/test/java/org/omegat/languages/km/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/nl/src/test/java/org/omegat/languages/nl/MorfologikTest.java
+++ b/language-modules/nl/src/test/java/org/omegat/languages/nl/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/pl/src/test/java/org/omegat/languages/pl/MorfologikTest.java
+++ b/language-modules/pl/src/test/java/org/omegat/languages/pl/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/pt/src/test/java/org/omegat/languages/pt/HunspellTest.java
+++ b/language-modules/pt/src/test/java/org/omegat/languages/pt/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/ro/src/test/java/org/omegat/languages/ro/MorfologikTest.java
+++ b/language-modules/ro/src/test/java/org/omegat/languages/ro/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/ru/src/test/java/org/omegat/languages/ru/MorfologikTest.java
+++ b/language-modules/ru/src/test/java/org/omegat/languages/ru/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/sk/src/test/java/org/omegat/languages/sk/MorfologikTest.java
+++ b/language-modules/sk/src/test/java/org/omegat/languages/sk/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/sl/src/test/java/org/omegat/languages/sl/MorfologikTest.java
+++ b/language-modules/sl/src/test/java/org/omegat/languages/sl/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/src/test/java/org/omegat/languages/LanguageModuleContentTest.java
+++ b/language-modules/src/test/java/org/omegat/languages/LanguageModuleContentTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/language-modules/sv/src/test/java/org/omegat/languages/sv/HunspellTest.java
+++ b/language-modules/sv/src/test/java/org/omegat/languages/sv/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/ta/src/test/java/org/omegat/languages/ta/MorfologikTest.java
+++ b/language-modules/ta/src/test/java/org/omegat/languages/ta/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/tl/src/test/java/org/omegat/languages/tl/MorfologikTest.java
+++ b/language-modules/tl/src/test/java/org/omegat/languages/tl/MorfologikTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/uk/src/test/java/org/omegat/languages/uk/HunspellTest.java
+++ b/language-modules/uk/src/test/java/org/omegat/languages/uk/HunspellTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/language-modules/zh/src/test/java/org/omegat/languages/zh/ChinesePluginTest.java
+++ b/language-modules/zh/src/test/java/org/omegat/languages/zh/ChinesePluginTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/ibmwatson/src/main/java/org/omegat/machinetranslators/ibmwatson/IBMWatsonTranslate.java
+++ b/machinetranslators/ibmwatson/src/main/java/org/omegat/machinetranslators/ibmwatson/IBMWatsonTranslate.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/ibmwatson/src/test/java/org/omegat/machinetranslators/ibmwatson/IBMWatsonTranslateTest.java
+++ b/machinetranslators/ibmwatson/src/test/java/org/omegat/machinetranslators/ibmwatson/IBMWatsonTranslateTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/AbstractMyMemoryTranslate.java
+++ b/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/AbstractMyMemoryTranslate.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryHumanTranslate.java
+++ b/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryHumanTranslate.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryMachineTranslate.java
+++ b/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryMachineTranslate.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryTranslate.java
+++ b/machinetranslators/mymemory/src/main/java/org/omegat/machinetranslators/mymemory/MyMemoryTranslate.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/mymemory/src/test/java/org/omegat/machinetranslators/mymemory/MyMemoryTranslationTest.java
+++ b/machinetranslators/mymemory/src/test/java/org/omegat/machinetranslators/mymemory/MyMemoryTranslationTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/yandex/src/main/java/org/omegat/machinetranslators/yandex/YandexCloudTranslate.java
+++ b/machinetranslators/yandex/src/main/java/org/omegat/machinetranslators/yandex/YandexCloudTranslate.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/machinetranslators/yandex/src/test/java/org/omegat/machinetranslators/yandex/YandexCloudTranslateTest.java
+++ b/machinetranslators/yandex/src/test/java/org/omegat/machinetranslators/yandex/YandexCloudTranslateTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/spellchecker/hunspell/src/test/java/org/omegat/spellchecker/hunspell/HunspellSpellcheckerTest.java
+++ b/spellchecker/hunspell/src/test/java/org/omegat/spellchecker/hunspell/HunspellSpellcheckerTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/spellchecker/lucene/src/main/java/org/omegat/spellchecker/lucene/LuceneHunSpellChecker.java
+++ b/spellchecker/lucene/src/main/java/org/omegat/spellchecker/lucene/LuceneHunSpellChecker.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/spellchecker/lucene/src/test/java/org/omegat/spellchecker/lucene/LuceneHunspellSpellcheckerTest.java
+++ b/spellchecker/lucene/src/test/java/org/omegat/spellchecker/lucene/LuceneHunspellSpellcheckerTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/spellchecker/morfologik/src/test/java/org/omegat/spellchecker/morfologik/MorfologikSpellcheckerTest.java
+++ b/spellchecker/morfologik/src/test/java/org/omegat/spellchecker/morfologik/MorfologikSpellcheckerTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/src/docs/developer/30.CodingStyles.md
+++ b/src/docs/developer/30.CodingStyles.md
@@ -4,7 +4,9 @@ OmegaT project uses following coding style rules and coding policy.
 
 ## Code Style Basics
 
-* Each java file has a GPL3 copyright header. OmegaT has a unit test to check header.
+* Each java file has a GPL3 copyright header. OmegaT has a checkstyle rule to check header.
+* Copyright header in java file should be normal comment, not javadoc comment.
+* Each properties file has a GPL3 copyright header.
 * Source code has a maximum 120 characters in each line.
 * The Maximum line length of comments in sources is 80 characters 
 * Indentation is 4 spaces. Don't use TAB character.

--- a/src/main/java/org/omegat/Main.java
+++ b/src/main/java/org/omegat/Main.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/MainClassLoader.java
+++ b/src/main/java/org/omegat/MainClassLoader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/BaseSubCommand.java
+++ b/src/main/java/org/omegat/cli/BaseSubCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/CommandCommon.java
+++ b/src/main/java/org/omegat/cli/CommandCommon.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/CommonParameters.java
+++ b/src/main/java/org/omegat/cli/CommonParameters.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/LegacyAlignCommand.java
+++ b/src/main/java/org/omegat/cli/LegacyAlignCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/LegacyParameters.java
+++ b/src/main/java/org/omegat/cli/LegacyParameters.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/PseudoTranslateCommand.java
+++ b/src/main/java/org/omegat/cli/PseudoTranslateCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/StartCommand.java
+++ b/src/main/java/org/omegat/cli/StartCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/StatsCommand.java
+++ b/src/main/java/org/omegat/cli/StatsCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/SubCommands.java
+++ b/src/main/java/org/omegat/cli/SubCommands.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/TeamCommand.java
+++ b/src/main/java/org/omegat/cli/TeamCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/cli/TranslateCommand.java
+++ b/src/main/java/org/omegat/cli/TranslateCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/convert/ConvertProject.java
+++ b/src/main/java/org/omegat/convert/ConvertProject.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/convert/ConvertProject26to37team.java
+++ b/src/main/java/org/omegat/convert/ConvertProject26to37team.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/Core.java
+++ b/src/main/java/org/omegat/core/Core.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/CoreEvents.java
+++ b/src/main/java/org/omegat/core/CoreEvents.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/KnownException.java
+++ b/src/main/java/org/omegat/core/KnownException.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/CommandVarExpansion.java
+++ b/src/main/java/org/omegat/core/data/CommandVarExpansion.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/CoreState.java
+++ b/src/main/java/org/omegat/core/data/CoreState.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/DataUtils.java
+++ b/src/main/java/org/omegat/core/data/DataUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/EntryKey.java
+++ b/src/main/java/org/omegat/core/data/EntryKey.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ExternalTMFactory.java
+++ b/src/main/java/org/omegat/core/data/ExternalTMFactory.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ExternalTMX.java
+++ b/src/main/java/org/omegat/core/data/ExternalTMX.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/IProject.java
+++ b/src/main/java/org/omegat/core/data/IProject.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ITMXEntry.java
+++ b/src/main/java/org/omegat/core/data/ITMXEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ITranslationEntry.java
+++ b/src/main/java/org/omegat/core/data/ITranslationEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ImportFromAutoTMX.java
+++ b/src/main/java/org/omegat/core/data/ImportFromAutoTMX.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/LastSegmentManager.java
+++ b/src/main/java/org/omegat/core/data/LastSegmentManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/NotLoadedProject.java
+++ b/src/main/java/org/omegat/core/data/NotLoadedProject.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ParseEntry.java
+++ b/src/main/java/org/omegat/core/data/ParseEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/PluginInformation.java
+++ b/src/main/java/org/omegat/core/data/PluginInformation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/PrepareTMXEntry.java
+++ b/src/main/java/org/omegat/core/data/PrepareTMXEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ProjectException.java
+++ b/src/main/java/org/omegat/core/data/ProjectException.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ProjectFactory.java
+++ b/src/main/java/org/omegat/core/data/ProjectFactory.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ProjectProperties.java
+++ b/src/main/java/org/omegat/core/data/ProjectProperties.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ProjectTMX.java
+++ b/src/main/java/org/omegat/core/data/ProjectTMX.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/ProtectedPart.java
+++ b/src/main/java/org/omegat/core/data/ProtectedPart.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/RuntimePreferenceStore.java
+++ b/src/main/java/org/omegat/core/data/RuntimePreferenceStore.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/SegmentProperties.java
+++ b/src/main/java/org/omegat/core/data/SegmentProperties.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/SourceTextEntry.java
+++ b/src/main/java/org/omegat/core/data/SourceTextEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/StringData.java
+++ b/src/main/java/org/omegat/core/data/StringData.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/StringEntry.java
+++ b/src/main/java/org/omegat/core/data/StringEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/SyncTMX.java
+++ b/src/main/java/org/omegat/core/data/SyncTMX.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/TMXEntry.java
+++ b/src/main/java/org/omegat/core/data/TMXEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/data/TranslateEntry.java
+++ b/src/main/java/org/omegat/core/data/TranslateEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/dictionaries/DictionariesManager.java
+++ b/src/main/java/org/omegat/core/dictionaries/DictionariesManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/dictionaries/DictionaryData.java
+++ b/src/main/java/org/omegat/core/dictionaries/DictionaryData.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/dictionaries/DictionaryEntry.java
+++ b/src/main/java/org/omegat/core/dictionaries/DictionaryEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/dictionaries/IDictionary.java
+++ b/src/main/java/org/omegat/core/dictionaries/IDictionary.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/dictionaries/IDictionaryFactory.java
+++ b/src/main/java/org/omegat/core/dictionaries/IDictionaryFactory.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/dictionaries/LingvoDSL.java
+++ b/src/main/java/org/omegat/core/dictionaries/LingvoDSL.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/dictionaries/StarDict.java
+++ b/src/main/java/org/omegat/core/dictionaries/StarDict.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/events/IApplicationEventListener.java
+++ b/src/main/java/org/omegat/core/events/IApplicationEventListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/events/IColorsChangedEventListener.java
+++ b/src/main/java/org/omegat/core/events/IColorsChangedEventListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/events/IEditorEventListener.java
+++ b/src/main/java/org/omegat/core/events/IEditorEventListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/events/IEntryEventListener.java
+++ b/src/main/java/org/omegat/core/events/IEntryEventListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/events/IFontChangedEventListener.java
+++ b/src/main/java/org/omegat/core/events/IFontChangedEventListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/events/IProjectEventListener.java
+++ b/src/main/java/org/omegat/core/events/IProjectEventListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/events/IStopped.java
+++ b/src/main/java/org/omegat/core/events/IStopped.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/glossaries/IGlossary.java
+++ b/src/main/java/org/omegat/core/glossaries/IGlossary.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/machinetranslators/BaseCachedTranslate.java
+++ b/src/main/java/org/omegat/core/machinetranslators/BaseCachedTranslate.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/machinetranslators/BaseTranslate.java
+++ b/src/main/java/org/omegat/core/machinetranslators/BaseTranslate.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/machinetranslators/MachineTranslators.java
+++ b/src/main/java/org/omegat/core/machinetranslators/MachineTranslators.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/machinetranslators/MachineTranslatorsManager.java
+++ b/src/main/java/org/omegat/core/machinetranslators/MachineTranslatorsManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/matching/DiffDriver.java
+++ b/src/main/java/org/omegat/core/matching/DiffDriver.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/matching/FuzzyMatcher.java
+++ b/src/main/java/org/omegat/core/matching/FuzzyMatcher.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/matching/ISimilarityCalculator.java
+++ b/src/main/java/org/omegat/core/matching/ISimilarityCalculator.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/matching/LevenshteinDistance.java
+++ b/src/main/java/org/omegat/core/matching/LevenshteinDistance.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/matching/NearString.java
+++ b/src/main/java/org/omegat/core/matching/NearString.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/search/SearchExpression.java
+++ b/src/main/java/org/omegat/core/search/SearchExpression.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/search/SearchMatch.java
+++ b/src/main/java/org/omegat/core/search/SearchMatch.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/search/SearchMode.java
+++ b/src/main/java/org/omegat/core/search/SearchMode.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/search/SearchResultEntry.java
+++ b/src/main/java/org/omegat/core/search/SearchResultEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/search/Searcher.java
+++ b/src/main/java/org/omegat/core/search/Searcher.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/segmentation/MapRule.java
+++ b/src/main/java/org/omegat/core/segmentation/MapRule.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/segmentation/Rule.java
+++ b/src/main/java/org/omegat/core/segmentation/Rule.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/segmentation/SRX.java
+++ b/src/main/java/org/omegat/core/segmentation/SRX.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/segmentation/Segmenter.java
+++ b/src/main/java/org/omegat/core/segmentation/Segmenter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/segmentation/datamodels/MappingRulesModel.java
+++ b/src/main/java/org/omegat/core/segmentation/datamodels/MappingRulesModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/segmentation/datamodels/SRXOptionsModel.java
+++ b/src/main/java/org/omegat/core/segmentation/datamodels/SRXOptionsModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/segmentation/datamodels/SegmentationRulesModel.java
+++ b/src/main/java/org/omegat/core/segmentation/datamodels/SegmentationRulesModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/AbstractHunspellDictionary.java
+++ b/src/main/java/org/omegat/core/spellchecker/AbstractHunspellDictionary.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/AbstractMorfologikDictionary.java
+++ b/src/main/java/org/omegat/core/spellchecker/AbstractMorfologikDictionary.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/DictionaryManager.java
+++ b/src/main/java/org/omegat/core/spellchecker/DictionaryManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/ISpellChecker.java
+++ b/src/main/java/org/omegat/core/spellchecker/ISpellChecker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/ISpellCheckerDictionary.java
+++ b/src/main/java/org/omegat/core/spellchecker/ISpellCheckerDictionary.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/ISpellCheckerProvider.java
+++ b/src/main/java/org/omegat/core/spellchecker/ISpellCheckerProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/SpellCheckDictionaryType.java
+++ b/src/main/java/org/omegat/core/spellchecker/SpellCheckDictionaryType.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/SpellCheckerManager.java
+++ b/src/main/java/org/omegat/core/spellchecker/SpellCheckerManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/spellchecker/SpellCheckerMarker.java
+++ b/src/main/java/org/omegat/core/spellchecker/SpellCheckerMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/CalcMatchStatistics.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/CalcPerFileMatchStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/CalcPerFileMatchStatistics.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/CalcStandardStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/CalcStandardStatistics.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/FindMatches.java
+++ b/src/main/java/org/omegat/core/statistics/FindMatches.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/ICalcStatistics.java
+++ b/src/main/java/org/omegat/core/statistics/ICalcStatistics.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/IStatsConsumer.java
+++ b/src/main/java/org/omegat/core/statistics/IStatsConsumer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/StatOutputFormat.java
+++ b/src/main/java/org/omegat/core/statistics/StatOutputFormat.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/Statistics.java
+++ b/src/main/java/org/omegat/core/statistics/Statistics.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/StatisticsInfo.java
+++ b/src/main/java/org/omegat/core/statistics/StatisticsInfo.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/StatisticsSettings.java
+++ b/src/main/java/org/omegat/core/statistics/StatisticsSettings.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/dso/FileData.java
+++ b/src/main/java/org/omegat/core/statistics/dso/FileData.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/dso/MatchStatCounts.java
+++ b/src/main/java/org/omegat/core/statistics/dso/MatchStatCounts.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/dso/StatCount.java
+++ b/src/main/java/org/omegat/core/statistics/dso/StatCount.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/dso/StatProjectProperties.java
+++ b/src/main/java/org/omegat/core/statistics/dso/StatProjectProperties.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/statistics/dso/StatsResult.java
+++ b/src/main/java/org/omegat/core/statistics/dso/StatsResult.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/tagvalidation/ErrorReport.java
+++ b/src/main/java/org/omegat/core/tagvalidation/ErrorReport.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/tagvalidation/ITagValidation.java
+++ b/src/main/java/org/omegat/core/tagvalidation/ITagValidation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/tagvalidation/TagRepair.java
+++ b/src/main/java/org/omegat/core/tagvalidation/TagRepair.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/tagvalidation/TagValidation.java
+++ b/src/main/java/org/omegat/core/tagvalidation/TagValidation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/tagvalidation/TagValidationTool.java
+++ b/src/main/java/org/omegat/core/tagvalidation/TagValidationTool.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/IRemoteRepository2.java
+++ b/src/main/java/org/omegat/core/team2/IRemoteRepository2.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/PreparedFileInfo.java
+++ b/src/main/java/org/omegat/core/team2/PreparedFileInfo.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/ProjectTeamSettings.java
+++ b/src/main/java/org/omegat/core/team2/ProjectTeamSettings.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/RebaseAndCommit.java
+++ b/src/main/java/org/omegat/core/team2/RebaseAndCommit.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/RemoteRepositoryFactory.java
+++ b/src/main/java/org/omegat/core/team2/RemoteRepositoryFactory.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/TeamSettings.java
+++ b/src/main/java/org/omegat/core/team2/TeamSettings.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/TeamTool.java
+++ b/src/main/java/org/omegat/core/team2/TeamTool.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/gui/PassphraseDialog.java
+++ b/src/main/java/org/omegat/core/team2/gui/PassphraseDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/gui/RepositoriesCredentialsController.java
+++ b/src/main/java/org/omegat/core/team2/gui/RepositoriesCredentialsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/gui/RepositoriesCredentialsPanel.java
+++ b/src/main/java/org/omegat/core/team2/gui/RepositoriesCredentialsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/gui/UserPassDialog.java
+++ b/src/main/java/org/omegat/core/team2/gui/UserPassDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/impl/FileRepository.java
+++ b/src/main/java/org/omegat/core/team2/impl/FileRepository.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/impl/GITCredentialsProvider.java
+++ b/src/main/java/org/omegat/core/team2/impl/GITCredentialsProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/impl/GITRemoteRepository2.java
+++ b/src/main/java/org/omegat/core/team2/impl/GITRemoteRepository2.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/impl/HTTPRemoteRepository.java
+++ b/src/main/java/org/omegat/core/team2/impl/HTTPRemoteRepository.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/impl/SVNAuthenticationManager.java
+++ b/src/main/java/org/omegat/core/team2/impl/SVNAuthenticationManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/impl/SVNRemoteRepository2.java
+++ b/src/main/java/org/omegat/core/team2/impl/SVNRemoteRepository2.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/impl/TeamUtils.java
+++ b/src/main/java/org/omegat/core/team2/impl/TeamUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/operation/GlossaryRebaseOperation.java
+++ b/src/main/java/org/omegat/core/team2/operation/GlossaryRebaseOperation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/operation/IRebaseOperation.java
+++ b/src/main/java/org/omegat/core/team2/operation/IRebaseOperation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/operation/RebaseUtils.java
+++ b/src/main/java/org/omegat/core/team2/operation/RebaseUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/team2/operation/TMXRebaseOperation.java
+++ b/src/main/java/org/omegat/core/team2/operation/TMXRebaseOperation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/threads/CommandMonitor.java
+++ b/src/main/java/org/omegat/core/threads/CommandMonitor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/threads/Completion.java
+++ b/src/main/java/org/omegat/core/threads/Completion.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/threads/IAutoSave.java
+++ b/src/main/java/org/omegat/core/threads/IAutoSave.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/threads/LongProcessInterruptedException.java
+++ b/src/main/java/org/omegat/core/threads/LongProcessInterruptedException.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/threads/LongProcessThread.java
+++ b/src/main/java/org/omegat/core/threads/LongProcessThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/threads/SaveThread.java
+++ b/src/main/java/org/omegat/core/threads/SaveThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/threads/SearchThread.java
+++ b/src/main/java/org/omegat/core/threads/SearchThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/core/threads/VersionCheckThread.java
+++ b/src/main/java/org/omegat/core/threads/VersionCheckThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/ExternalFinder.java
+++ b/src/main/java/org/omegat/externalfinder/ExternalFinder.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderCustomizer.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderCustomizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemCommandEditorController.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemCommandEditorController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemEditorController.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemEditorController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemEditorPanel.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemEditorPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemURLEditorController.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderItemURLEditorController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderPreferencesController.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderPreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderPreferencesPanel.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderPreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/gui/ExternalFinderSubItemEditorPanel.java
+++ b/src/main/java/org/omegat/externalfinder/gui/ExternalFinderSubItemEditorPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderConfiguration.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderConfiguration.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderItem.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderItem.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemCommand.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemCommand.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemMenuGenerator.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemMenuGenerator.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemPopupMenuConstructor.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemPopupMenuConstructor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemURL.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderItemURL.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderValidationException.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderValidationException.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderXMLLoader.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderXMLLoader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/ExternalFinderXMLWriter.java
+++ b/src/main/java/org/omegat/externalfinder/item/ExternalFinderXMLWriter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/IExternalFinderItemLoader.java
+++ b/src/main/java/org/omegat/externalfinder/item/IExternalFinderItemLoader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/externalfinder/item/IExternalFinderItemMenuGenerator.java
+++ b/src/main/java/org/omegat/externalfinder/item/IExternalFinderItemMenuGenerator.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/AbstractFilter.java
+++ b/src/main/java/org/omegat/filters2/AbstractFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/AbstractOptions.java
+++ b/src/main/java/org/omegat/filters2/AbstractOptions.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/FilterContext.java
+++ b/src/main/java/org/omegat/filters2/FilterContext.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/IAlignCallback.java
+++ b/src/main/java/org/omegat/filters2/IAlignCallback.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/IFilter.java
+++ b/src/main/java/org/omegat/filters2/IFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/IParseCallback.java
+++ b/src/main/java/org/omegat/filters2/IParseCallback.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/ITranslateCallback.java
+++ b/src/main/java/org/omegat/filters2/ITranslateCallback.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/Instance.java
+++ b/src/main/java/org/omegat/filters2/Instance.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/TranslationException.java
+++ b/src/main/java/org/omegat/filters2/TranslationException.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/hhc/HHCFilter2.java
+++ b/src/main/java/org/omegat/filters2/hhc/HHCFilter2.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/hhc/HHCFilterVisitor.java
+++ b/src/main/java/org/omegat/filters2/hhc/HHCFilterVisitor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/html2/EditOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/html2/EditOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/html2/FilterVisitor.java
+++ b/src/main/java/org/omegat/filters2/html2/FilterVisitor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/html2/HTMLFilter2.java
+++ b/src/main/java/org/omegat/filters2/html2/HTMLFilter2.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/html2/HTMLOptions.java
+++ b/src/main/java/org/omegat/filters2/html2/HTMLOptions.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/html2/HTMLReader.java
+++ b/src/main/java/org/omegat/filters2/html2/HTMLReader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/html2/HTMLUtils.java
+++ b/src/main/java/org/omegat/filters2/html2/HTMLUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/html2/HTMLWriter.java
+++ b/src/main/java/org/omegat/filters2/html2/HTMLWriter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/latex/LatexFilter.java
+++ b/src/main/java/org/omegat/filters2/latex/LatexFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/master/FilterMaster.java
+++ b/src/main/java/org/omegat/filters2/master/FilterMaster.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/master/FiltersTableModel.java
+++ b/src/main/java/org/omegat/filters2/master/FiltersTableModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/master/FiltersUtil.java
+++ b/src/main/java/org/omegat/filters2/master/FiltersUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/master/OneFilterTableModel.java
+++ b/src/main/java/org/omegat/filters2/master/OneFilterTableModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/master/PluginUtils.java
+++ b/src/main/java/org/omegat/filters2/master/PluginUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
+++ b/src/main/java/org/omegat/filters2/moodlephp/MoodlePHPFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/moodlephp/MoodlePHPOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/moodlephp/MoodlePHPOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
+++ b/src/main/java/org/omegat/filters2/mozdtd/MozillaDTDFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/mozdtd/MozillaDTDOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/mozdtd/MozillaDTDOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/mozlang/MozillaLangFilter.java
+++ b/src/main/java/org/omegat/filters2/mozlang/MozillaLangFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/pdf/PdfFilter.java
+++ b/src/main/java/org/omegat/filters2/pdf/PdfFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/po/PoFilter.java
+++ b/src/main/java/org/omegat/filters2/po/PoFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/po/PoOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/po/PoOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/rc/RcFilter.java
+++ b/src/main/java/org/omegat/filters2/rc/RcFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/subtitles/SbvFilter.java
+++ b/src/main/java/org/omegat/filters2/subtitles/SbvFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/subtitles/SrtFilter.java
+++ b/src/main/java/org/omegat/filters2/subtitles/SrtFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/subtitles/WebVttFilter.java
+++ b/src/main/java/org/omegat/filters2/subtitles/WebVttFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/LineLengthLimitWriter.java
+++ b/src/main/java/org/omegat/filters2/text/LineLengthLimitWriter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/TextFilter.java
+++ b/src/main/java/org/omegat/filters2/text/TextFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/TextOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/text/TextOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
+++ b/src/main/java/org/omegat/filters2/text/bundles/ResourceBundleFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/text/bundles/ResourceBundleOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/dokuwiki/DokuWikiFilter.java
+++ b/src/main/java/org/omegat/filters2/text/dokuwiki/DokuWikiFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/ilias/ILIASFilter.java
+++ b/src/main/java/org/omegat/filters2/text/ilias/ILIASFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/ini/INIFilter.java
+++ b/src/main/java/org/omegat/filters2/text/ini/INIFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/magento/MagentoFilter.java
+++ b/src/main/java/org/omegat/filters2/text/magento/MagentoFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/mozftl/MozillaFTLFilter.java
+++ b/src/main/java/org/omegat/filters2/text/mozftl/MozillaFTLFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/mozftl/MozillaFTLOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/text/mozftl/MozillaFTLOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
 OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/yaml/YamlFilter.java
+++ b/src/main/java/org/omegat/filters2/text/yaml/YamlFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/yaml/YamlOptions.java
+++ b/src/main/java/org/omegat/filters2/text/yaml/YamlOptions.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/text/yaml/YamlOptionsDialog.java
+++ b/src/main/java/org/omegat/filters2/text/yaml/YamlOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/xtagqxp/Xtag.java
+++ b/src/main/java/org/omegat/filters2/xtagqxp/Xtag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters2/xtagqxp/XtagFilter.java
+++ b/src/main/java/org/omegat/filters2/xtagqxp/XtagFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/AggregatedTag.java
+++ b/src/main/java/org/omegat/filters3/AggregatedTag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/Attribute.java
+++ b/src/main/java/org/omegat/filters3/Attribute.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/Attributes.java
+++ b/src/main/java/org/omegat/filters3/Attributes.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/Element.java
+++ b/src/main/java/org/omegat/filters3/Element.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/Entry.java
+++ b/src/main/java/org/omegat/filters3/Entry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/OutOfTurnTag.java
+++ b/src/main/java/org/omegat/filters3/OutOfTurnTag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/Tag.java
+++ b/src/main/java/org/omegat/filters3/Tag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/Text.java
+++ b/src/main/java/org/omegat/filters3/Text.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/Comment.java
+++ b/src/main/java/org/omegat/filters3/xml/Comment.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/DTD.java
+++ b/src/main/java/org/omegat/filters3/xml/DTD.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/DefaultXMLDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/DefaultXMLDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/Entity.java
+++ b/src/main/java/org/omegat/filters3/xml/Entity.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/Handler.java
+++ b/src/main/java/org/omegat/filters3/xml/Handler.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/ProcessingInstruction.java
+++ b/src/main/java/org/omegat/filters3/xml/ProcessingInstruction.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/Translator.java
+++ b/src/main/java/org/omegat/filters3/xml/Translator.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLContentBasedTag.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLContentBasedTag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLEntityText.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLEntityText.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLIntactEntry.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLIntactEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLIntactTag.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLIntactTag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLOutOfTurnTag.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLOutOfTurnTag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLPseudoTag.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLPseudoTag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLReader.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLReader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLTag.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLTag.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLText.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLText.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLUtils.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/XMLWriter.java
+++ b/src/main/java/org/omegat/filters3/xml/XMLWriter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/android/AndroidDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/android/AndroidDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/android/AndroidFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/android/AndroidFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/camtasiawindows/CamtasiaWindowsDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/camtasiawindows/CamtasiaWindowsDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/camtasiawindows/CamtasiaWindowsFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/camtasiawindows/CamtasiaWindowsFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/docbook/DocBookDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/docbook/DocBookDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/docbook/DocBookFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/docbook/DocBookFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/flash/FlashDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/flash/FlashDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/flash/FlashFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/flash/FlashFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/helpandmanual/HelpAndManualDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/helpandmanual/HelpAndManualDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/helpandmanual/HelpAndManualFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/helpandmanual/HelpAndManualFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/infix/InfixDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/infix/InfixDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/infix/InfixFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/infix/InfixFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/l10nmgr/L10nmgrDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/l10nmgr/L10nmgrDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/l10nmgr/L10nmgrFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/l10nmgr/L10nmgrFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/opendoc/EditOpenDocOptionsDialog.java
+++ b/src/main/java/org/omegat/filters3/xml/opendoc/EditOpenDocOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/opendoc/OpenDocDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/opendoc/OpenDocDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/opendoc/OpenDocFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/opendoc/OpenDocFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/opendoc/OpenDocOptions.java
+++ b/src/main/java/org/omegat/filters3/xml/opendoc/OpenDocOptions.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/opendoc/OpenDocXMLFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/opendoc/OpenDocXMLFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/openxml/EditOpenXMLOptionsDialog.java
+++ b/src/main/java/org/omegat/filters3/xml/openxml/EditOpenXMLOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/openxml/OpenXMLDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/openxml/OpenXMLDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/openxml/OpenXMLFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/openxml/OpenXMLFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/openxml/OpenXMLOptions.java
+++ b/src/main/java/org/omegat/filters3/xml/openxml/OpenXMLOptions.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/openxml/OpenXMLXMLFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/openxml/OpenXMLXMLFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/properties/PropertiesDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/properties/PropertiesDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/properties/PropertiesFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/properties/PropertiesFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/relaxng/RelaxNGDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/relaxng/RelaxNGDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/relaxng/RelaxNGFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/relaxng/RelaxNGFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/resx/ResXDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/resx/ResXDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/resx/ResXFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/resx/ResXFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/schematron/SchematronDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/schematron/SchematronDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/schematron/SchematronFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/schematron/SchematronFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/scribus/ScribusDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/scribus/ScribusDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/scribus/ScribusFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/scribus/ScribusFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/svg/SvgDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/svg/SvgDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/svg/SvgFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/svg/SvgFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/txml/TXMLDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/txml/TXMLDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/txml/TXMLFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/txml/TXMLFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/typo3/Typo3Dialect.java
+++ b/src/main/java/org/omegat/filters3/xml/typo3/Typo3Dialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/typo3/Typo3Filter.java
+++ b/src/main/java/org/omegat/filters3/xml/typo3/Typo3Filter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/visio/VisioDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/visio/VisioDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/visio/VisioFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/visio/VisioFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/wix/WiXDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/wix/WiXDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/wix/WiXFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/wix/WiXFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/wordpress/WordpressDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/wordpress/WordpressDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/wordpress/WordpressFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/wordpress/WordpressFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xhtml/EditXOptionsDialog.java
+++ b/src/main/java/org/omegat/filters3/xml/xhtml/EditXOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xhtml/XHTMLDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/xhtml/XHTMLDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xhtml/XHTMLFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/xhtml/XHTMLFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xhtml/XHTMLOptions.java
+++ b/src/main/java/org/omegat/filters3/xml/xhtml/XHTMLOptions.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xliff/EditXLIFFOptionsDialog.java
+++ b/src/main/java/org/omegat/filters3/xml/xliff/EditXLIFFOptionsDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xliff/XLIFFDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/xliff/XLIFFDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xliff/XLIFFFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/xliff/XLIFFFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xliff/XLIFFOptions.java
+++ b/src/main/java/org/omegat/filters3/xml/xliff/XLIFFOptions.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xmlspreadsheet/XMLSpreadsheetDialect.java
+++ b/src/main/java/org/omegat/filters3/xml/xmlspreadsheet/XMLSpreadsheetDialect.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters3/xml/xmlspreadsheet/XMLSpreadsheetFilter.java
+++ b/src/main/java/org/omegat/filters3/xml/xmlspreadsheet/XMLSpreadsheetFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/AbstractZipFilter.java
+++ b/src/main/java/org/omegat/filters4/AbstractZipFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/xml/AbstractXmlFilter.java
+++ b/src/main/java/org/omegat/filters4/xml/AbstractXmlFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
+++ b/src/main/java/org/omegat/filters4/xml/openxml/MsOfficeFileFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
+++ b/src/main/java/org/omegat/filters4/xml/openxml/OpenXmlFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/AbstractXliffFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/xml/xliff/SdlProject.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/SdlProject.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/xml/xliff/SdlXliff.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/SdlXliff.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/xml/xliff/Xliff1Filter.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/Xliff1Filter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/filters4/xml/xliff/Xliff2Filter.java
+++ b/src/main/java/org/omegat/filters4/xml/xliff/Xliff2Filter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/comments/CommentsTextArea.java
+++ b/src/main/java/org/omegat/gui/comments/CommentsTextArea.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/comments/ICommentProvider.java
+++ b/src/main/java/org/omegat/gui/comments/ICommentProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/comments/IComments.java
+++ b/src/main/java/org/omegat/gui/comments/IComments.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/common/EntryInfoPane.java
+++ b/src/main/java/org/omegat/gui/common/EntryInfoPane.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/common/EntryInfoSearchThread.java
+++ b/src/main/java/org/omegat/gui/common/EntryInfoSearchThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/common/EntryInfoThreadPane.java
+++ b/src/main/java/org/omegat/gui/common/EntryInfoThreadPane.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/AboutDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/AboutDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/ChooseMedProject.java
+++ b/src/main/java/org/omegat/gui/dialogs/ChooseMedProject.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/ChoosePluginFile.java
+++ b/src/main/java/org/omegat/gui/dialogs/ChoosePluginFile.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/ConflictDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/ConflictDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/ConflictDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/ConflictDialogController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/CreateGlossaryEntry.java
+++ b/src/main/java/org/omegat/gui/dialogs/CreateGlossaryEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/FileCollisionDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/FileCollisionDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/FilenamePatternsEditor.java
+++ b/src/main/java/org/omegat/gui/dialogs/FilenamePatternsEditor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/FilenamePatternsEditorController.java
+++ b/src/main/java/org/omegat/gui/dialogs/FilenamePatternsEditorController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/GoToSegmentDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/GoToSegmentDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/KeyStrokeEditorDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/KeyStrokeEditorDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/KeyStrokeEditorPanel.java
+++ b/src/main/java/org/omegat/gui/dialogs/KeyStrokeEditorPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/LastChangesDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/LastChangesDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/LicenseDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/LicenseDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/LogDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/LogDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/LogDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/LogDialogController.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/NewProjectFileChooser.java
+++ b/src/main/java/org/omegat/gui/dialogs/NewProjectFileChooser.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/NewTeamProject.java
+++ b/src/main/java/org/omegat/gui/dialogs/NewTeamProject.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/NewTeamProjectController.java
+++ b/src/main/java/org/omegat/gui/dialogs/NewTeamProjectController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/PasswordEnterDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/PasswordEnterDialogController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/PasswordSetDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/PasswordSetDialogController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/PasswordSetPanel.java
+++ b/src/main/java/org/omegat/gui/dialogs/PasswordSetPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/PreferencesDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/PreferencesDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/RepositoriesMappingDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/RepositoriesMappingDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/VersionCheckDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/VersionCheckDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dialogs/VersionCheckPanel.java
+++ b/src/main/java/org/omegat/gui/dialogs/VersionCheckPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dictionaries/DictionariesTextArea.java
+++ b/src/main/java/org/omegat/gui/dictionaries/DictionariesTextArea.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dictionaries/DictionaryPopup.java
+++ b/src/main/java/org/omegat/gui/dictionaries/DictionaryPopup.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/dictionaries/IDictionaries.java
+++ b/src/main/java/org/omegat/gui/dictionaries/IDictionaries.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/AlphabeticalMarkers.java
+++ b/src/main/java/org/omegat/gui/editor/AlphabeticalMarkers.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/CollapsibleBar.java
+++ b/src/main/java/org/omegat/gui/editor/CollapsibleBar.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/Document3.java
+++ b/src/main/java/org/omegat/gui/editor/Document3.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/DocumentFilter3.java
+++ b/src/main/java/org/omegat/gui/editor/DocumentFilter3.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/EditorController.java
+++ b/src/main/java/org/omegat/gui/editor/EditorController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/EditorPopups.java
+++ b/src/main/java/org/omegat/gui/editor/EditorPopups.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/EditorSettings.java
+++ b/src/main/java/org/omegat/gui/editor/EditorSettings.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/EditorTextArea3.java
+++ b/src/main/java/org/omegat/gui/editor/EditorTextArea3.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/EditorUtils.java
+++ b/src/main/java/org/omegat/gui/editor/EditorUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/IEditor.java
+++ b/src/main/java/org/omegat/gui/editor/IEditor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/IEditorFilter.java
+++ b/src/main/java/org/omegat/gui/editor/IEditorFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/IEditorSettings.java
+++ b/src/main/java/org/omegat/gui/editor/IEditorSettings.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/IPopupMenuConstructor.java
+++ b/src/main/java/org/omegat/gui/editor/IPopupMenuConstructor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/MarkerController.java
+++ b/src/main/java/org/omegat/gui/editor/MarkerController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/ModificationInfoManager.java
+++ b/src/main/java/org/omegat/gui/editor/ModificationInfoManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/SegmentBuilder.java
+++ b/src/main/java/org/omegat/gui/editor/SegmentBuilder.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/SegmentExportImport.java
+++ b/src/main/java/org/omegat/gui/editor/SegmentExportImport.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/SegmentHistory.java
+++ b/src/main/java/org/omegat/gui/editor/SegmentHistory.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/TagAutoCompleterView.java
+++ b/src/main/java/org/omegat/gui/editor/TagAutoCompleterView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/TranslationUndoManager.java
+++ b/src/main/java/org/omegat/gui/editor/TranslationUndoManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/UnderlineFactory.java
+++ b/src/main/java/org/omegat/gui/editor/UnderlineFactory.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/ViewLabel.java
+++ b/src/main/java/org/omegat/gui/editor/ViewLabel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/ViewParagraph.java
+++ b/src/main/java/org/omegat/gui/editor/ViewParagraph.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autocompleter/AbstractAutoCompleterView.java
+++ b/src/main/java/org/omegat/gui/editor/autocompleter/AbstractAutoCompleterView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleter.java
+++ b/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleterItem.java
+++ b/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleterItem.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleterKeys.java
+++ b/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleterKeys.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleterListView.java
+++ b/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleterListView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleterTableView.java
+++ b/src/main/java/org/omegat/gui/editor/autocompleter/AutoCompleterTableView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autocompleter/IAutoCompleter.java
+++ b/src/main/java/org/omegat/gui/editor/autocompleter/IAutoCompleter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autotext/Autotext.java
+++ b/src/main/java/org/omegat/gui/editor/autotext/Autotext.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autotext/AutotextAutoCompleterView.java
+++ b/src/main/java/org/omegat/gui/editor/autotext/AutotextAutoCompleterView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/autotext/AutotextTableModel.java
+++ b/src/main/java/org/omegat/gui/editor/autotext/AutotextTableModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/chartable/CharTableAutoCompleterView.java
+++ b/src/main/java/org/omegat/gui/editor/chartable/CharTableAutoCompleterView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/chartable/CharTableModel.java
+++ b/src/main/java/org/omegat/gui/editor/chartable/CharTableModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/chartable/CharTableRenderer.java
+++ b/src/main/java/org/omegat/gui/editor/chartable/CharTableRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/filter/FilterBarReplace.java
+++ b/src/main/java/org/omegat/gui/editor/filter/FilterBarReplace.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/filter/FilterBarSearch.java
+++ b/src/main/java/org/omegat/gui/editor/filter/FilterBarSearch.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/filter/ReplaceFilter.java
+++ b/src/main/java/org/omegat/gui/editor/filter/ReplaceFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/filter/SearchFilter.java
+++ b/src/main/java/org/omegat/gui/editor/filter/SearchFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/history/HistoryCompleter.java
+++ b/src/main/java/org/omegat/gui/editor/history/HistoryCompleter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/history/HistoryPredictor.java
+++ b/src/main/java/org/omegat/gui/editor/history/HistoryPredictor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/history/WordCompleter.java
+++ b/src/main/java/org/omegat/gui/editor/history/WordCompleter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/history/WordPredictor.java
+++ b/src/main/java/org/omegat/gui/editor/history/WordPredictor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/AbstractMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/AbstractMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/AltTranslationsMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/AltTranslationsMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/BidiMarkers.java
+++ b/src/main/java/org/omegat/gui/editor/mark/BidiMarkers.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/BidiPainter.java
+++ b/src/main/java/org/omegat/gui/editor/mark/BidiPainter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/CalcMarkersThread.java
+++ b/src/main/java/org/omegat/gui/editor/mark/CalcMarkersThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ComesFromAutoTMMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
 OmegaT - Computer Assisted Translation (CAT) tool
          with fuzzy matching, translation memory, keyword search,
          glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/ComesFromMTMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ComesFromMTMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
 OmegaT - Computer Assisted Translation (CAT) tool
          with fuzzy matching, translation memory, keyword search,
          glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/EntryMarks.java
+++ b/src/main/java/org/omegat/gui/editor/mark/EntryMarks.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/FontFallbackMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/FontFallbackMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/IMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/IMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/Mark.java
+++ b/src/main/java/org/omegat/gui/editor/mark/Mark.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/NBSPMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/NBSPMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ProtectedPartsMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/RemoveTagMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/RemoveTagMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/ReplaceMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/ReplaceMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/SymbolPainter.java
+++ b/src/main/java/org/omegat/gui/editor/mark/SymbolPainter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/TransparentHighlightPainter.java
+++ b/src/main/java/org/omegat/gui/editor/mark/TransparentHighlightPainter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/editor/mark/WhitespaceMarker.java
+++ b/src/main/java/org/omegat/gui/editor/mark/WhitespaceMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/exttrans/IMTGlossarySupplier.java
+++ b/src/main/java/org/omegat/gui/exttrans/IMTGlossarySupplier.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/exttrans/IMachineTranslation.java
+++ b/src/main/java/org/omegat/gui/exttrans/IMachineTranslation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/exttrans/MTConfigDialog.java
+++ b/src/main/java/org/omegat/gui/exttrans/MTConfigDialog.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/exttrans/MTConfigPanel.java
+++ b/src/main/java/org/omegat/gui/exttrans/MTConfigPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/exttrans/MachineTranslateController.java
+++ b/src/main/java/org/omegat/gui/exttrans/MachineTranslateController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/exttrans/MachineTranslateFindThread.java
+++ b/src/main/java/org/omegat/gui/exttrans/MachineTranslateFindThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/exttrans/MachineTranslateTextArea.java
+++ b/src/main/java/org/omegat/gui/exttrans/MachineTranslateTextArea.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/exttrans/MachineTranslationInfo.java
+++ b/src/main/java/org/omegat/gui/exttrans/MachineTranslationInfo.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filelist/IProjectFilesList.java
+++ b/src/main/java/org/omegat/gui/filelist/IProjectFilesList.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filelist/ProjectFilesList.java
+++ b/src/main/java/org/omegat/gui/filelist/ProjectFilesList.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
+++ b/src/main/java/org/omegat/gui/filelist/ProjectFilesListController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filelist/TableFilterPanel.java
+++ b/src/main/java/org/omegat/gui/filelist/TableFilterPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filters2/FilterEditor.java
+++ b/src/main/java/org/omegat/gui/filters2/FilterEditor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filters2/FiltersCustomizer.java
+++ b/src/main/java/org/omegat/gui/filters2/FiltersCustomizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filters2/FiltersCustomizerController.java
+++ b/src/main/java/org/omegat/gui/filters2/FiltersCustomizerController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filters2/FiltersCustomizerPanel.java
+++ b/src/main/java/org/omegat/gui/filters2/FiltersCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/filters2/InstanceEditor.java
+++ b/src/main/java/org/omegat/gui/filters2/InstanceEditor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/DefaultGlossaryRenderer.java
+++ b/src/main/java/org/omegat/gui/glossary/DefaultGlossaryRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/DictionaryGlossaryRenderer.java
+++ b/src/main/java/org/omegat/gui/glossary/DictionaryGlossaryRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/FindGlossaryThread.java
+++ b/src/main/java/org/omegat/gui/glossary/FindGlossaryThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossaryAutoCompleterView.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossaryAutoCompleterView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossaryEntry.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossaryEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossaryManager.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossaryManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossaryReaderCSV.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossaryReaderCSV.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossaryReaderTBX.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossaryReaderTBX.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossaryReaderTSV.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossaryReaderTSV.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossaryRenderers.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossaryRenderers.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossarySearcher.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossarySearcher.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/GlossaryTextArea.java
+++ b/src/main/java/org/omegat/gui/glossary/GlossaryTextArea.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/IGlossaries.java
+++ b/src/main/java/org/omegat/gui/glossary/IGlossaries.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/IGlossaryRenderer.java
+++ b/src/main/java/org/omegat/gui/glossary/IGlossaryRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/TransTipsMarker.java
+++ b/src/main/java/org/omegat/gui/glossary/TransTipsMarker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/glossary/TransTipsPopup.java
+++ b/src/main/java/org/omegat/gui/glossary/TransTipsPopup.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IIssue.java
+++ b/src/main/java/org/omegat/gui/issues/IIssue.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IIssueProvider.java
+++ b/src/main/java/org/omegat/gui/issues/IIssueProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IIssues.java
+++ b/src/main/java/org/omegat/gui/issues/IIssues.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssueChecker.java
+++ b/src/main/java/org/omegat/gui/issues/IssueChecker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
          with fuzzy matching, translation memory, keyword search,
          glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssueColumn.java
+++ b/src/main/java/org/omegat/gui/issues/IssueColumn.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssueDetailSplitPanel.java
+++ b/src/main/java/org/omegat/gui/issues/IssueDetailSplitPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssueProviders.java
+++ b/src/main/java/org/omegat/gui/issues/IssueProviders.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssueProvidersSelectorController.java
+++ b/src/main/java/org/omegat/gui/issues/IssueProvidersSelectorController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssueProvidersSelectorPanel.java
+++ b/src/main/java/org/omegat/gui/issues/IssueProvidersSelectorPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssuesPanel.java
+++ b/src/main/java/org/omegat/gui/issues/IssuesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssuesPanelController.java
+++ b/src/main/java/org/omegat/gui/issues/IssuesPanelController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssuesTableModel.java
+++ b/src/main/java/org/omegat/gui/issues/IssuesTableModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/IssuesTypeListModel.java
+++ b/src/main/java/org/omegat/gui/issues/IssuesTypeListModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/SimpleColorIcon.java
+++ b/src/main/java/org/omegat/gui/issues/SimpleColorIcon.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/SimpleIssue.java
+++ b/src/main/java/org/omegat/gui/issues/SimpleIssue.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/SpellingIssueProvider.java
+++ b/src/main/java/org/omegat/gui/issues/SpellingIssueProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/TagIssue.java
+++ b/src/main/java/org/omegat/gui/issues/TagIssue.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/TerminologyIssueProvider.java
+++ b/src/main/java/org/omegat/gui/issues/TerminologyIssueProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/issues/TripleSplitButtonPanel.java
+++ b/src/main/java/org/omegat/gui/issues/TripleSplitButtonPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/BaseMainWindowMenuHandler.java
+++ b/src/main/java/org/omegat/gui/main/BaseMainWindowMenuHandler.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/ConsoleWindow.java
+++ b/src/main/java/org/omegat/gui/main/ConsoleWindow.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/DockablePanel.java
+++ b/src/main/java/org/omegat/gui/main/DockablePanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/DockableScrollPane.java
+++ b/src/main/java/org/omegat/gui/main/DockableScrollPane.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/IMainMenu.java
+++ b/src/main/java/org/omegat/gui/main/IMainMenu.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/IMainWindow.java
+++ b/src/main/java/org/omegat/gui/main/IMainWindow.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/MainMenuIcons.java
+++ b/src/main/java/org/omegat/gui/main/MainMenuIcons.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/MainWindow.java
+++ b/src/main/java/org/omegat/gui/main/MainWindow.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/MainWindowMenu.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowMenu.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/MainWindowMenuHandler.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowMenuHandler.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/MainWindowStatusBar.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowStatusBar.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/MainWindowStatusBarController.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowStatusBarController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/MainWindowUI.java
+++ b/src/main/java/org/omegat/gui/main/MainWindowUI.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/ProjectMedProcessing.java
+++ b/src/main/java/org/omegat/gui/main/ProjectMedProcessing.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/main/java/org/omegat/gui/main/ProjectUICommands.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/matches/FindMatchesThread.java
+++ b/src/main/java/org/omegat/gui/matches/FindMatchesThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/matches/IMatcher.java
+++ b/src/main/java/org/omegat/gui/matches/IMatcher.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/matches/MatchScoresTooltip.java
+++ b/src/main/java/org/omegat/gui/matches/MatchScoresTooltip.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
+++ b/src/main/java/org/omegat/gui/matches/MatchesTextArea.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/matches/MatchesVarExpansion.java
+++ b/src/main/java/org/omegat/gui/matches/MatchesVarExpansion.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/multtrans/MultipleTransFindThread.java
+++ b/src/main/java/org/omegat/gui/multtrans/MultipleTransFindThread.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/multtrans/MultipleTransFoundEntry.java
+++ b/src/main/java/org/omegat/gui/multtrans/MultipleTransFoundEntry.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/multtrans/MultipleTransPane.java
+++ b/src/main/java/org/omegat/gui/multtrans/MultipleTransPane.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/notes/INotes.java
+++ b/src/main/java/org/omegat/gui/notes/INotes.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/notes/NotesTextArea.java
+++ b/src/main/java/org/omegat/gui/notes/NotesTextArea.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/BasePreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/BasePreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/IPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/IPreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/PreferencePanel.java
+++ b/src/main/java/org/omegat/gui/preferences/PreferencePanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/PreferenceViewSelectorPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/PreferenceViewSelectorPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/PreferencesControllers.java
+++ b/src/main/java/org/omegat/gui/preferences/PreferencesControllers.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/PreferencesWindowController.java
+++ b/src/main/java/org/omegat/gui/preferences/PreferencesWindowController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/AppearanceController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/AppearanceController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/AppearancePreferencesPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/AppearancePreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/AutoCompleterController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/AutoCompleterController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/AutoCompleterPreferencesPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/AutoCompleterPreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/AutotextAutoCompleterOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/AutotextAutoCompleterOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/AutotextAutoCompleterOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/AutotextAutoCompleterOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/CharTableAutoCompleterOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/CharTableAutoCompleterOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/CharTableAutoCompleterOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/CharTableAutoCompleterOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/CustomColorSelectionController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/CustomColorSelectionController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/CustomColorSelectionPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/CustomColorSelectionPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/DictionaryPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/DictionaryPreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/DictionaryPreferencesPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/DictionaryPreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/EditingBehaviorController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/EditingBehaviorController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/EditingBehaviorPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/EditingBehaviorPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/FontSelectionController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/FontSelectionController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/FontSelectionPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/FontSelectionPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/GeneralOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/GeneralOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/GeneralOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/GeneralOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/GlossaryAutoCompleterOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/GlossaryPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/GlossaryPreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/GlossaryPreferencesPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/GlossaryPreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/HistoryAutoCompleterOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/HistoryAutoCompleterOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/HistoryAutoCompleterOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/HistoryAutoCompleterOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/LanguageToolConfigurationController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/LanguageToolConfigurationController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/LanguageToolConfigurationPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/MachineTranslationPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/MachineTranslationPreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/MachineTranslationPreferencesPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/MachineTranslationPreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/PluginDetailsPane.java
+++ b/src/main/java/org/omegat/gui/preferences/view/PluginDetailsPane.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/PluginInfoTableModel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/PluginInfoTableModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/PluginsPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/PluginsPreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/PluginsPreferencesPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/PluginsPreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/SaveOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/SaveOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/SaveOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/SaveOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/SecureStoreController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/SecureStoreController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/SecureStorePanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/SecureStorePanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/SourceFilesViewOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/SourceFilesViewOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/SpellcheckerConfigurationPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/SpellcheckerConfigurationPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/TMMatchesPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/TMMatchesPreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/TMMatchesPreferencesPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/TMMatchesPreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/TagProcessingOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/TagProcessingOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/TagProcessingOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/TagProcessingOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/TeamOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/TeamOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/TeamOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/TeamOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/UserPassController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/UserPassController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/UserPassPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/UserPassPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/VersionCheckPreferencesController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/VersionCheckPreferencesController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/VersionCheckPreferencesPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/VersionCheckPreferencesPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/ViewOptionsController.java
+++ b/src/main/java/org/omegat/gui/preferences/view/ViewOptionsController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/preferences/view/ViewOptionsPanel.java
+++ b/src/main/java/org/omegat/gui/preferences/view/ViewOptionsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/FlashColorInterpolator.java
+++ b/src/main/java/org/omegat/gui/properties/FlashColorInterpolator.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/FlashingTable.java
+++ b/src/main/java/org/omegat/gui/properties/FlashingTable.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/FlashingTextArea.java
+++ b/src/main/java/org/omegat/gui/properties/FlashingTextArea.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/ForcedWrappingEditorKit.java
+++ b/src/main/java/org/omegat/gui/properties/ForcedWrappingEditorKit.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/ISegmentPropertiesView.java
+++ b/src/main/java/org/omegat/gui/properties/ISegmentPropertiesView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/MultilineCellRenderer.java
+++ b/src/main/java/org/omegat/gui/properties/MultilineCellRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/PropertiesTableModel.java
+++ b/src/main/java/org/omegat/gui/properties/PropertiesTableModel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/SegmentPropertiesArea.java
+++ b/src/main/java/org/omegat/gui/properties/SegmentPropertiesArea.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/SegmentPropertiesListCell.java
+++ b/src/main/java/org/omegat/gui/properties/SegmentPropertiesListCell.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/SegmentPropertiesListView.java
+++ b/src/main/java/org/omegat/gui/properties/SegmentPropertiesListView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/SegmentPropertiesMouseAdapter.java
+++ b/src/main/java/org/omegat/gui/properties/SegmentPropertiesMouseAdapter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/SegmentPropertiesTableView.java
+++ b/src/main/java/org/omegat/gui/properties/SegmentPropertiesTableView.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/properties/SingleLineCellRenderer.java
+++ b/src/main/java/org/omegat/gui/properties/SingleLineCellRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/repositoriesmapping/RepositoriesMappingController.java
+++ b/src/main/java/org/omegat/gui/repositoriesmapping/RepositoriesMappingController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/repositoriesmapping/RepositoriesMappingPanel.java
+++ b/src/main/java/org/omegat/gui/repositoriesmapping/RepositoriesMappingPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ConsoleBindings.java
+++ b/src/main/java/org/omegat/gui/scripting/ConsoleBindings.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/IScriptLogger.java
+++ b/src/main/java/org/omegat/gui/scripting/IScriptLogger.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ScriptItem.java
+++ b/src/main/java/org/omegat/gui/scripting/ScriptItem.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ScriptRunner.java
+++ b/src/main/java/org/omegat/gui/scripting/ScriptRunner.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ScriptSet.java
+++ b/src/main/java/org/omegat/gui/scripting/ScriptSet.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ScriptingModule.java
+++ b/src/main/java/org/omegat/gui/scripting/ScriptingModule.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ScriptingWindow.java
+++ b/src/main/java/org/omegat/gui/scripting/ScriptingWindow.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ScriptsMonitor.java
+++ b/src/main/java/org/omegat/gui/scripting/ScriptsMonitor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/runner/AbstractScriptRunner.java
+++ b/src/main/java/org/omegat/gui/scripting/runner/AbstractScriptRunner.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/runner/StandardScriptRunner.java
+++ b/src/main/java/org/omegat/gui/scripting/runner/StandardScriptRunner.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ui/AbstractScriptEditor.java
+++ b/src/main/java/org/omegat/gui/scripting/ui/AbstractScriptEditor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ui/RichScriptEditor.java
+++ b/src/main/java/org/omegat/gui/scripting/ui/RichScriptEditor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/scripting/ui/StandardScriptEditor.java
+++ b/src/main/java/org/omegat/gui/scripting/ui/StandardScriptEditor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/search/EntryListPane.java
+++ b/src/main/java/org/omegat/gui/search/EntryListPane.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/search/HistoryManager.java
+++ b/src/main/java/org/omegat/gui/search/HistoryManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/search/MFindField.java
+++ b/src/main/java/org/omegat/gui/search/MFindField.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/search/SearchWindowController.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/search/SearchWindowForm.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowForm.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/search/SearchWindowManager.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowManager.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/search/SearchWindowMenu.java
+++ b/src/main/java/org/omegat/gui/search/SearchWindowMenu.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/segmentation/SegmentationCustomizer.java
+++ b/src/main/java/org/omegat/gui/segmentation/SegmentationCustomizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/segmentation/SegmentationCustomizerController.java
+++ b/src/main/java/org/omegat/gui/segmentation/SegmentationCustomizerController.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/segmentation/SegmentationCustomizerPanel.java
+++ b/src/main/java/org/omegat/gui/segmentation/SegmentationCustomizerPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/shortcuts/PropertiesShortcuts.java
+++ b/src/main/java/org/omegat/gui/shortcuts/PropertiesShortcuts.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/stat/BaseMatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/BaseMatchStatisticsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/stat/BaseStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/BaseStatisticsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/MatchStatisticsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/stat/PerFileMatchStatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/PerFileMatchStatisticsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/stat/StatisticsPanel.java
+++ b/src/main/java/org/omegat/gui/stat/StatisticsPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/stat/StatisticsWindow.java
+++ b/src/main/java/org/omegat/gui/stat/StatisticsWindow.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/stat/TitledTablePanel.java
+++ b/src/main/java/org/omegat/gui/stat/TitledTablePanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/theme/DefaultClassicTheme.java
+++ b/src/main/java/org/omegat/gui/theme/DefaultClassicTheme.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/theme/DefaultFlatTheme.java
+++ b/src/main/java/org/omegat/gui/theme/DefaultFlatTheme.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/gui/theme/DelegatingLookAndFeel.java
+++ b/src/main/java/org/omegat/gui/theme/DelegatingLookAndFeel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/help/Help.java
+++ b/src/main/java/org/omegat/help/Help.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/BaseLanguageToolBridge.java
+++ b/src/main/java/org/omegat/languagetools/BaseLanguageToolBridge.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/ILanguageToolBridge.java
+++ b/src/main/java/org/omegat/languagetools/ILanguageToolBridge.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageClassBroker.java
+++ b/src/main/java/org/omegat/languagetools/LanguageClassBroker.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageDataBroker.java
+++ b/src/main/java/org/omegat/languagetools/LanguageDataBroker.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageManager.java
+++ b/src/main/java/org/omegat/languagetools/LanguageManager.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageToolIssueProvider.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolIssueProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageToolNativeBridge.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolNativeBridge.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageToolNetworkBridge.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolNetworkBridge.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageToolPrefs.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolPrefs.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageToolResult.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolResult.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/languagetools/LanguageToolWrapper.java
+++ b/src/main/java/org/omegat/languagetools/LanguageToolWrapper.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/BaseTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/BaseTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/DefaultTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/DefaultTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/HunspellTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/HunspellTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/ITokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/ITokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneArabicTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneArabicTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneArmenianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneArmenianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneBasqueTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneBasqueTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneBrazilianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneBrazilianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneBulgarianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneBulgarianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneCJKTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneCJKTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneCatalanTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneCatalanTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneCzechTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneCzechTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneDanishTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneDanishTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneDutchTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneDutchTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneEnglishTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneEnglishTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneFinnishTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneFinnishTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneFrenchTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneFrenchTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneGalicianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneGalicianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneGermanTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneGermanTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneGreekTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneGreekTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneHindiTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneHindiTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneHungarianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneHungarianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneIndonesianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneIndonesianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneIrishTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneIrishTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneItalianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneItalianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneJapaneseTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneJapaneseTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneLatvianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneLatvianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneNorwegianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneNorwegianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LucenePersianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LucenePersianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LucenePolishTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LucenePolishTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LucenePortugueseTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LucenePortugueseTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneRomanianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneRomanianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneRussianTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneRussianTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneSmartChineseTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneSmartChineseTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneSpanishTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneSpanishTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneSwedishTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneSwedishTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneThaiTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneThaiTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/LuceneTurkishTokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/LuceneTurkishTokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/Tokenizer.java
+++ b/src/main/java/org/omegat/tokenizer/Tokenizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/tokenizer/WordIterator.java
+++ b/src/main/java/org/omegat/tokenizer/WordIterator.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/BiDiUtils.java
+++ b/src/main/java/org/omegat/util/BiDiUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/BufferedFileReader.java
+++ b/src/main/java/org/omegat/util/BufferedFileReader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/CredentialsManager.java
+++ b/src/main/java/org/omegat/util/CredentialsManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/DirectoryMonitor.java
+++ b/src/main/java/org/omegat/util/DirectoryMonitor.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/EncodingDetector.java
+++ b/src/main/java/org/omegat/util/EncodingDetector.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/EncodingSniffer.java
+++ b/src/main/java/org/omegat/util/EncodingSniffer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/FileUtil.java
+++ b/src/main/java/org/omegat/util/FileUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/FunctionalAction.java
+++ b/src/main/java/org/omegat/util/FunctionalAction.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/HTMLUtils.java
+++ b/src/main/java/org/omegat/util/HTMLUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/HttpConnectionUtils.java
+++ b/src/main/java/org/omegat/util/HttpConnectionUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/InlineTagHandler.java
+++ b/src/main/java/org/omegat/util/InlineTagHandler.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/Java8Compat.java
+++ b/src/main/java/org/omegat/util/Java8Compat.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/JsonParser.java
+++ b/src/main/java/org/omegat/util/JsonParser.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/Language.java
+++ b/src/main/java/org/omegat/util/Language.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/LinebreakPreservingReader.java
+++ b/src/main/java/org/omegat/util/LinebreakPreservingReader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/Log.java
+++ b/src/main/java/org/omegat/util/Log.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/MagicComment.java
+++ b/src/main/java/org/omegat/util/MagicComment.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/MemoryUtils.java
+++ b/src/main/java/org/omegat/util/MemoryUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/MixedEolHandlingReader.java
+++ b/src/main/java/org/omegat/util/MixedEolHandlingReader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/MultiMap.java
+++ b/src/main/java/org/omegat/util/MultiMap.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/NullBufferedWriter.java
+++ b/src/main/java/org/omegat/util/NullBufferedWriter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/NullWriter.java
+++ b/src/main/java/org/omegat/util/NullWriter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/NumeralValueParser.java
+++ b/src/main/java/org/omegat/util/NumeralValueParser.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/OConsts.java
+++ b/src/main/java/org/omegat/util/OConsts.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/OStrings.java
+++ b/src/main/java/org/omegat/util/OStrings.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/PatternConsts.java
+++ b/src/main/java/org/omegat/util/PatternConsts.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/Platform.java
+++ b/src/main/java/org/omegat/util/Platform.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/PluginInstaller.java
+++ b/src/main/java/org/omegat/util/PluginInstaller.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/Preferences.java
+++ b/src/main/java/org/omegat/util/Preferences.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/PreferencesImpl.java
+++ b/src/main/java/org/omegat/util/PreferencesImpl.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/PreferencesXML.java
+++ b/src/main/java/org/omegat/util/PreferencesXML.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/ProjectFileStorage.java
+++ b/src/main/java/org/omegat/util/ProjectFileStorage.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/RecentProjects.java
+++ b/src/main/java/org/omegat/util/RecentProjects.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/RuntimePreferences.java
+++ b/src/main/java/org/omegat/util/RuntimePreferences.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/StaticUtils.java
+++ b/src/main/java/org/omegat/util/StaticUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/StreamUtil.java
+++ b/src/main/java/org/omegat/util/StreamUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/StringUtil.java
+++ b/src/main/java/org/omegat/util/StringUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/TMXDateParser.java
+++ b/src/main/java/org/omegat/util/TMXDateParser.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/TMXLSResourceResolver.java
+++ b/src/main/java/org/omegat/util/TMXLSResourceResolver.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/TMXProp.java
+++ b/src/main/java/org/omegat/util/TMXProp.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/TMXReader2.java
+++ b/src/main/java/org/omegat/util/TMXReader2.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/TMXWriter.java
+++ b/src/main/java/org/omegat/util/TMXWriter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/TMXWriter2.java
+++ b/src/main/java/org/omegat/util/TMXWriter2.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/TagUtil.java
+++ b/src/main/java/org/omegat/util/TagUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/Token.java
+++ b/src/main/java/org/omegat/util/Token.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/VarExpansion.java
+++ b/src/main/java/org/omegat/util/VarExpansion.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/VersionChecker.java
+++ b/src/main/java/org/omegat/util/VersionChecker.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/WikiGet.java
+++ b/src/main/java/org/omegat/util/WikiGet.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/CharacterWrapEditorKit.java
+++ b/src/main/java/org/omegat/util/gui/CharacterWrapEditorKit.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/CustomContainerFactory.java
+++ b/src/main/java/org/omegat/util/gui/CustomContainerFactory.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/CustomDockingUISettings.java
+++ b/src/main/java/org/omegat/util/gui/CustomDockingUISettings.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/DataTableStyling.java
+++ b/src/main/java/org/omegat/util/gui/DataTableStyling.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/DelegatingComboBoxRenderer.java
+++ b/src/main/java/org/omegat/util/gui/DelegatingComboBoxRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/DesktopWrapper.java
+++ b/src/main/java/org/omegat/util/gui/DesktopWrapper.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
  with fuzzy matching, translation memory, keyword search,
  glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/DragTargetOverlay.java
+++ b/src/main/java/org/omegat/util/gui/DragTargetOverlay.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/ExternalBrowserLaunchingLinkListener.java
+++ b/src/main/java/org/omegat/util/gui/ExternalBrowserLaunchingLinkListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/FontFallbackListener.java
+++ b/src/main/java/org/omegat/util/gui/FontFallbackListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/FontFallbackManager.java
+++ b/src/main/java/org/omegat/util/gui/FontFallbackManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/HintTextField.java
+++ b/src/main/java/org/omegat/util/gui/HintTextField.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/HtmlMediaSupport.java
+++ b/src/main/java/org/omegat/util/gui/HtmlMediaSupport.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/IPaneMenu.java
+++ b/src/main/java/org/omegat/util/gui/IPaneMenu.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/JTextPaneLinkifier.java
+++ b/src/main/java/org/omegat/util/gui/JTextPaneLinkifier.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/LanguageComboBoxRenderer.java
+++ b/src/main/java/org/omegat/util/gui/LanguageComboBoxRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/MenuItemPager.java
+++ b/src/main/java/org/omegat/util/gui/MenuItemPager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/NoWrapEditorKit.java
+++ b/src/main/java/org/omegat/util/gui/NoWrapEditorKit.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/OSXIntegration.java
+++ b/src/main/java/org/omegat/util/gui/OSXIntegration.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/OmegaTFileChooser.java
+++ b/src/main/java/org/omegat/util/gui/OmegaTFileChooser.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/OpenProjectFileChooser.java
+++ b/src/main/java/org/omegat/util/gui/OpenProjectFileChooser.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/ReasonablySizedPanel.java
+++ b/src/main/java/org/omegat/util/gui/ReasonablySizedPanel.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/ResourcesUtil.java
+++ b/src/main/java/org/omegat/util/gui/ResourcesUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/RoundedCornerBorder.java
+++ b/src/main/java/org/omegat/util/gui/RoundedCornerBorder.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/SoundActionListener.java
+++ b/src/main/java/org/omegat/util/gui/SoundActionListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/StaticUIUtils.java
+++ b/src/main/java/org/omegat/util/gui/StaticUIUtils.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/Styles.java
+++ b/src/main/java/org/omegat/util/gui/Styles.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/TableColumnSizer.java
+++ b/src/main/java/org/omegat/util/gui/TableColumnSizer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/TextUtil.java
+++ b/src/main/java/org/omegat/util/gui/TextUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/TokenizerComboBoxRenderer.java
+++ b/src/main/java/org/omegat/util/gui/TokenizerComboBoxRenderer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/TooltipAttribute.java
+++ b/src/main/java/org/omegat/util/gui/TooltipAttribute.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/UIDesignManager.java
+++ b/src/main/java/org/omegat/util/gui/UIDesignManager.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/UIThreadsUtil.java
+++ b/src/main/java/org/omegat/util/gui/UIThreadsUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/gui/ViewFactoryHelper.java
+++ b/src/main/java/org/omegat/util/gui/ViewFactoryHelper.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/html/EntityUtil.java
+++ b/src/main/java/org/omegat/util/html/EntityUtil.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/logging/OmegaTFileHandler.java
+++ b/src/main/java/org/omegat/util/logging/OmegaTFileHandler.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/logging/OmegaTLogFormatter.java
+++ b/src/main/java/org/omegat/util/logging/OmegaTLogFormatter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/xml/DefaultEntityFilter.java
+++ b/src/main/java/org/omegat/util/xml/DefaultEntityFilter.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/xml/XMLAttribute.java
+++ b/src/main/java/org/omegat/util/xml/XMLAttribute.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/xml/XMLBlock.java
+++ b/src/main/java/org/omegat/util/xml/XMLBlock.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/xml/XMLReader.java
+++ b/src/main/java/org/omegat/util/xml/XMLReader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/main/java/org/omegat/util/xml/XMLStreamReader.java
+++ b/src/main/java/org/omegat/util/xml/XMLStreamReader.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/MainTest.java
+++ b/src/test/java/org/omegat/MainTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/cli/CommandCommonTest.java
+++ b/src/test/java/org/omegat/cli/CommandCommonTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/cli/LegacyParametersTest.java
+++ b/src/test/java/org/omegat/cli/LegacyParametersTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/DistributionSmokeTests.java
+++ b/src/test/java/org/omegat/core/DistributionSmokeTests.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/KnownExceptionTest.java
+++ b/src/test/java/org/omegat/core/KnownExceptionTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/MemoryStressTests.java
+++ b/src/test/java/org/omegat/core/MemoryStressTests.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/ModuleDistributionSmokeTest.java
+++ b/src/test/java/org/omegat/core/ModuleDistributionSmokeTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/AutoTmxTest.java
+++ b/src/test/java/org/omegat/core/data/AutoTmxTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/ExternalTMFactoryTest.java
+++ b/src/test/java/org/omegat/core/data/ExternalTMFactoryTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/MergeTest.java
+++ b/src/test/java/org/omegat/core/data/MergeTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/NotLoadedProjectTest.java
+++ b/src/test/java/org/omegat/core/data/NotLoadedProjectTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/PluginInformationTest.java
+++ b/src/test/java/org/omegat/core/data/PluginInformationTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/ProjectPropertiesTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectPropertiesTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/ProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectReloadLeakTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/RealProjectTest.java
+++ b/src/test/java/org/omegat/core/data/RealProjectTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/TmxComplianceBase.java
+++ b/src/test/java/org/omegat/core/data/TmxComplianceBase.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/TmxComplianceTests.java
+++ b/src/test/java/org/omegat/core/data/TmxComplianceTests.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/TmxSegmentationTest.java
+++ b/src/test/java/org/omegat/core/data/TmxSegmentationTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/data/TokenTest.java
+++ b/src/test/java/org/omegat/core/data/TokenTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/dictionaries/DictionariesManagerTest.java
+++ b/src/test/java/org/omegat/core/dictionaries/DictionariesManagerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/dictionaries/DictionaryDataTest.java
+++ b/src/test/java/org/omegat/core/dictionaries/DictionaryDataTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/dictionaries/LingvoDSLTest.java
+++ b/src/test/java/org/omegat/core/dictionaries/LingvoDSLTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/dictionaries/OnlineDictionaryTest.java
+++ b/src/test/java/org/omegat/core/dictionaries/OnlineDictionaryTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/dictionaries/StarDictTest.java
+++ b/src/test/java/org/omegat/core/dictionaries/StarDictTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/dictionaries/package-info.java
+++ b/src/test/java/org/omegat/core/dictionaries/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/machinetranslators/MachineTranslatorsManagerTest.java
+++ b/src/test/java/org/omegat/core/machinetranslators/MachineTranslatorsManagerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/matching/LevenshteinDistanceTest.java
+++ b/src/test/java/org/omegat/core/matching/LevenshteinDistanceTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/segmentation/SRXTest.java
+++ b/src/test/java/org/omegat/core/segmentation/SRXTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/segmentation/SegmenterTest.java
+++ b/src/test/java/org/omegat/core/segmentation/SegmenterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/spellchecker/SpellCheckerManagerTest.java
+++ b/src/test/java/org/omegat/core/spellchecker/SpellCheckerManagerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/CalcMatchStatisticsTest.java
+++ b/src/test/java/org/omegat/core/statistics/CalcMatchStatisticsTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  *  OmegaT - Computer Assisted Translation (CAT) tool
  *           with fuzzy matching, translation memory, keyword search,
  *           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/CalcStandardStatisticsTest.java
+++ b/src/test/java/org/omegat/core/statistics/CalcStandardStatisticsTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  *  OmegaT - Computer Assisted Translation (CAT) tool
  *           with fuzzy matching, translation memory, keyword search,
  *           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/FindMatchesNumbersLoadTest.java
+++ b/src/test/java/org/omegat/core/statistics/FindMatchesNumbersLoadTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/FindMatchesNumbersTest.java
+++ b/src/test/java/org/omegat/core/statistics/FindMatchesNumbersTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/FindMatchesTest.java
+++ b/src/test/java/org/omegat/core/statistics/FindMatchesTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/StatisticsTest.java
+++ b/src/test/java/org/omegat/core/statistics/StatisticsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/StatsResultTest.java
+++ b/src/test/java/org/omegat/core/statistics/StatsResultTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/TestingParseCallback.java
+++ b/src/test/java/org/omegat/core/statistics/TestingParseCallback.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  *  OmegaT - Computer Assisted Translation (CAT) tool
  *           with fuzzy matching, translation memory, keyword search,
  *           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/TestingProject.java
+++ b/src/test/java/org/omegat/core/statistics/TestingProject.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  *  OmegaT - Computer Assisted Translation (CAT) tool
  *           with fuzzy matching, translation memory, keyword search,
  *           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/statistics/TestingStatsConsumer.java
+++ b/src/test/java/org/omegat/core/statistics/TestingStatsConsumer.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  *  OmegaT - Computer Assisted Translation (CAT) tool
  *           with fuzzy matching, translation memory, keyword search,
  *           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/tagvalidation/TagRepairTest.java
+++ b/src/test/java/org/omegat/core/tagvalidation/TagRepairTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/tagvalidation/TagValidationTest.java
+++ b/src/test/java/org/omegat/core/tagvalidation/TagValidationTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/AbstractRemoteRepository2IT.java
+++ b/src/test/java/org/omegat/core/team2/AbstractRemoteRepository2IT.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/GitRemoteRepository2IT.java
+++ b/src/test/java/org/omegat/core/team2/GitRemoteRepository2IT.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/RebaseAndCommitTest.java
+++ b/src/test/java/org/omegat/core/team2/RebaseAndCommitTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/RemoteRepositoryFactoryTest.java
+++ b/src/test/java/org/omegat/core/team2/RemoteRepositoryFactoryTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/RemoteRepositoryProvider2Test.java
+++ b/src/test/java/org/omegat/core/team2/RemoteRepositoryProvider2Test.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/RemoteRepositoryProviderTest.java
+++ b/src/test/java/org/omegat/core/team2/RemoteRepositoryProviderTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/SVNRemoteRepository2IT.java
+++ b/src/test/java/org/omegat/core/team2/SVNRemoteRepository2IT.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/impl/GITCredentialsProviderTest.java
+++ b/src/test/java/org/omegat/core/team2/impl/GITCredentialsProviderTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/core/team2/impl/HTTPRemoteRepositoryTest.java
+++ b/src/test/java/org/omegat/core/team2/impl/HTTPRemoteRepositoryTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/externalfinder/ExternalFinderTest.java
+++ b/src/test/java/org/omegat/externalfinder/ExternalFinderTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/AndroidFilterTest.java
+++ b/src/test/java/org/omegat/filters/AndroidFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/DocBookFilterTest.java
+++ b/src/test/java/org/omegat/filters/DocBookFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/DokuWikiFilterTest.java
+++ b/src/test/java/org/omegat/filters/DokuWikiFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/FiltersTest.java
+++ b/src/test/java/org/omegat/filters/FiltersTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/HHCFilter2Test.java
+++ b/src/test/java/org/omegat/filters/HHCFilter2Test.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/HTMLFilter2Test.java
+++ b/src/test/java/org/omegat/filters/HTMLFilter2Test.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/HelpAndManualFilterTest.java
+++ b/src/test/java/org/omegat/filters/HelpAndManualFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/ILIASFilterTest.java
+++ b/src/test/java/org/omegat/filters/ILIASFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/INIFilterTest.java
+++ b/src/test/java/org/omegat/filters/INIFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/LatexFilterTest.java
+++ b/src/test/java/org/omegat/filters/LatexFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/MagentoFilterTest.java
+++ b/src/test/java/org/omegat/filters/MagentoFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/MoodlePHPFilterTest.java
+++ b/src/test/java/org/omegat/filters/MoodlePHPFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/MozillaDTDFilterTest.java
+++ b/src/test/java/org/omegat/filters/MozillaDTDFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/MozillaFTLFilterTest.java
+++ b/src/test/java/org/omegat/filters/MozillaFTLFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/OpenDocFilterTest.java
+++ b/src/test/java/org/omegat/filters/OpenDocFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/OpenXMLFilterTest.java
+++ b/src/test/java/org/omegat/filters/OpenXMLFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/POFilterTest.java
+++ b/src/test/java/org/omegat/filters/POFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/PdfFilterTest.java
+++ b/src/test/java/org/omegat/filters/PdfFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/RcFilterTest.java
+++ b/src/test/java/org/omegat/filters/RcFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/RelaxNGFilterTest.java
+++ b/src/test/java/org/omegat/filters/RelaxNGFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/ResXFilterTest.java
+++ b/src/test/java/org/omegat/filters/ResXFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/ResourceBundleFilterTest.java
+++ b/src/test/java/org/omegat/filters/ResourceBundleFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/Scribus.java
+++ b/src/test/java/org/omegat/filters/Scribus.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/SrtFilterTest.java
+++ b/src/test/java/org/omegat/filters/SrtFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/SvgFilterTest.java
+++ b/src/test/java/org/omegat/filters/SvgFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/TestFilterBase.java
+++ b/src/test/java/org/omegat/filters/TestFilterBase.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/TextFilterTest.java
+++ b/src/test/java/org/omegat/filters/TextFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/WiXFilterTest.java
+++ b/src/test/java/org/omegat/filters/WiXFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/Wordpress.java
+++ b/src/test/java/org/omegat/filters/Wordpress.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/XHTMLFilterTest.java
+++ b/src/test/java/org/omegat/filters/XHTMLFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/XLIFFFilterTest.java
+++ b/src/test/java/org/omegat/filters/XLIFFFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/XMLSpreadsheetTest.java
+++ b/src/test/java/org/omegat/filters/XMLSpreadsheetTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters/YamlFilterTest.java
+++ b/src/test/java/org/omegat/filters/YamlFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
          with fuzzy matching, translation memory, keyword search,
          glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters2/latex/LatexFilterUnitTest.java
+++ b/src/test/java/org/omegat/filters2/latex/LatexFilterUnitTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters2/master/FilterMasterTest.java
+++ b/src/test/java/org/omegat/filters2/master/FilterMasterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters2/master/PluginUtilsTest.java
+++ b/src/test/java/org/omegat/filters2/master/PluginUtilsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters2/text/LineLengthLimitWriterTest.java
+++ b/src/test/java/org/omegat/filters2/text/LineLengthLimitWriterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters3/xml/XMLFilterTest.java
+++ b/src/test/java/org/omegat/filters3/xml/XMLFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters4/MsOfficeFileFilterTest.java
+++ b/src/test/java/org/omegat/filters4/MsOfficeFileFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters4/Xliff1FilterTest.java
+++ b/src/test/java/org/omegat/filters4/Xliff1FilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters4/Xliff2FilterTest.java
+++ b/src/test/java/org/omegat/filters4/Xliff2FilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/filters4/xml/openxml/OpenXmlFilterTest.java
+++ b/src/test/java/org/omegat/filters4/xml/openxml/OpenXmlFilterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/dialogs/DialogsTest.java
+++ b/src/test/java/org/omegat/gui/dialogs/DialogsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/BoundEditorColorsTest.java
+++ b/src/test/java/org/omegat/gui/editor/BoundEditorColorsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/CollapsibleBarTest.java
+++ b/src/test/java/org/omegat/gui/editor/CollapsibleBarTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/Document3BoundColorsTest.java
+++ b/src/test/java/org/omegat/gui/editor/Document3BoundColorsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/DocumentFilter3Test.java
+++ b/src/test/java/org/omegat/gui/editor/DocumentFilter3Test.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/EditorControllerTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorControllerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/EditorEnforcedSegmentTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorEnforcedSegmentTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorProjectReloadLeakTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/EditorUtilsTest.java
+++ b/src/test/java/org/omegat/gui/editor/EditorUtilsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/SegmentExportImportTest.java
+++ b/src/test/java/org/omegat/gui/editor/SegmentExportImportTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/TestingProject.java
+++ b/src/test/java/org/omegat/gui/editor/TestingProject.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/TestingProjectProperties.java
+++ b/src/test/java/org/omegat/gui/editor/TestingProjectProperties.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/chartable/CharTableModelTest.java
+++ b/src/test/java/org/omegat/gui/editor/chartable/CharTableModelTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/history/WordCompleterTest.java
+++ b/src/test/java/org/omegat/gui/editor/history/WordCompleterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/history/WordPredictorTest.java
+++ b/src/test/java/org/omegat/gui/editor/history/WordPredictorTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/mark/AltTranslationsMarkerTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/AltTranslationsMarkerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/editor/mark/MarkerBoundColorsTest.java
+++ b/src/test/java/org/omegat/gui/editor/mark/MarkerBoundColorsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerDisposeTest.java
+++ b/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerDisposeTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerTest.java
+++ b/src/test/java/org/omegat/gui/filelist/ProjectFilesListControllerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/FindGlossaryThreadTest.java
+++ b/src/test/java/org/omegat/gui/glossary/FindGlossaryThreadTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/GlossaryAutoCompleterViewTest.java
+++ b/src/test/java/org/omegat/gui/glossary/GlossaryAutoCompleterViewTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/GlossaryEntryTest.java
+++ b/src/test/java/org/omegat/gui/glossary/GlossaryEntryTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/GlossaryReaderCSVTest.java
+++ b/src/test/java/org/omegat/gui/glossary/GlossaryReaderCSVTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/GlossaryReaderTBXTest.java
+++ b/src/test/java/org/omegat/gui/glossary/GlossaryReaderTBXTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
+++ b/src/test/java/org/omegat/gui/glossary/GlossaryReaderTSVTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/GlossarySearcherTest.java
+++ b/src/test/java/org/omegat/gui/glossary/GlossarySearcherTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/GlossaryTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/glossary/GlossaryTextAreaTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/glossary/TransTipsMarkerTest.java
+++ b/src/test/java/org/omegat/gui/glossary/TransTipsMarkerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/issues/IssueCheckerTest.java
+++ b/src/test/java/org/omegat/gui/issues/IssueCheckerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/issues/IssueProvidersTest.java
+++ b/src/test/java/org/omegat/gui/issues/IssueProvidersTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/issues/IssuesTableModelTest.java
+++ b/src/test/java/org/omegat/gui/issues/IssuesTableModelTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/issues/IssuesTypeListModelTest.java
+++ b/src/test/java/org/omegat/gui/issues/IssuesTypeListModelTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/issues/SimpleIssueTest.java
+++ b/src/test/java/org/omegat/gui/issues/SimpleIssueTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/issues/TerminologyIssueProviderTest.java
+++ b/src/test/java/org/omegat/gui/issues/TerminologyIssueProviderTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/issues/TestingIssue.java
+++ b/src/test/java/org/omegat/gui/issues/TestingIssue.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/issues/TestingIssueProvider.java
+++ b/src/test/java/org/omegat/gui/issues/TestingIssueProvider.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/main/MainWindowMenuTest.java
+++ b/src/test/java/org/omegat/gui/main/MainWindowMenuTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/matches/FindMatchesThreadTest.java
+++ b/src/test/java/org/omegat/gui/matches/FindMatchesThreadTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/matches/MatchScoresTooltipTest.java
+++ b/src/test/java/org/omegat/gui/matches/MatchScoresTooltipTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/matches/MatchesTextAreaTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/matches/MatchesVarExpansionTest.java
+++ b/src/test/java/org/omegat/gui/matches/MatchesVarExpansionTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/notes/NotesTextAreaTest.java
+++ b/src/test/java/org/omegat/gui/notes/NotesTextAreaTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/preferences/RequiresEditorRefreshTest.java
+++ b/src/test/java/org/omegat/gui/preferences/RequiresEditorRefreshTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/preferences/view/CustomColorSelectionControllerTest.java
+++ b/src/test/java/org/omegat/gui/preferences/view/CustomColorSelectionControllerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/scripting/ScriptItemTest.java
+++ b/src/test/java/org/omegat/gui/scripting/ScriptItemTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/scripting/ScriptRunnerTest.java
+++ b/src/test/java/org/omegat/gui/scripting/ScriptRunnerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/scripting/ScriptingTest.java
+++ b/src/test/java/org/omegat/gui/scripting/ScriptingTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/search/SearchWindowTest.java
+++ b/src/test/java/org/omegat/gui/search/SearchWindowTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/gui/shortcuts/PropertiesShortcutsTest.java
+++ b/src/test/java/org/omegat/gui/shortcuts/PropertiesShortcutsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/languagetools/FalseFriendsTest.java
+++ b/src/test/java/org/omegat/languagetools/FalseFriendsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/languagetools/LanguageToolTest.java
+++ b/src/test/java/org/omegat/languagetools/LanguageToolTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/tokenizer/BaseTokenizerTest.java
+++ b/src/test/java/org/omegat/tokenizer/BaseTokenizerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/tokenizer/DefaultTokenizerTest.java
+++ b/src/test/java/org/omegat/tokenizer/DefaultTokenizerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/tokenizer/HunspellTokenizerTest.java
+++ b/src/test/java/org/omegat/tokenizer/HunspellTokenizerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/tokenizer/TokenizerTest.java
+++ b/src/test/java/org/omegat/tokenizer/TokenizerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/tokenizer/TokenizerTestBase.java
+++ b/src/test/java/org/omegat/tokenizer/TokenizerTestBase.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/BiDiUtilsTest.java
+++ b/src/test/java/org/omegat/util/BiDiUtilsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/FileUtilTest.java
+++ b/src/test/java/org/omegat/util/FileUtilTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/HttpConnectionUtilsTest.java
+++ b/src/test/java/org/omegat/util/HttpConnectionUtilsTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  *  OmegaT - Computer Assisted Translation (CAT) tool
  *           with fuzzy matching, translation memory, keyword search,
  *           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/JsonParserTest.java
+++ b/src/test/java/org/omegat/util/JsonParserTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/LanguageTest.java
+++ b/src/test/java/org/omegat/util/LanguageTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/MagicCommentTest.java
+++ b/src/test/java/org/omegat/util/MagicCommentTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/MixedEolHandlingReaderTest.java
+++ b/src/test/java/org/omegat/util/MixedEolHandlingReaderTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/NumeralValueParserTest.java
+++ b/src/test/java/org/omegat/util/NumeralValueParserTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/OStringsTest.java
+++ b/src/test/java/org/omegat/util/OStringsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/PatternConstsTest.java
+++ b/src/test/java/org/omegat/util/PatternConstsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/PluginInstallerTest.java
+++ b/src/test/java/org/omegat/util/PluginInstallerTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  *  OmegaT - Computer Assisted Translation (CAT) tool
  *           with fuzzy matching, translation memory, keyword search,
  *           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/PreferencesTest.java
+++ b/src/test/java/org/omegat/util/PreferencesTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/ProjectFileStorageTest.java
+++ b/src/test/java/org/omegat/util/ProjectFileStorageTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/StaticUtilsTest.java
+++ b/src/test/java/org/omegat/util/StaticUtilsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/StringUtilTest.java
+++ b/src/test/java/org/omegat/util/StringUtilTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/TMXDateParserTest.java
+++ b/src/test/java/org/omegat/util/TMXDateParserTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
 OmegaT - Computer Assisted Translation (CAT) tool
          with fuzzy matching, translation memory, keyword search,
          glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/TMXReaderTest.java
+++ b/src/test/java/org/omegat/util/TMXReaderTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/TMXWriterTest.java
+++ b/src/test/java/org/omegat/util/TMXWriterTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/TagUtilTest.java
+++ b/src/test/java/org/omegat/util/TagUtilTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/VersionTest.java
+++ b/src/test/java/org/omegat/util/VersionTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/XMLStreamReaderTest.java
+++ b/src/test/java/org/omegat/util/XMLStreamReaderTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/editor/EditorUtilsTest.java
+++ b/src/test/java/org/omegat/util/editor/EditorUtilsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/gui/StaticUIUtilsTest.java
+++ b/src/test/java/org/omegat/util/gui/StaticUIUtilsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/gui/StylesBoundAttributesTest.java
+++ b/src/test/java/org/omegat/util/gui/StylesBoundAttributesTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/org/omegat/util/gui/StylesTest.java
+++ b/src/test/java/org/omegat/util/gui/StylesTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/svn/BundleTest.java
+++ b/src/test/java/svn/BundleTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/test/java/svn/PluginsTest.java
+++ b/src/test/java/svn/PluginsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/TestMainInitializer.java
+++ b/src/testAcceptance/java/org/omegat/TestMainInitializer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/cli/ConsolePseudoTranslateTest.java
+++ b/src/testAcceptance/java/org/omegat/cli/ConsolePseudoTranslateTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/cli/ConsoleStatsTest.java
+++ b/src/testAcceptance/java/org/omegat/cli/ConsoleStatsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/cli/ConsoleTeamInitTest.java
+++ b/src/testAcceptance/java/org/omegat/cli/ConsoleTeamInitTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/cli/ConsoleTestsCommon.java
+++ b/src/testAcceptance/java/org/omegat/cli/ConsoleTestsCommon.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/cli/ConsoleTranslateTest.java
+++ b/src/testAcceptance/java/org/omegat/cli/ConsoleTranslateTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/externalfinder/ExternalFinderTest.java
+++ b/src/testAcceptance/java/org/omegat/externalfinder/ExternalFinderTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/align/AlignerWindowTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/align/AlignerWindowTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/dialogs/AboutDialogTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/dialogs/AboutDialogTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/dialogs/ConflictDialogTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/dialogs/ConflictDialogTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/dialogs/ProjectPropertiesDialogTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/editor/EditorIdenticalTranslationTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/editor/EditorIdenticalTranslationTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/editor/EditorTestBase.java
+++ b/src/testAcceptance/java/org/omegat/gui/editor/EditorTestBase.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/editor/EditorTextAreaIntroTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/editor/EditorTextAreaIntroTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/editor/EditorTextLoadedTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/editor/EditorTextLoadedTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/editor/EditorUtilsGUITest.java
+++ b/src/testAcceptance/java/org/omegat/gui/editor/EditorUtilsGUITest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/editor/TestingEditorEntryListener.java
+++ b/src/testAcceptance/java/org/omegat/gui/editor/TestingEditorEntryListener.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/exttrans/MachineTranslateTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/exttrans/MachineTranslateTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/glossary/GlossaryTextTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/glossary/GlossaryTextTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/issues/IssuesPanelTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/issues/IssuesPanelTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/main/TestCoreGUI.java
+++ b/src/testAcceptance/java/org/omegat/gui/main/TestCoreGUI.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/main/TestMainWindow.java
+++ b/src/testAcceptance/java/org/omegat/gui/main/TestMainWindow.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/main/TestMainWindowMenuHandler.java
+++ b/src/testAcceptance/java/org/omegat/gui/main/TestMainWindowMenuHandler.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/matches/FuzzyMatchesSegmentsTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/matches/FuzzyMatchesSegmentsTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/matches/MatchesTextExternalTmTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/matches/MatchesTextExternalTmTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/matches/MatchesTextTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/matches/MatchesTextTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/properties/SegmentPropertiesAreaTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/properties/SegmentPropertiesAreaTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/gui/search/SearchWindowTest.java
+++ b/src/testAcceptance/java/org/omegat/gui/search/SearchWindowTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testAcceptance/java/org/omegat/machinetranslators/dummy/package-info.java
+++ b/src/testAcceptance/java/org/omegat/machinetranslators/dummy/package-info.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/core/TestCore.java
+++ b/src/testFixtures/java/org/omegat/core/TestCore.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/core/TestCoreInitializer.java
+++ b/src/testFixtures/java/org/omegat/core/TestCoreInitializer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/core/data/TMXEntryFactoryForTest.java
+++ b/src/testFixtures/java/org/omegat/core/data/TMXEntryFactoryForTest.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/core/data/TestCoreState.java
+++ b/src/testFixtures/java/org/omegat/core/data/TestCoreState.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/core/data/TestRuntimePreferenceStore.java
+++ b/src/testFixtures/java/org/omegat/core/data/TestRuntimePreferenceStore.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/gui/main/MainMenuStub.java
+++ b/src/testFixtures/java/org/omegat/gui/main/MainMenuStub.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/gui/main/TestingMainMenu.java
+++ b/src/testFixtures/java/org/omegat/gui/main/TestingMainMenu.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/languages/LanguageModuleTestBase.java
+++ b/src/testFixtures/java/org/omegat/languages/LanguageModuleTestBase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   OmegaT - Computer Assisted Translation (CAT) tool
            with fuzzy matching, translation memory, keyword search,
            glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/util/LocaleRule.java
+++ b/src/testFixtures/java/org/omegat/util/LocaleRule.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/src/testFixtures/java/org/omegat/util/TestPreferences.java
+++ b/src/testFixtures/java/org/omegat/util/TestPreferences.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.
@@ -26,8 +26,6 @@
 package org.omegat.util;
 
 import java.util.List;
-
-import org.omegat.util.PreferencesImpl.IPrefsPersistence;
 
 /**
  * An isolated preferences store for tests.

--- a/src/testFixtures/java/org/omegat/util/TestPreferencesInitializer.java
+++ b/src/testFixtures/java/org/omegat/util/TestPreferencesInitializer.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegration.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
+++ b/test-integration/src/org/omegat/core/data/TestTeamIntegrationChild.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/test-integration/src/org/omegat/core/team2/operation/TestingGlossaryRebaseOperation.java
+++ b/test-integration/src/org/omegat/core/team2/operation/TestingGlossaryRebaseOperation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.

--- a/test-integration/src/org/omegat/core/team2/operation/TestingTMXRebaseOperation.java
+++ b/test-integration/src/org/omegat/core/team2/operation/TestingTMXRebaseOperation.java
@@ -1,4 +1,4 @@
-/**************************************************************************
+/*
  OmegaT - Computer Assisted Translation (CAT) tool
           with fuzzy matching, translation memory, keyword search,
           glossaries, and translation leveraging into updated projects.


### PR DESCRIPTION

Copyright header is not javadoc, but in historical reason, we uses `/*****` for a first line. This cause javadoc error.

## Pull request type

- Build and release changes -> [build/release]

## Which ticket is resolved?

none; dev-ML discussion
https://sourceforge.net/p/omegat/mailman/message/59361184/ explain it.

## What does this PR change?

- replace first line of java files to be normal comment `/*`


## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
