### PR TITLE
fix(team): auto reconnect

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -121,7 +121,7 @@
 
     <suppress files="StaticUtils\.java" checks="EmptyStatement" lines="158,162,549"/>
     <suppress files="StaticUtils\.java" checks="LineLength" lines="715"/>
-    <suppress files="PatternConsts\.java" checks="LineLength" lines="50,259,294"/>
+    <suppress files="PatternConsts\.java" checks="LineLength" lines="51"/>
 
     <!-- repository -->
     <suppress checks="(ConstantName|OperatorWrap)" files="GITCredentialProvider\.java" lines="89,90,91,94,95"/>

--- a/src/docs/manual/en/Dialogs_ProjectProperties.xml
+++ b/src/docs/manual/en/Dialogs_ProjectProperties.xml
@@ -332,6 +332,30 @@
                </note>
             </listitem>
          </varlistentry>
+         <varlistentry xml:id="dialogs.project.properties.tag.definitions">
+            <term xml:id="dialogs.project.properties.tag.definitions.title">
+               <guibutton>Local Tag Definitions...</guibutton>
+            </term>
+            <listitem>
+               <para>By default, the custom tag and flagged text definitions are
+                  		  global and shared by all projects. They are found in the
+                  <link linkend="dialogs.preferences.tag.processing" endterm="dialogs.preferences.tag.processing.title"></link>
+                  		  preferences.</para>
+               <para>Use this button to create local tag definitions specific to
+                  		  your project. Check the
+                  <option>Use local tag definitions</option> box, and adjust the two
+                  		  regular expressions as desired. An empty field means the project
+                  		  does not use that expression at all.</para>
+               <para>The project will store the expressions in the
+                  <link linkend="project.folder.omegat.tag.patterns" endterm="project.folder.omegat.tag.patterns.title"></link> file located in its
+                  <link linkend="project.folder.omegat.folder" endterm="project.folder.omegat.folder.title"></link> folder. These
+                  		  settings will supersede the global tag definitions.</para>
+               <note>
+                  <para>To disable local tag definitions, uncheck the box, or remove
+                     			that file while the project is closed.</para>
+               </note>
+            </listitem>
+         </varlistentry>
       </variablelist>
    </section>
    <section xml:id="dialogs.project.properties.file.locations">

--- a/src/docs/manual/en/HowTo_UseTeamProject.xml
+++ b/src/docs/manual/en/HowTo_UseTeamProject.xml
@@ -120,8 +120,9 @@
                <filename>omegat.project</filename>
                file and the optional use of special files for project-specific
                filters or segmentation rules.</para>
-            <para>Project-specific file filter settings and segmentation rules
-               are negotiated with the team instead of being silently
+            <para>Project-specific file filter settings, segmentation rules
+               and tag definitions are negotiated with the team instead of
+               being silently
                overwritten: after changing them in the project properties,
                OmegaT offers to share the change, and when the local version
                differs from the team version on opening the project, it asks

--- a/src/docs/manual/en/HowTo_UseTeamProject.xml
+++ b/src/docs/manual/en/HowTo_UseTeamProject.xml
@@ -116,10 +116,17 @@
          <term>Team project configuration</term>
          <listitem>
             <para>As in regular local projects, the configuration of the team
-               project is defined by the contents of the 
+               project is defined by the contents of the
                <filename>omegat.project</filename>
                file and the optional use of special files for project-specific
                filters or segmentation rules.</para>
+            <para>Project-specific file filter settings and segmentation rules
+               are negotiated with the team instead of being silently
+               overwritten: after changing them in the project properties,
+               OmegaT offers to share the change, and when the local version
+               differs from the team version on opening the project, it asks
+               whether to share the local version, use the team version, or
+               keep the local version for the current session.</para>
             <para>The first time the project is downloaded, OmegaT retrieves the
                
                <filename>omegat.project</filename> file from the server. This file

--- a/src/docs/manual/en/OmegaT_Preferences.xml
+++ b/src/docs/manual/en/OmegaT_Preferences.xml
@@ -1104,6 +1104,10 @@
                   <literal>|</literal> to have OmegaT consider
                   		  the two tags: 
                   <userinput>(\d+)|(&lt;/?[^&gt;]+&gt;)</userinput>.</para>
+               <para>Individual projects can replace this expression and the 
+                  <option>Flagged text</option> expression with their own using the 
+                  <link linkend="dialogs.project.properties.tag.definitions" endterm="dialogs.project.properties.tag.definitions.title"></link>
+                  		  button in the project properties.</para>
                <para>See the 
                   <link linkend="app.regex" endterm="app.regex.title"></link>
                   		  appendix for details.</para>

--- a/src/docs/manual/en/OmegaT_ProjectFolder.xml
+++ b/src/docs/manual/en/OmegaT_ProjectFolder.xml
@@ -551,6 +551,12 @@
                <para>This file contains the project-specific external searches.</para>
             </listitem>
          </varlistentry>
+         <varlistentry xml:id="project.folder.omegat.tag.patterns">
+            <term xml:id="project.folder.omegat.tag.patterns.title">tag_patterns.xml</term>
+            <listitem>
+               <para>This file contains the project-specific tag definitions.</para>
+            </listitem>
+         </varlistentry>
          <varlistentry xml:id="project.folder.omegat.file.order">
             <term xml:id="project.folder.omegat.file.order.title">files_order.txt</term>
             <listitem>

--- a/src/main/java/org/omegat/core/data/IProject.java
+++ b/src/main/java/org/omegat/core/data/IProject.java
@@ -29,6 +29,7 @@
 package org.omegat.core.data;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -106,6 +107,51 @@ public interface IProject {
      * @throws Exception if any error occurs during the commit process
      */
     void commitSourceFiles() throws Exception;
+
+    /**
+     * Sets a registered team project setting and commits the project
+     * settings file (omegat/project_settings.properties) to the team
+     * repository, so the whole team gets the value. The setting lives in
+     * its own file because older OmegaT versions reject unknown elements in
+     * omegat.project but ignore extra files. No operation for non-team
+     * projects. Must run through Core.executeExclusively, like saveProject.
+     *
+     * @param key
+     *            key of a setting registered in {@link TeamSettingsRegistry}
+     * @param value
+     *            raw value to distribute, null for the default
+     * @throws Exception
+     *             if writing or committing the file fails
+     */
+    default void publishProjectSetting(String key, @Nullable String value) throws Exception {
+    }
+
+    /**
+     * Sets a registered team project setting for this session and writes it
+     * to the local project settings file only: the next open of the team
+     * project supersedes it with the remote value again. No operation for
+     * non-team projects. Must run through Core.executeExclusively, like
+     * saveProject.
+     *
+     * @param key
+     *            key of a setting registered in {@link TeamSettingsRegistry}
+     * @param value
+     *            raw value to restore, null for the default
+     * @throws Exception
+     *             if writing the file fails
+     */
+    default void useLocalProjectSetting(String key, @Nullable String value) throws Exception {
+    }
+
+    /**
+     * The local raw values that the team values superseded during the last
+     * load of a team project, keyed by setting key; an entry with null value
+     * means the local side had the default. Empty when everything agreed,
+     * always empty for non-team projects.
+     */
+    default Map<String, @Nullable String> getSupersededLocalSettings() {
+        return Collections.emptyMap();
+    }
 
     /**
      * Get project properties.

--- a/src/main/java/org/omegat/core/data/IProject.java
+++ b/src/main/java/org/omegat/core/data/IProject.java
@@ -7,6 +7,7 @@
                2010 Didier Briel
                2014-2015 Alex Buloichik
                2017 Didier Briel
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -71,6 +72,29 @@ public interface IProject {
      * Execute synchronization.
      */
     void teamSync();
+
+    /**
+     * Check whether lost team synchronization looks restorable: the project is
+     * a team project, currently offline, and the remote hosts accept
+     * connections again. Called from the auto-save thread WITHOUT the project
+     * lock, so implementations must not touch project data; a short network
+     * probe is allowed. Restoring happens through
+     * {@link #saveProject(boolean)} with team synchronization.
+     */
+    default boolean canRestoreTeamSync() {
+        return false;
+    }
+
+    /**
+     * Restore lost team synchronization: one save with team synchronization
+     * through the regular save path. Unlike a manual save, a failure must not
+     * interrupt the user: implementations report it without a modal dialog
+     * and back off. The auto-save thread calls it after
+     * {@link #canRestoreTeamSync()} approved.
+     */
+    default void restoreTeamSync() {
+        saveProject(true);
+    }
 
     /**
      * Close project.

--- a/src/main/java/org/omegat/core/data/ProjectProperties.java
+++ b/src/main/java/org/omegat/core/data/ProjectProperties.java
@@ -48,6 +48,7 @@ import org.omegat.util.Log;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
 import org.omegat.util.StringUtil;
+import org.omegat.util.TagPatternsStorage;
 
 import gen.core.filters.Filters;
 import gen.core.project.RepositoryDefinition;
@@ -111,6 +112,7 @@ public class ProjectProperties {
 
         loadProjectSRX();
         loadProjectFiltersOrDefaults();
+        loadProjectTagPatterns();
 
         setSourceTokenizer(PluginUtils.getTokenizerClassForLanguage(getSourceLanguage()));
         setTargetTokenizer(PluginUtils.getTokenizerClassForLanguage(getTargetLanguage()));
@@ -589,6 +591,68 @@ public class ProjectProperties {
         this.externalCommand = command;
     }
 
+    /**
+     * Loads tag_patterns.xml if found in the /omegat folder of the project
+     * (feature requests #926, #1427, #824). An unreadable file is logged and
+     * treated as no override, but it is remembered so that the next save
+     * does not delete a file the user could still repair.
+     */
+    public void loadProjectTagPatterns() {
+        File configFile = new File(getProjectInternal(), TagPatternsStorage.FILE_TAG_PATTERNS);
+        TagPatternsStorage.TagPatterns patterns;
+        try {
+            patterns = TagPatternsStorage.load(configFile);
+            tagPatternsLoadFailed = false;
+        } catch (IOException e) {
+            Log.logErrorRB("LOG_PROJECT_TAG_PATTERNS_LOAD_ERROR", configFile);
+            Log.log(e);
+            patterns = null;
+            tagPatternsLoadFailed = true;
+        }
+        customTagPattern = patterns == null ? null : patterns.getCustomTagPattern();
+        removeTextPattern = patterns == null ? null : patterns.getRemoveTextPattern();
+    }
+
+    /**
+     * Whether the last attempt to read tag_patterns.xml failed. While true,
+     * the broken file must not be overwritten or deleted by a routine save.
+     */
+    public boolean isTagPatternsLoadFailed() {
+        return tagPatternsLoadFailed;
+    }
+
+    /**
+     * Clears the load-failure marker once the user has actively chosen new
+     * tag expressions, so the next save may replace the broken file.
+     */
+    public void resetTagPatternsLoadFailed() {
+        tagPatternsLoadFailed = false;
+    }
+
+    /**
+     * The project-specific custom tag regular expression, or null when the
+     * project inherits the global preference (feature requests #926, #1427).
+     */
+    public String getCustomTagPattern() {
+        return customTagPattern;
+    }
+
+    public void setCustomTagPattern(String customTagPattern) {
+        this.customTagPattern = customTagPattern;
+    }
+
+    /**
+     * The project-specific removed-text regular expression, or null when the
+     * project inherits the global preference (feature request #824).
+     */
+    public String getRemoveTextPattern() {
+        return removeTextPattern;
+    }
+
+    public void setRemoveTextPattern(String removeTextPattern) {
+        this.removeTextPattern = removeTextPattern;
+    }
+
     public boolean isProjectValid() {
         boolean returnValue;
         try {
@@ -696,6 +760,9 @@ public class ProjectProperties {
     private Filters projectFilters;
 
     private String externalCommand;
+    private String customTagPattern;
+    private String removeTextPattern;
+    private boolean tagPatternsLoadFailed;
 
     protected File projectRootDir;
     protected ProjectPath sourceDir = new ProjectPath(true);

--- a/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
+++ b/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
@@ -1,0 +1,168 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+import org.jspecify.annotations.Nullable;
+
+import org.omegat.util.Log;
+
+/**
+ * Storage of optional per-project settings in
+ * {@code omegat/project_settings.properties}. The settings live in their own
+ * file instead of {@code omegat.project} on purpose: the project file parser
+ * of released OmegaT versions rejects unknown elements, so a new element
+ * there would make the project unreadable for every team member on an older
+ * version, while an extra file in the {@code omegat} folder is ignored.
+ *
+ * The file is written deterministically (sorted keys, no timestamp comment),
+ * so distributing an unchanged file to a team repository stays recognisable
+ * as a byte-identical no-op.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class ProjectSettingsStorage {
+
+    public static final String FILE_PROJECT_SETTINGS = "project_settings.properties";
+
+    private ProjectSettingsStorage() {
+    }
+
+    /** The settings file of the given project. */
+    public static File getFile(ProjectProperties config) {
+        return new File(config.getProjectInternal(), FILE_PROJECT_SETTINGS);
+    }
+
+    /**
+     * The stored raw value of given key: null when the file or the key is
+     * absent or the file is unreadable, so callers can distinguish "not
+     * configured" from an explicit value.
+     */
+    public static @Nullable String load(ProjectProperties config, String key) {
+        File file = getFile(config);
+        if (!file.isFile()) {
+            return null;
+        }
+        Properties props = new Properties();
+        try (Reader in = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+            props.load(in);
+        } catch (IOException ex) {
+            Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+            return null;
+        }
+        String value = props.getProperty(key);
+        return value == null ? null : value.trim();
+    }
+
+    /**
+     * Store the raw value under given key (null removes the key), keeping
+     * any other keys of the file so settings can share it. Removing a key
+     * from an absent file is a no-op, so it never materialises the file.
+     */
+    public static void save(ProjectProperties config, String key, @Nullable String value)
+            throws IOException {
+        File file = getFile(config);
+        if (value == null && !file.isFile()) {
+            return;
+        }
+        Map<String, String> entries = new TreeMap<>();
+        if (file.isFile()) {
+            Properties existing = new Properties();
+            try (Reader in = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+                existing.load(in);
+            }
+            existing.stringPropertyNames().forEach(k -> entries.put(k, existing.getProperty(k)));
+        }
+        if (value == null) {
+            entries.remove(key);
+        } else {
+            entries.put(key, value);
+        }
+        File dir = file.getParentFile();
+        if (dir != null && !dir.isDirectory() && !dir.mkdirs()) {
+            throw new IOException("Cannot create " + dir);
+        }
+        try (Writer out = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+            for (Map.Entry<String, String> e : entries.entrySet()) {
+                out.write(escape(e.getKey(), true) + "=" + escape(e.getValue(), false) + "\n");
+            }
+        }
+    }
+
+    /**
+     * Escape a key or value the way {@code Properties.store} would, minus
+     * the Latin-1 escaping (the file is read and written as UTF-8), so
+     * foreign keys of other settings survive the load/save round trip
+     * unchanged.
+     */
+    private static String escape(String s, boolean isKey) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+            case '\\':
+                sb.append("\\\\");
+                break;
+            case '\t':
+                sb.append("\\t");
+                break;
+            case '\n':
+                sb.append("\\n");
+                break;
+            case '\r':
+                sb.append("\\r");
+                break;
+            case '\f':
+                sb.append("\\f");
+                break;
+            case '=':
+            case ':':
+            case '#':
+            case '!':
+                sb.append('\\').append(c);
+                break;
+            case ' ':
+                if (isKey || i == 0) {
+                    sb.append('\\');
+                }
+                sb.append(c);
+                break;
+            default:
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
+++ b/src/main/java/org/omegat/core/data/ProjectSettingsStorage.java
@@ -71,7 +71,14 @@ public final class ProjectSettingsStorage {
      * configured" from an explicit value.
      */
     public static @Nullable String load(ProjectProperties config, String key) {
-        File file = getFile(config);
+        return loadFromFile(getFile(config), key);
+    }
+
+    /**
+     * Like {@link #load}, but from an explicit settings file, e.g. the copy
+     * in a repository checkout.
+     */
+    public static @Nullable String loadFromFile(File file, String key) {
         if (!file.isFile()) {
             return null;
         }

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -252,11 +252,214 @@ public class RealProject implements IProject {
             FilterMaster.saveConfig(config.getProjectFilters(),
                     new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
             ProjectFileStorage.writeProjectFile(config);
+            persistSessionSettings(config, supersededLocalSettings.keySet());
         } finally {
             lockProject();
         }
         Preferences.setPreference(Preferences.SOURCE_LOCALE, config.getSourceLanguage().toString());
         Preferences.setPreference(Preferences.TARGET_LOCALE, config.getTargetLanguage().toString());
+    }
+
+    /**
+     * Persist the session values of all registered team settings to the
+     * sidecar file. Opt-in: only materialised once a setting was used, so
+     * default projects stay byte-identical to older OmegaT versions. While
+     * a superseded local value awaits the user's decision, the session runs
+     * on the team value but the file keeps the local one - persisting the
+     * session value here would silently turn a dismissed question into
+     * "take the team value". Static for testability.
+     */
+    static void persistSessionSettings(ProjectProperties config, Set<String> supersededKeys)
+            throws IOException {
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            String sessionValue = setting.read(config);
+            if (!supersededKeys.contains(setting.getKey())
+                    && (sessionValue != null || ProjectSettingsStorage.getFile(config).isFile())) {
+                ProjectSettingsStorage.save(config, setting.getKey(), sessionValue);
+            }
+        }
+    }
+
+    /**
+     * The local raw values that the just synced team values superseded
+     * during the load, keyed by setting key (null value = local default), or
+     * empty when everything agreed. Read by the question shown after a team
+     * project opened.
+     */
+    private volatile Map<String, @Nullable String> supersededLocalSettings = Collections.emptyMap();
+
+    @Override
+    public Map<String, @Nullable String> getSupersededLocalSettings() {
+        return supersededLocalSettings;
+    }
+
+    @Override
+    public void publishProjectSetting(String key, @Nullable String value) throws Exception {
+        if (!remoteRepositoryProvider.isManaged()) {
+            return;
+        }
+        TeamSetting setting = requireRegistered(key);
+        // The session and the local file keep the user's value even when the
+        // commit fails: the file then still diverges from the team and the
+        // next open asks again.
+        setting.apply(config, value);
+        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        // A checkout parked between teamSyncPrepare and teamSync must not be
+        // moved to latest behind the sync's back (same cleanup as
+        // saveProject).
+        tmxPrepared = null;
+        glossaryPrepared = null;
+        remoteRepositoryProvider.cleanPrepared();
+        commitProjectSettings(remoteRepositoryProvider, config);
+        clearSupersededLocalSetting(key);
+    }
+
+    @Override
+    public void useLocalProjectSetting(String key, @Nullable String value) throws Exception {
+        if (!remoteRepositoryProvider.isManaged()) {
+            return;
+        }
+        TeamSetting setting = requireRegistered(key);
+        setting.apply(config, value);
+        // Local write only: the next open of the team project syncs the
+        // remote file back in, notices a divergence and asks again.
+        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        clearSupersededLocalSetting(key);
+    }
+
+    private static TeamSetting requireRegistered(String key) {
+        TeamSetting setting = TeamSettingsRegistry.byKey(key);
+        if (setting == null) {
+            throw new IllegalArgumentException("Unknown team setting: " + key);
+        }
+        return setting;
+    }
+
+    private void clearSupersededLocalSetting(String key) {
+        if (supersededLocalSettings.containsKey(key)) {
+            Map<String, @Nullable String> remaining = new HashMap<>(supersededLocalSettings);
+            remaining.remove(key);
+            supersededLocalSettings = Collections.unmodifiableMap(remaining);
+        }
+    }
+
+    /**
+     * Commit the project settings file to the team repositories. Skips the
+     * commit when every repository copy is already byte-identical, because
+     * git reports the no-op commit of an unchanged file the same way as a
+     * rejected push. Static for testability.
+     */
+    static void commitProjectSettings(RemoteRepositoryProvider provider, ProjectProperties config)
+            throws Exception {
+        // The checkout may be stale, and a commit onto an old base would be
+        // rejected on push.
+        provider.switchAllToLatest();
+        String underRoot = config.getProjectInternalRelative()
+                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
+        if (!provider.isIdenticalInRepositoriesIgnoringEol(underRoot)) {
+            provider.copyFilesFromProjectToRepos(underRoot, null);
+            if (!provider.commitFilesChecked(underRoot, "Update the shared project settings")) {
+                throw new IOException(OStrings.getString("TEAM_SETTING_SHARE_ERROR"));
+            }
+        }
+    }
+
+    /**
+     * Apply the stored project settings to the session. For an online team
+     * project the team's state wins: the sync just overwrote a diverging
+     * local file with the remote one, and a purely local file (which the
+     * sync leaves alone, because it never existed remotely) does not count
+     * either - the team default stays active until the value is shared.
+     * Either way the superseded local values are kept for the question shown
+     * after the load, so every open asks again until the value is shared or
+     * dropped, as the share prompt promises.
+     *
+     * @param preSyncValues
+     *            the locally stored normalized values from before the team
+     *            sync, keyed by setting key
+     */
+    private void loadProjectSettings(Map<String, @Nullable String> preSyncValues) {
+        if (TeamSettingsRegistry.all().isEmpty()) {
+            supersededLocalSettings = Collections.emptyMap();
+            return;
+        }
+        boolean teamOnline = remoteRepositoryProvider.isManaged() && isOnlineMode;
+        boolean identical = false;
+        if (teamOnline) {
+            try {
+                // After the sync a settings file that exists remotely is
+                // byte-identical locally; a non-identical or absent file
+                // means the team does not carry the setting, so the local
+                // file is a local-only divergence.
+                identical = remoteRepositoryProvider.isIdenticalInRepositories(
+                        config.getProjectInternalRelative()
+                                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+            } catch (IOException ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                // fall back to trusting the local file
+                identical = true;
+            }
+        }
+        Map<String, @Nullable String> superseded = new HashMap<>();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            String preSync = preSyncValues.get(setting.getKey());
+            String postSync = setting.normalize(ProjectSettingsStorage.load(config, setting.getKey()));
+            SettingResolution state = resolveSetting(preSync, postSync, identical, teamOnline);
+            setting.apply(config, state.effective);
+            if (state.asks) {
+                superseded.put(setting.getKey(), state.supersededLocal);
+            }
+        }
+        supersededLocalSettings = Collections.unmodifiableMap(superseded);
+    }
+
+    /** Snapshot of the stored normalized values of all registered settings. */
+    private Map<String, @Nullable String> readStoredSettings() {
+        Map<String, @Nullable String> values = new HashMap<>();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            values.put(setting.getKey(),
+                    setting.normalize(ProjectSettingsStorage.load(config, setting.getKey())));
+        }
+        return values;
+    }
+
+    /** Resolution of one team setting after a load. */
+    static final class SettingResolution {
+        final @Nullable String effective;
+        final boolean asks;
+        final @Nullable String supersededLocal;
+
+        SettingResolution(@Nullable String effective, boolean asks, @Nullable String supersededLocal) {
+            this.effective = effective;
+            this.asks = asks;
+            this.supersededLocal = supersededLocal;
+        }
+    }
+
+    /**
+     * Decide which raw value a load activates and whether it superseded a
+     * diverging local value that the user should be asked about. Works on
+     * normalized values (default = null). Pure function for testability.
+     *
+     * @param preSyncStored
+     *            locally stored value from before the team sync, null when
+     *            file or key were absent
+     * @param postSyncStored
+     *            stored value after the team sync
+     * @param identicalInRepositories
+     *            whether the settings file is byte-identical in every team
+     *            repository (meaningless when teamOnline is false)
+     * @param teamOnline
+     *            whether this is a team project loaded in online mode
+     */
+    static SettingResolution resolveSetting(@Nullable String preSyncStored,
+            @Nullable String postSyncStored, boolean identicalInRepositories, boolean teamOnline) {
+        if (!teamOnline) {
+            return new SettingResolution(postSyncStored, false, null);
+        }
+        String team = identicalInRepositories ? postSyncStored : null;
+        boolean asks = !Objects.equals(preSyncStored, team);
+        return new SettingResolution(team, asks, asks ? preSyncStored : null);
     }
 
     /**
@@ -343,6 +546,7 @@ public class RealProject implements IProject {
 
             Core.getMainWindow().showStatusMessageRB("CT_LOADING_PROJECT");
 
+            Map<String, @Nullable String> preSyncSettings = readStoredSettings();
             if (remoteRepositoryProvider.isManaged()) {
                 try {
                     tmxPrepared = null;
@@ -360,6 +564,7 @@ public class RealProject implements IProject {
                 config.loadProjectFilters();
                 config.loadProjectSRX();
             }
+            loadProjectSettings(preSyncSettings);
 
             loadFilterSettings();
             loadSegmentationSettings();

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -57,6 +57,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -74,7 +75,6 @@ import org.omegat.core.KnownException;
 import org.omegat.core.data.TMXEntry.ExternalLinked;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.segmentation.SRX;
-import org.omegat.core.segmentation.SRXManager;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.statistics.dso.StatsResult;
 import org.omegat.core.statistics.Statistics;
@@ -135,6 +135,15 @@ import static org.omegat.core.data.IProject.AllTranslations.EMPTY_TRANSLATION;
  * @author Aaron Madlon-Kay
  */
 public class RealProject implements IProject {
+
+    static {
+        // The built-in file-backed settings must be registered wherever
+        // projects are handled - GUI, console and tests alike - because
+        // persistSessionSettings took over writing their files from
+        // saveProjectProperties.
+        TeamSettingFiles.ensureRegistered();
+    }
+
     protected final ProjectProperties config;
     protected RemoteRepositoryProvider remoteRepositoryProvider;
 
@@ -248,10 +257,9 @@ public class RealProject implements IProject {
     public void saveProjectProperties() throws Exception {
         unlockProject();
         try {
-            SRXManager.saveToSrx(config.getProjectSRX(), new File(config.getProjectInternal()));
-            FilterMaster.saveConfig(config.getProjectFilters(),
-                    new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
             ProjectFileStorage.writeProjectFile(config);
+            // Also writes the project's filters.xml and segmentation files,
+            // registered as file-backed team settings.
             persistSessionSettings(config, supersededLocalSettings.keySet());
         } finally {
             lockProject();
@@ -261,12 +269,12 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Persist the session values of all registered team settings to the
-     * sidecar file. Opt-in: only materialised once a setting was used, so
+     * Persist the session values of all registered team settings to their
+     * storage. Opt-in: only materialised once a setting was used, so
      * default projects stay byte-identical to older OmegaT versions. While
      * a superseded local value awaits the user's decision, the session runs
-     * on the team value but the file keeps the local one - persisting the
-     * session value here would silently turn a dismissed question into
+     * on the team value but the storage keeps the local one - persisting
+     * the session value here would silently turn a dismissed question into
      * "take the team value". Static for testability.
      */
     static void persistSessionSettings(ProjectProperties config, Set<String> supersededKeys)
@@ -274,8 +282,8 @@ public class RealProject implements IProject {
         for (TeamSetting setting : TeamSettingsRegistry.all()) {
             String sessionValue = setting.read(config);
             if (!supersededKeys.contains(setting.getKey())
-                    && (sessionValue != null || ProjectSettingsStorage.getFile(config).isFile())) {
-                ProjectSettingsStorage.save(config, setting.getKey(), sessionValue);
+                    && (sessionValue != null || setting.storageMaterialized(config))) {
+                setting.saveStored(config, sessionValue);
             }
         }
     }
@@ -303,14 +311,14 @@ public class RealProject implements IProject {
         // commit fails: the file then still diverges from the team and the
         // next open asks again.
         setting.apply(config, value);
-        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        setting.saveStored(config, value);
         // A checkout parked between teamSyncPrepare and teamSync must not be
         // moved to latest behind the sync's back (same cleanup as
         // saveProject).
         tmxPrepared = null;
         glossaryPrepared = null;
         remoteRepositoryProvider.cleanPrepared();
-        commitProjectSettings(remoteRepositoryProvider, config);
+        commitProjectSettings(remoteRepositoryProvider, config, setting);
         clearSupersededLocalSetting(key);
     }
 
@@ -323,7 +331,7 @@ public class RealProject implements IProject {
         setting.apply(config, value);
         // Local write only: the next open of the team project syncs the
         // remote file back in, notices a divergence and asks again.
-        ProjectSettingsStorage.save(config, key, setting.normalize(value));
+        setting.saveStored(config, value);
         clearSupersededLocalSetting(key);
     }
 
@@ -344,23 +352,36 @@ public class RealProject implements IProject {
     }
 
     /**
-     * Commit the project settings file to the team repositories. Skips the
-     * commit when every repository copy is already byte-identical, because
-     * git reports the no-op commit of an unchanged file the same way as a
-     * rejected push. Static for testability.
+     * Commit the files carrying the given setting to the team repositories.
+     * Skips a file whose repository copies are already byte-identical,
+     * because git reports the no-op commit of an unchanged file the same
+     * way as a rejected push; a file absent from the checkout but present
+     * in a repository is deleted there, so sharing "no project-specific
+     * configuration" distributes the removal. Static for testability.
      */
-    static void commitProjectSettings(RemoteRepositoryProvider provider, ProjectProperties config)
-            throws Exception {
+    static void commitProjectSettings(RemoteRepositoryProvider provider, ProjectProperties config,
+            TeamSetting setting) throws Exception {
         // The checkout may be stale, and a commit onto an old base would be
         // rejected on push.
         provider.switchAllToLatest();
-        String underRoot = config.getProjectInternalRelative()
-                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
-        if (!provider.isIdenticalInRepositoriesIgnoringEol(underRoot)) {
-            provider.copyFilesFromProjectToRepos(underRoot, null);
-            if (!provider.commitFilesChecked(underRoot, "Update the shared project settings")) {
-                throw new IOException(OStrings.getString("TEAM_SETTING_SHARE_ERROR"));
+        List<String> toCommit = new ArrayList<>();
+        for (String underRoot : setting.storagePaths(config)) {
+            if (new File(config.getProjectRootDir(), underRoot).isFile()) {
+                if (!provider.isIdenticalInRepositoriesIgnoringEol(underRoot)) {
+                    provider.copyFilesFromProjectToRepos(underRoot, null);
+                    toCommit.add(underRoot);
+                }
+            } else if (setting.isFileBacked() && provider.existsInRepositories(underRoot)) {
+                // Only for a file-backed setting is the file the value: the
+                // sidecar also carries other settings, a missing checkout
+                // copy must never delete it in the repositories.
+                provider.deleteFilesFromRepos(underRoot);
+                toCommit.add(underRoot);
             }
+        }
+        if (!toCommit.isEmpty()
+                && !provider.commitFilesChecked(toCommit, "Update the shared project settings")) {
+            throw new IOException(OStrings.getString("TEAM_SETTING_SHARE_ERROR"));
         }
     }
 
@@ -384,27 +405,19 @@ public class RealProject implements IProject {
             return;
         }
         boolean teamOnline = remoteRepositoryProvider.isManaged() && isOnlineMode;
-        boolean identical = false;
-        if (teamOnline) {
-            try {
-                // After the sync a settings file that exists remotely is
-                // byte-identical locally; a non-identical or absent file
-                // means the team does not carry the setting, so the local
-                // file is a local-only divergence.
-                identical = remoteRepositoryProvider.isIdenticalInRepositories(
-                        config.getProjectInternalRelative()
-                                + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
-            } catch (IOException ex) {
-                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
-                // fall back to trusting the local file
-                identical = true;
-            }
-        }
         Map<String, @Nullable String> superseded = new HashMap<>();
         for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            // The team's value is read from the repository checkouts by
+            // content, not by byte comparison: a repository copy may be
+            // differently formatted or still in a legacy format (like
+            // segmentation.conf next to a migrated checkout) while carrying
+            // the same configuration. Null means the team does not carry
+            // the setting, so a local value is a local-only divergence.
+            String teamValue = teamOnline ? repositoryStoredValue(setting) : null;
             String preSync = preSyncValues.get(setting.getKey());
-            String postSync = setting.normalize(ProjectSettingsStorage.load(config, setting.getKey()));
-            SettingResolution state = resolveSetting(preSync, postSync, identical, teamOnline);
+            String postSync = setting.loadStored(config);
+            SettingResolution state = resolveSetting(preSync,
+                    teamValue != null ? teamValue : postSync, teamValue != null, teamOnline);
             setting.apply(config, state.effective);
             if (state.asks) {
                 superseded.put(setting.getKey(), state.supersededLocal);
@@ -413,12 +426,33 @@ public class RealProject implements IProject {
         supersededLocalSettings = Collections.unmodifiableMap(superseded);
     }
 
+    /**
+     * The normalized value the team repositories carry for the setting:
+     * null when no repository carries it, or when the repositories
+     * disagree among themselves - the load then treats the setting as not
+     * carried and asks about the local value instead of guessing.
+     */
+    private @Nullable String repositoryStoredValue(TeamSetting setting) {
+        String value = null;
+        boolean first = true;
+        for (Function<String, @Nullable File> view : remoteRepositoryProvider
+                .repositoryFileViews(setting.storagePaths(config))) {
+            String repoValue = setting.loadStoredFrom(config, view);
+            if (first) {
+                value = repoValue;
+                first = false;
+            } else if (!Objects.equals(value, repoValue)) {
+                return null;
+            }
+        }
+        return value;
+    }
+
     /** Snapshot of the stored normalized values of all registered settings. */
     private Map<String, @Nullable String> readStoredSettings() {
         Map<String, @Nullable String> values = new HashMap<>();
         for (TeamSetting setting : TeamSettingsRegistry.all()) {
-            values.put(setting.getKey(),
-                    setting.normalize(ProjectSettingsStorage.load(config, setting.getKey())));
+            values.put(setting.getKey(), setting.loadStored(config));
         }
         return values;
     }
@@ -440,6 +474,10 @@ public class RealProject implements IProject {
      * Decide which raw value a load activates and whether it superseded a
      * diverging local value that the user should be asked about. Works on
      * normalized values (default = null). Pure function for testability.
+     * A team value arriving over a locally absent one activates quietly:
+     * there is nothing to rescue, a fresh checkout would question every
+     * new member, and sharing the absence back would delete the team's
+     * files.
      *
      * @param preSyncStored
      *            locally stored value from before the team sync, null when
@@ -447,8 +485,8 @@ public class RealProject implements IProject {
      * @param postSyncStored
      *            stored value after the team sync
      * @param identicalInRepositories
-     *            whether the settings file is byte-identical in every team
-     *            repository (meaningless when teamOnline is false)
+     *            whether the team carries the locally stored value
+     *            (meaningless when teamOnline is false)
      * @param teamOnline
      *            whether this is a team project loaded in online mode
      */
@@ -458,7 +496,7 @@ public class RealProject implements IProject {
             return new SettingResolution(postSyncStored, false, null);
         }
         String team = identicalInRepositories ? postSyncStored : null;
-        boolean asks = !Objects.equals(preSyncStored, team);
+        boolean asks = preSyncStored != null && !Objects.equals(preSyncStored, team);
         return new SettingResolution(team, asks, asks ? preSyncStored : null);
     }
 

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -534,6 +534,10 @@ public class RealProject implements IProject {
             SRX srx = config.getProjectSRX();
             Core.setSegmenter(new Segmenter(srx == null ? Preferences.getSRX() : srx));
 
+            // Project-specific custom tag / removed-text expressions take
+            // effect before the initial source parse.
+            PatternConsts.applyProjectPatterns(config.getCustomTagPattern(), config.getRemoveTextPattern());
+
             loadTranslations();
             setProjectModified(true);
             saveProject(false);
@@ -557,6 +561,12 @@ public class RealProject implements IProject {
             // trouble in Tinseltown...
             Log.logErrorRB(e, "CT_ERROR_CREATING_PROJECT");
             Core.getMainWindow().displayErrorRB(e, "CT_ERROR_CREATING_PROJECT");
+        } finally {
+            if (!loaded) {
+                // An aborted creation must not leak the project expressions
+                // into the globally visible patterns.
+                PatternConsts.clearProjectPatterns();
+            }
         }
         Log.logInfoRB("LOG_DATAENGINE_CREATE_END");
     }
@@ -601,8 +611,14 @@ public class RealProject implements IProject {
                 // reload them again
                 config.loadProjectFilters();
                 config.loadProjectSRX();
+                config.loadProjectTagPatterns();
             }
             loadProjectSettings(preSyncSettings);
+
+            // Project-specific custom tag / removed-text expressions take
+            // effect before any source file is parsed, and only after the
+            // team sync above delivered the current tag_patterns.xml.
+            PatternConsts.applyProjectPatterns(config.getCustomTagPattern(), config.getRemoveTextPattern());
 
             loadFilterSettings();
             loadSegmentationSettings();
@@ -683,6 +699,12 @@ public class RealProject implements IProject {
             if (!loaded) {
                 unlockProject();
             }
+        } finally {
+            if (!loaded) {
+                // An aborted load must not leak the project expressions into
+                // the globally visible patterns.
+                PatternConsts.clearProjectPatterns();
+            }
         }
 
         Log.logInfoRB("LOG_DATAENGINE_LOAD_END");
@@ -754,6 +776,7 @@ public class RealProject implements IProject {
     @Override
     public void closeProject() {
         loaded = false;
+        PatternConsts.clearProjectPatterns();
         flushProcessCache();
         tmMonitor.fin();
         tmOtherLanguagesMonitor.fin();

--- a/src/main/java/org/omegat/core/data/RealProject.java
+++ b/src/main/java/org/omegat/core/data/RealProject.java
@@ -15,6 +15,7 @@
                2018 Enrique Estevez Fernandez
                2019 Thomas Cordonnier
                2020 Briac Pilpre
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -82,6 +83,7 @@ import org.omegat.core.statistics.StatisticsInfo;
 import org.omegat.core.team2.IRemoteRepository2;
 import org.omegat.core.team2.PreparedFileInfo;
 import org.omegat.core.team2.RebaseAndCommit;
+import org.omegat.core.team2.RemoteReachabilityProbe;
 import org.omegat.core.team2.RemoteRepositoryProvider;
 import org.omegat.core.team2.operation.GlossaryRebaseOperation;
 import org.omegat.core.team2.operation.RebaseUtils;
@@ -110,6 +112,7 @@ import org.omegat.util.TagUtil;
 import org.omegat.util.gui.UIThreadsUtil;
 
 import gen.core.filters.Filters;
+import gen.core.project.RepositoryDefinition;
 
 import static org.omegat.core.data.IProject.AllTranslations.EMPTY_TRANSLATION;
 
@@ -160,7 +163,21 @@ public class RealProject implements IProject {
 
     private final Object projectTMXLock = new Object();
 
-    private boolean isOnlineMode;
+    /** Volatile: the auto-save thread reads it outside the project lock. */
+    private volatile boolean isOnlineMode;
+
+    /** Back-off after a restore attempt failed with a non-network error. */
+    private static final long TEAM_SYNC_RESTORE_BACKOFF_MS = 30L * 60 * 1000;
+
+    /**
+     * Earliest moment for the next automatic team sync restore attempt.
+     * Pushed into the future when a restore fails with a non-network error,
+     * so the auto-save thread does not repeat that error every interval.
+     */
+    private volatile long nextTeamSyncRestoreAttempt;
+
+    /** True while {@link #restoreTeamSync()} drives the current save. */
+    private volatile boolean teamSyncRestoreRunning;
 
     private RandomAccessFile raFile;
     private FileChannel lockChannel;
@@ -1131,7 +1148,15 @@ public class RealProject implements IProject {
                     }
                 } catch (Exception e) {
                     Log.logErrorRB(e, "CT_ERROR_SAVING_PROJ");
-                    Objects.requireNonNull(Core.getMainWindow()).displayErrorRB(e, "CT_ERROR_SAVING_PROJ");
+                    if (teamSyncRestoreRunning) {
+                        // An automatic restore must not interrupt the user
+                        // with a modal dialog every auto-save interval; back
+                        // off and retry much later instead.
+                        nextTeamSyncRestoreAttempt = System.currentTimeMillis()
+                                + TEAM_SYNC_RESTORE_BACKOFF_MS;
+                    } else {
+                        Objects.requireNonNull(Core.getMainWindow()).displayErrorRB(e, "CT_ERROR_SAVING_PROJ");
+                    }
                 }
 
                 LastSegmentManager.saveLastSegment();
@@ -2204,6 +2229,26 @@ public class RealProject implements IProject {
         }
         isOnlineMode = false;
         preparedStatus = PreparedStatus.NONE;
+    }
+
+    @Override
+    public boolean canRestoreTeamSync() {
+        if (!remoteRepositoryProvider.isManaged() || isOnlineMode
+                || System.currentTimeMillis() < nextTeamSyncRestoreAttempt) {
+            return false;
+        }
+        List<RepositoryDefinition> repositories = config.getRepositories();
+        return repositories != null && RemoteReachabilityProbe.canReachAll(repositories);
+    }
+
+    @Override
+    public void restoreTeamSync() {
+        teamSyncRestoreRunning = true;
+        try {
+            saveProject(true);
+        } finally {
+            teamSyncRestoreRunning = false;
+        }
     }
 
     @Override

--- a/src/main/java/org/omegat/core/data/TeamSetting.java
+++ b/src/main/java/org/omegat/core/data/TeamSetting.java
@@ -25,6 +25,9 @@
 
 package org.omegat.core.data;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -36,15 +39,97 @@ import org.openide.awt.Mnemonics;
 import org.omegat.util.OStrings;
 
 /**
- * Descriptor of one per-project setting negotiated with team, stored in
- * sidecar file handled by {@link ProjectSettingsStorage}. Feature code
+ * Descriptor of one per-project setting negotiated with team. Feature code
  * registers descriptor through {@link TeamSettingsRegistry}; core then
  * loads, saves, distributes and questions the setting generically. Raw
- * values are strings; null means "not configured", i.e. default.
+ * values are strings; null means "not configured", i.e. default. Values
+ * are stored through pluggable {@link Storage}: by default a key in the
+ * sidecar file handled by {@link ProjectSettingsStorage}, alternatively a
+ * whole configuration file of the project whose canonical content is the
+ * raw value.
  *
  * @author stephan.pakebusch at zollsoft.de
  */
 public final class TeamSetting {
+
+    /**
+     * Persistence of one team setting's raw value in a file tree - the
+     * project checkout, or through a resolver a repository checkout.
+     * Implementations must treat null as "not configured": loading an
+     * absent value returns null, saving null removes the stored value.
+     */
+    public interface Storage {
+
+        /**
+         * Raw value carried by the files the resolver yields, null when
+         * not configured or unreadable. The resolver maps a path from
+         * {@link #pathsUnderRoot} to the file holding it in the inspected
+         * tree, or null when the tree does not cover the path.
+         */
+        @Nullable
+        String loadFrom(ProjectProperties config, Function<String, @Nullable File> fileResolver);
+
+        /** Stores raw value in the project checkout; null removes it. */
+        void save(ProjectProperties config, @Nullable String raw) throws IOException;
+
+        /**
+         * Project-root-relative paths of the files that carry the setting
+         * in the team repositories.
+         */
+        List<String> pathsUnderRoot(ProjectProperties config);
+
+        /** Stored raw value in the project checkout. */
+        default @Nullable String load(ProjectProperties config) {
+            return loadFrom(config, path -> new File(config.getProjectRootDir(), path));
+        }
+
+        /**
+         * Whether any of the setting's files exist in the project
+         * checkout; false keeps default projects byte-identical to
+         * projects of older OmegaT versions.
+         */
+        default boolean materialized(ProjectProperties config) {
+            return pathsUnderRoot(config).stream()
+                    .anyMatch(path -> new File(config.getProjectRootDir(), path).isFile());
+        }
+
+        /**
+         * Whether the raw value is the content of the storage's own
+         * file(s), so sharing a null value may delete them in the team
+         * repositories. The internal sidecar storage answers false - its
+         * file also carries other settings.
+         */
+        default boolean fileBacked() {
+            return true;
+        }
+    }
+
+    private static Storage sidecarStorage(String key) {
+        return new Storage() {
+            @Override
+            public @Nullable String loadFrom(ProjectProperties config,
+                    Function<String, @Nullable File> fileResolver) {
+                File file = fileResolver.apply(pathsUnderRoot(config).get(0));
+                return file == null ? null : ProjectSettingsStorage.loadFromFile(file, key);
+            }
+
+            @Override
+            public void save(ProjectProperties config, @Nullable String raw) throws IOException {
+                ProjectSettingsStorage.save(config, key, raw);
+            }
+
+            @Override
+            public List<String> pathsUnderRoot(ProjectProperties config) {
+                return List.of(config.getProjectInternalRelative()
+                        + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+            }
+
+            @Override
+            public boolean fileBacked() {
+                return false;
+            }
+        };
+    }
 
     private final String key;
     private final String nameKey;
@@ -52,16 +137,19 @@ public final class TeamSetting {
     private final BiConsumer<ProjectProperties, @Nullable String> applier;
     private final Function<@Nullable String, String> valueDescriber;
     private final UnaryOperator<@Nullable String> normalizer;
+    private final Storage storage;
 
     private TeamSetting(String key, String nameKey, Function<ProjectProperties, @Nullable String> reader,
             BiConsumer<ProjectProperties, @Nullable String> applier,
-            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer,
+            Storage storage) {
         this.key = key;
         this.nameKey = nameKey;
         this.reader = reader;
         this.applier = applier;
         this.valueDescriber = valueDescriber;
         this.normalizer = normalizer;
+        this.storage = storage;
     }
 
     /**
@@ -86,7 +174,37 @@ public final class TeamSetting {
             Function<ProjectProperties, @Nullable String> reader,
             BiConsumer<ProjectProperties, @Nullable String> applier,
             Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
-        return new TeamSetting(key, nameKey, reader, applier, valueDescriber, normalizer);
+        return new TeamSetting(key, nameKey, reader, applier, valueDescriber, normalizer,
+                sidecarStorage(key));
+    }
+
+    /**
+     * Descriptor of a setting stored in its own configuration file(s)
+     * instead of the sidecar. The raw value is the canonical content of the
+     * file, null means the file is absent, and sharing the value with the
+     * team distributes the file itself - including its removal.
+     *
+     * @param key
+     *            registry key of the setting
+     * @param nameKey
+     *            resource key of localized display name
+     * @param reader
+     *            current session value as canonical content, null when the
+     *            project carries no specific configuration
+     * @param applier
+     *            applies canonical content (null = default) to session; must
+     *            be an idempotent setter, it also runs with unchanged values
+     * @param valueDescriber
+     *            localized description of raw value for dialogs
+     * @param storage
+     *            persistence of the configuration file(s)
+     */
+    public static TeamSetting ofStoredFile(String key, String nameKey,
+            Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, Storage storage) {
+        UnaryOperator<@Nullable String> normalizer = raw -> raw == null || raw.isBlank() ? null : raw;
+        return new TeamSetting(key, nameKey, reader, applier, valueDescriber, normalizer, storage);
     }
 
     /**
@@ -108,12 +226,54 @@ public final class TeamSetting {
                         (raw == null ? defaultValue : Boolean.parseBoolean(raw.trim()))
                                 ? "TEAM_SETTING_VALUE_ON"
                                 : "TEAM_SETTING_VALUE_OFF"),
-                normalizer);
+                normalizer, sidecarStorage(key));
     }
 
-    /** Key in project_settings.properties. */
+    /** Registry key of the setting. */
     public String getKey() {
         return key;
+    }
+
+    /** Stored normalized raw value, null when not configured. */
+    public @Nullable String loadStored(ProjectProperties config) {
+        return normalize(storage.load(config));
+    }
+
+    /**
+     * Normalized raw value carried by the files the resolver yields, e.g.
+     * a repository checkout - see {@link Storage#loadFrom}.
+     */
+    public @Nullable String loadStoredFrom(ProjectProperties config,
+            Function<String, @Nullable File> fileResolver) {
+        return normalize(storage.loadFrom(config, fileResolver));
+    }
+
+    /** Stores raw value; null removes the stored value. */
+    public void saveStored(ProjectProperties config, @Nullable String raw) throws IOException {
+        storage.save(config, normalize(raw));
+    }
+
+    /**
+     * Project-root-relative paths of the files that carry the setting in
+     * the team repositories.
+     */
+    public List<String> storagePaths(ProjectProperties config) {
+        return storage.pathsUnderRoot(config);
+    }
+
+    /** Whether the setting's file(s) exist in the project checkout. */
+    public boolean storageMaterialized(ProjectProperties config) {
+        return storage.materialized(config);
+    }
+
+    /**
+     * Whether the raw value is the content of own configuration file(s)
+     * ({@link #ofStoredFile}) instead of a key in the shared sidecar file.
+     * Only for such a setting may sharing a null value delete files in the
+     * team repositories - the sidecar file also carries other settings.
+     */
+    public boolean isFileBacked() {
+        return storage.fileBacked();
     }
 
     /**

--- a/src/main/java/org/omegat/core/data/TeamSetting.java
+++ b/src/main/java/org/omegat/core/data/TeamSetting.java
@@ -1,0 +1,146 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+import org.jspecify.annotations.Nullable;
+import org.openide.awt.Mnemonics;
+
+import org.omegat.util.OStrings;
+
+/**
+ * Descriptor of one per-project setting negotiated with team, stored in
+ * sidecar file handled by {@link ProjectSettingsStorage}. Feature code
+ * registers descriptor through {@link TeamSettingsRegistry}; core then
+ * loads, saves, distributes and questions the setting generically. Raw
+ * values are strings; null means "not configured", i.e. default.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSetting {
+
+    private final String key;
+    private final String nameKey;
+    private final Function<ProjectProperties, @Nullable String> reader;
+    private final BiConsumer<ProjectProperties, @Nullable String> applier;
+    private final Function<@Nullable String, String> valueDescriber;
+    private final UnaryOperator<@Nullable String> normalizer;
+
+    private TeamSetting(String key, String nameKey, Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+        this.key = key;
+        this.nameKey = nameKey;
+        this.reader = reader;
+        this.applier = applier;
+        this.valueDescriber = valueDescriber;
+        this.normalizer = normalizer;
+    }
+
+    /**
+     * Descriptor with fully custom behaviour, for non-boolean settings.
+     *
+     * @param key
+     *            key in project_settings.properties
+     * @param nameKey
+     *            resource key of localized display name
+     * @param reader
+     *            current session value as normalized raw string, null for
+     *            default
+     * @param applier
+     *            applies raw value (null = default) to session; must be an
+     *            idempotent setter, it also runs with unchanged values
+     * @param valueDescriber
+     *            localized description of raw value for dialogs
+     * @param normalizer
+     *            canonical form of raw value; must map default to null
+     */
+    public static TeamSetting of(String key, String nameKey,
+            Function<ProjectProperties, @Nullable String> reader,
+            BiConsumer<ProjectProperties, @Nullable String> applier,
+            Function<@Nullable String, String> valueDescriber, UnaryOperator<@Nullable String> normalizer) {
+        return new TeamSetting(key, nameKey, reader, applier, valueDescriber, normalizer);
+    }
+
+    /**
+     * Boolean setting; absent key means given default, only the non-default
+     * value materialises in the file, so default projects stay byte-identical
+     * to projects of older OmegaT versions.
+     */
+    public static TeamSetting ofBoolean(String key, String nameKey, boolean defaultValue,
+            Predicate<ProjectProperties> getter, BiConsumer<ProjectProperties, Boolean> setter) {
+        UnaryOperator<@Nullable String> normalizer = raw -> {
+            boolean value = raw == null ? defaultValue : Boolean.parseBoolean(raw.trim());
+            return value == defaultValue ? null : Boolean.toString(value);
+        };
+        return new TeamSetting(key, nameKey,
+                config -> getter.test(config) == defaultValue ? null : Boolean.toString(!defaultValue),
+                (config, raw) -> setter.accept(config,
+                        raw == null ? defaultValue : Boolean.parseBoolean(raw.trim())),
+                raw -> OStrings.getString(
+                        (raw == null ? defaultValue : Boolean.parseBoolean(raw.trim()))
+                                ? "TEAM_SETTING_VALUE_ON"
+                                : "TEAM_SETTING_VALUE_OFF"),
+                normalizer);
+    }
+
+    /** Key in project_settings.properties. */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Localized display name for dialogs. Mnemonic markers are stripped, so
+     * existing menu or checkbox label keys work as name key.
+     */
+    public String getDisplayName() {
+        return Mnemonics.removeMnemonics(OStrings.getString(nameKey));
+    }
+
+    /** Current session value as normalized raw string, null for default. */
+    public @Nullable String read(ProjectProperties config) {
+        return normalize(reader.apply(config));
+    }
+
+    /** Applies raw value (null = default) to session. */
+    public void apply(ProjectProperties config, @Nullable String raw) {
+        applier.accept(config, normalize(raw));
+    }
+
+    /** Localized description of raw value for dialogs. */
+    public String describe(@Nullable String raw) {
+        return valueDescriber.apply(raw);
+    }
+
+    /** Canonical form of raw value; default maps to null. */
+    public @Nullable String normalize(@Nullable String raw) {
+        return normalizer.apply(raw);
+    }
+}

--- a/src/main/java/org/omegat/core/data/TeamSettingFiles.java
+++ b/src/main/java/org/omegat/core/data/TeamSettingFiles.java
@@ -1,0 +1,292 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.jspecify.annotations.Nullable;
+
+import gen.core.filters.Filters;
+import org.omegat.core.Core;
+import org.omegat.core.segmentation.SRX;
+import org.omegat.core.segmentation.SRXManager;
+import org.omegat.core.segmentation.Segmenter;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.util.Log;
+import org.omegat.util.OStrings;
+import org.omegat.util.Preferences;
+
+/**
+ * The built-in file-backed team settings: the project's file filter
+ * configuration ({@code omegat/filters.xml}) and segmentation rules
+ * ({@code omegat/segmentation.srx}, legacy {@code segmentation.conf}). A
+ * team sync used to overwrite local changes to these files silently and
+ * OmegaT never committed them itself; registered as {@link TeamSetting},
+ * the generic negotiation asks instead and offers to distribute a change
+ * to the team. The raw value is the canonical serialized content, so
+ * differently formatted files with equal rules do not count as diverged.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSettingFiles {
+
+    /** Registry key of the file filter configuration setting. */
+    public static final String FILTERS_KEY = "filters";
+
+    /** Registry key of the segmentation rules setting. */
+    public static final String SEGMENTATION_KEY = "segmentation";
+
+    /** File filter configuration as a team setting. */
+    public static final TeamSetting FILTERS = TeamSetting.ofStoredFile(FILTERS_KEY,
+            "TEAM_SETTING_NAME_FILTERS", TeamSettingFiles::readSessionFilters,
+            TeamSettingFiles::applySessionFilters, TeamSettingFiles::describeFile,
+            new FiltersStorage());
+
+    /** Segmentation rules as a team setting. */
+    public static final TeamSetting SEGMENTATION = TeamSetting.ofStoredFile(SEGMENTATION_KEY,
+            "TEAM_SETTING_NAME_SEGMENTATION", TeamSettingFiles::readSessionSegmentation,
+            TeamSettingFiles::applySessionSegmentation, TeamSettingFiles::describeFile,
+            new SegmentationStorage());
+
+    private static final Object REGISTER_LOCK = new Object();
+
+    private TeamSettingFiles() {
+    }
+
+    /** Registers both settings when absent; safe under concurrent calls. */
+    public static void ensureRegistered() {
+        synchronized (REGISTER_LOCK) {
+            for (TeamSetting setting : List.of(FILTERS, SEGMENTATION)) {
+                if (TeamSettingsRegistry.byKey(setting.getKey()) == null) {
+                    TeamSettingsRegistry.register(setting);
+                }
+            }
+        }
+    }
+
+    private static @Nullable String readSessionFilters(ProjectProperties config) {
+        Filters filters = config.getProjectFilters();
+        if (filters == null) {
+            return null;
+        }
+        try {
+            return FilterMaster.writeConfigToString(canonical(filters));
+        } catch (IOException ex) {
+            Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+            return null;
+        }
+    }
+
+    /**
+     * The canonical form includes the completion with this installation's
+     * available filters that loading a file applies anyway: without it, a
+     * configuration from a team repository or an older OmegaT version
+     * would differ from every locally (re)written file, reading as a
+     * divergence on each open although nobody changed anything.
+     */
+    private static Filters canonical(Filters filters) {
+        return FilterMaster.completeWithAvailableFilters(filters);
+    }
+
+    private static void applySessionFilters(ProjectProperties config, @Nullable String raw) {
+        if (raw == null) {
+            config.setProjectFilters(null);
+        } else {
+            try {
+                config.setProjectFilters(canonical(FilterMaster.loadConfigFromString(raw)));
+            } catch (IOException ex) {
+                // Unparseable content: keep the current session
+                // configuration instead of silently falling back to global
+                // defaults.
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                return;
+            }
+        }
+        // Answering the divergence question must take effect like flipping
+        // a value setting does; entries loaded before the swap keep their
+        // parse until the next reload, as with any mid-session change.
+        if (appliesToLoadedProject(config)) {
+            Core.setFilterMaster(new FilterMaster(
+                    Optional.ofNullable(config.getProjectFilters()).orElse(Preferences.getFilters())));
+        }
+    }
+
+    private static @Nullable String readSessionSegmentation(ProjectProperties config) {
+        SRX srx = config.getProjectSRX();
+        if (srx == null) {
+            return null;
+        }
+        try {
+            return SRXManager.writeToString(srx);
+        } catch (IOException ex) {
+            Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+            return null;
+        }
+    }
+
+    private static void applySessionSegmentation(ProjectProperties config, @Nullable String raw) {
+        if (raw == null) {
+            config.setProjectSRX(null);
+        } else {
+            try {
+                config.setProjectSRX(SRXManager.loadSrxFromString(raw));
+            } catch (IOException ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                return;
+            }
+        }
+        if (appliesToLoadedProject(config)) {
+            Core.setSegmenter(new Segmenter(
+                    Optional.ofNullable(config.getProjectSRX()).orElse(Preferences.getSRX())));
+        }
+    }
+
+    /**
+     * Whether the given properties belong to the loaded project, so the
+     * apply must also rewire the live filter master or segmenter. False
+     * during a project load - the load wires them itself right after the
+     * settings resolution - and for detached copies like the properties
+     * dialog working set.
+     */
+    private static boolean appliesToLoadedProject(ProjectProperties config) {
+        return Core.getProject().isProjectLoaded()
+                && Core.getProject().getProjectProperties() == config;
+    }
+
+    /**
+     * Dialogs cannot show whole files, so the description names the state
+     * and fingerprints the content, letting the user tell two project
+     * versions apart.
+     */
+    private static String describeFile(@Nullable String raw) {
+        if (raw == null) {
+            return OStrings.getString("TEAM_SETTING_VALUE_FILE_NONE");
+        }
+        return OStrings.getString("TEAM_SETTING_VALUE_FILE_CUSTOM", fingerprint(raw));
+    }
+
+    static String fingerprint(String content) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-1")
+                    .digest(content.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 4; i++) {
+                sb.append(String.format("%02x", hash[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static final class FiltersStorage implements TeamSetting.Storage {
+
+        @Override
+        public @Nullable String loadFrom(ProjectProperties config,
+                Function<String, @Nullable File> fileResolver) {
+            File file = fileResolver.apply(pathsUnderRoot(config).get(0));
+            if (file == null || !file.isFile()) {
+                return null;
+            }
+            try {
+                String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+                if (content.startsWith("\uFEFF")) {
+                    // the byte-stream loader accepted a BOM, so must we
+                    content = content.substring(1);
+                }
+                return FilterMaster
+                        .writeConfigToString(canonical(FilterMaster.loadConfigFromString(content)));
+            } catch (IOException ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                return null;
+            }
+        }
+
+        @Override
+        public void save(ProjectProperties config, @Nullable String raw) throws IOException {
+            FilterMaster.saveConfig(
+                    raw == null ? null : canonical(FilterMaster.loadConfigFromString(raw)),
+                    new File(config.getProjectInternal(), FilterMaster.FILE_FILTERS));
+        }
+
+        @Override
+        public List<String> pathsUnderRoot(ProjectProperties config) {
+            return List.of(config.getProjectInternalRelative() + FilterMaster.FILE_FILTERS);
+        }
+    }
+
+    private static final class SegmentationStorage implements TeamSetting.Storage {
+
+        @Override
+        public @Nullable String loadFrom(ProjectProperties config,
+                Function<String, @Nullable File> fileResolver) {
+            List<String> paths = pathsUnderRoot(config);
+            File srxFile = fileResolver.apply(paths.get(0));
+            File confFile = fileResolver.apply(paths.get(1));
+            SRX srx;
+            if (srxFile != null && srxFile.isFile()) {
+                srx = SRXManager.loadSrxFile(srxFile.toURI());
+            } else if (confFile != null && confFile.isFile()) {
+                srx = SRXManager.loadConfFileNoMigrate(confFile);
+            } else {
+                return null;
+            }
+            if (srx == null) {
+                return null;
+            }
+            try {
+                return SRXManager.writeToString(srx);
+            } catch (IOException ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                return null;
+            }
+        }
+
+        @Override
+        public void save(ProjectProperties config, @Nullable String raw) throws IOException {
+            SRXManager.saveToSrx(raw == null ? null : SRXManager.loadSrxFromString(raw),
+                    new File(config.getProjectInternal()));
+        }
+
+        @Override
+        public List<String> pathsUnderRoot(ProjectProperties config) {
+            // Both formats, srx first: sharing mirrors the sharer's
+            // checkout, which after the srx migration no longer holds a
+            // conf file, so the repository copy of the legacy file goes
+            // away with it.
+            return List.of(config.getProjectInternalRelative() + SRXManager.SRX_SENTSEG,
+                    config.getProjectInternalRelative() + SRXManager.CONF_SENTSEG);
+        }
+    }
+}

--- a/src/main/java/org/omegat/core/data/TeamSettingFiles.java
+++ b/src/main/java/org/omegat/core/data/TeamSettingFiles.java
@@ -45,17 +45,20 @@ import org.omegat.core.segmentation.Segmenter;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.util.Log;
 import org.omegat.util.OStrings;
+import org.omegat.util.PatternConsts;
 import org.omegat.util.Preferences;
+import org.omegat.util.TagPatternsStorage;
 
 /**
  * The built-in file-backed team settings: the project's file filter
- * configuration ({@code omegat/filters.xml}) and segmentation rules
- * ({@code omegat/segmentation.srx}, legacy {@code segmentation.conf}). A
- * team sync used to overwrite local changes to these files silently and
- * OmegaT never committed them itself; registered as {@link TeamSetting},
- * the generic negotiation asks instead and offers to distribute a change
- * to the team. The raw value is the canonical serialized content, so
- * differently formatted files with equal rules do not count as diverged.
+ * configuration ({@code omegat/filters.xml}), segmentation rules
+ * ({@code omegat/segmentation.srx}, legacy {@code segmentation.conf}) and
+ * tag definitions ({@code omegat/tag_patterns.xml}). A team sync used to
+ * overwrite local changes to these files silently and OmegaT never
+ * committed them itself; registered as {@link TeamSetting}, the generic
+ * negotiation asks instead and offers to distribute a change to the team.
+ * The raw value is the canonical serialized content, so differently
+ * formatted files with equal rules do not count as diverged.
  *
  * @author stephan.pakebusch at zollsoft.de
  */
@@ -66,6 +69,9 @@ public final class TeamSettingFiles {
 
     /** Registry key of the segmentation rules setting. */
     public static final String SEGMENTATION_KEY = "segmentation";
+
+    /** Registry key of the tag definitions setting. */
+    public static final String TAG_PATTERNS_KEY = "tag_patterns";
 
     /** File filter configuration as a team setting. */
     public static final TeamSetting FILTERS = TeamSetting.ofStoredFile(FILTERS_KEY,
@@ -79,15 +85,24 @@ public final class TeamSettingFiles {
             TeamSettingFiles::applySessionSegmentation, TeamSettingFiles::describeFile,
             new SegmentationStorage());
 
+    /**
+     * Project-specific custom tag and removed-text expressions as a team
+     * setting.
+     */
+    public static final TeamSetting TAG_PATTERNS = TeamSetting.ofStoredFile(TAG_PATTERNS_KEY,
+            "TEAM_SETTING_NAME_TAG_PATTERNS", TeamSettingFiles::readSessionTagPatterns,
+            TeamSettingFiles::applySessionTagPatterns, TeamSettingFiles::describeTagPatterns,
+            new TagPatternsFileStorage());
+
     private static final Object REGISTER_LOCK = new Object();
 
     private TeamSettingFiles() {
     }
 
-    /** Registers both settings when absent; safe under concurrent calls. */
+    /** Registers the settings when absent; safe under concurrent calls. */
     public static void ensureRegistered() {
         synchronized (REGISTER_LOCK) {
-            for (TeamSetting setting : List.of(FILTERS, SEGMENTATION)) {
+            for (TeamSetting setting : List.of(FILTERS, SEGMENTATION, TAG_PATTERNS)) {
                 if (TeamSettingsRegistry.byKey(setting.getKey()) == null) {
                     TeamSettingsRegistry.register(setting);
                 }
@@ -172,6 +187,73 @@ public final class TeamSettingFiles {
         }
     }
 
+    private static @Nullable String readSessionTagPatterns(ProjectProperties config) {
+        TagPatternsStorage.TagPatterns patterns = new TagPatternsStorage.TagPatterns();
+        patterns.setCustomTagPattern(config.getCustomTagPattern());
+        patterns.setRemoveTextPattern(config.getRemoveTextPattern());
+        if (patterns.isEmpty()) {
+            return null;
+        }
+        try {
+            return TagPatternsStorage.writeToString(patterns);
+        } catch (IOException ex) {
+            Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+            return null;
+        }
+    }
+
+    private static void applySessionTagPatterns(ProjectProperties config, @Nullable String raw) {
+        if (raw == null) {
+            config.setCustomTagPattern(null);
+            config.setRemoveTextPattern(null);
+        } else {
+            TagPatternsStorage.TagPatterns patterns;
+            try {
+                patterns = TagPatternsStorage.loadFromString(raw);
+            } catch (IOException ex) {
+                // Unparseable content: keep the current session expressions
+                // instead of silently falling back to global defaults.
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                return;
+            }
+            config.setCustomTagPattern(patterns.getCustomTagPattern());
+            config.setRemoveTextPattern(patterns.getRemoveTextPattern());
+        }
+        if (appliesToLoadedProject(config)) {
+            PatternConsts.applyProjectPatterns(config.getCustomTagPattern(),
+                    config.getRemoveTextPattern());
+        }
+    }
+
+    /**
+     * The two expressions are short enough to show, so unlike the other
+     * file-backed settings the description names them instead of a
+     * fingerprint.
+     */
+    private static String describeTagPatterns(@Nullable String raw) {
+        if (raw == null) {
+            return OStrings.getString("TEAM_SETTING_VALUE_FILE_NONE");
+        }
+        try {
+            TagPatternsStorage.TagPatterns patterns = TagPatternsStorage.loadFromString(raw);
+            return OStrings.getString("TEAM_SETTING_VALUE_TAG_PATTERNS",
+                    describePattern(patterns.getCustomTagPattern()),
+                    describePattern(patterns.getRemoveTextPattern()));
+        } catch (IOException ex) {
+            return describeFile(raw);
+        }
+    }
+
+    private static String describePattern(@Nullable String pattern) {
+        if (pattern == null) {
+            return OStrings.getString("TEAM_SETTING_VALUE_TAG_PATTERNS_GLOBAL");
+        }
+        if (pattern.isEmpty()) {
+            return OStrings.getString("TEAM_SETTING_VALUE_TAG_PATTERNS_OFF");
+        }
+        return '"' + pattern + '"';
+    }
+
     /**
      * Whether the given properties belong to the loaded project, so the
      * apply must also rewire the live filter master or segmenter. False
@@ -243,6 +325,46 @@ public final class TeamSettingFiles {
         @Override
         public List<String> pathsUnderRoot(ProjectProperties config) {
             return List.of(config.getProjectInternalRelative() + FilterMaster.FILE_FILTERS);
+        }
+    }
+
+    private static final class TagPatternsFileStorage implements TeamSetting.Storage {
+
+        @Override
+        public @Nullable String loadFrom(ProjectProperties config,
+                Function<String, @Nullable File> fileResolver) {
+            File file = fileResolver.apply(pathsUnderRoot(config).get(0));
+            if (file == null || !file.isFile()) {
+                return null;
+            }
+            try {
+                TagPatternsStorage.TagPatterns patterns = TagPatternsStorage.load(file);
+                return patterns == null || patterns.isEmpty() ? null
+                        : TagPatternsStorage.writeToString(patterns);
+            } catch (IOException ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                return null;
+            }
+        }
+
+        @Override
+        public void save(ProjectProperties config, @Nullable String raw) throws IOException {
+            if (raw == null && config.isTagPatternsLoadFailed()) {
+                // An unreadable file is not represented by the session's
+                // null value: leave it in place for repair instead of
+                // deleting it on a routine save.
+                return;
+            }
+            TagPatternsStorage.save(raw == null ? null : TagPatternsStorage.loadFromString(raw),
+                    new File(config.getProjectInternal(), TagPatternsStorage.FILE_TAG_PATTERNS));
+            // A successful write of real content replaces a possibly broken
+            // file, so the repair protection may end.
+            config.resetTagPatternsLoadFailed();
+        }
+
+        @Override
+        public List<String> pathsUnderRoot(ProjectProperties config) {
+            return List.of(config.getProjectInternalRelative() + TagPatternsStorage.FILE_TAG_PATTERNS);
         }
     }
 

--- a/src/main/java/org/omegat/core/data/TeamSettingsRegistry.java
+++ b/src/main/java/org/omegat/core/data/TeamSettingsRegistry.java
@@ -1,0 +1,70 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Registry of team-negotiated project settings. Feature code registers its
+ * {@link TeamSetting} at plugin load; core iterates registered settings when
+ * loading, saving and distributing projects. Empty registry means every
+ * related code path stays no-op.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class TeamSettingsRegistry {
+
+    private static final List<TeamSetting> SETTINGS = new CopyOnWriteArrayList<>();
+
+    private TeamSettingsRegistry() {
+    }
+
+    /** Registers setting; rejects duplicate key. */
+    public static void register(TeamSetting setting) {
+        if (byKey(setting.getKey()) != null) {
+            throw new IllegalArgumentException("Team setting already registered: " + setting.getKey());
+        }
+        SETTINGS.add(setting);
+    }
+
+    /** Removes setting with given key, for plugin unload and tests. */
+    public static void unregister(String key) {
+        SETTINGS.removeIf(s -> s.getKey().equals(key));
+    }
+
+    /** All registered settings, in registration order. */
+    public static List<TeamSetting> all() {
+        return List.copyOf(SETTINGS);
+    }
+
+    /** Setting with given key, null when unknown. */
+    public static @Nullable TeamSetting byKey(String key) {
+        return SETTINGS.stream().filter(s -> s.getKey().equals(key)).findFirst().orElse(null);
+    }
+}

--- a/src/main/java/org/omegat/core/segmentation/SRXManager.java
+++ b/src/main/java/org/omegat/core/segmentation/SRXManager.java
@@ -33,6 +33,8 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -40,6 +42,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -127,6 +130,33 @@ public final class SRXManager {
             return;
         }
 
+        try (FileOutputStream fos = new FileOutputStream(outFile)) {
+            MAPPER.writerWithDefaultPrettyPrinter().writeValue(fos, toJaxb(srx));
+        } catch (DatabindException e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Serializes segmentation rules to the same SRX text that
+     * {@link #saveToSrx} writes, for content comparisons that must not
+     * depend on file formatting.
+     *
+     * @param srx
+     *            the rules to serialize
+     * @return the rules as pretty-printed SRX
+     * @throws IOException
+     *             if the rules cannot be serialized
+     */
+    public static String writeToString(SRX srx) throws IOException {
+        try {
+            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(toJaxb(srx));
+        } catch (DatabindException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private static Srx toJaxb(SRX srx) {
         ObjectFactory factory = new ObjectFactory();
         Srx jaxbObject = factory.createSrx();
         jaxbObject.setVersion("2.0");
@@ -161,12 +191,7 @@ public final class SRXManager {
                 }
             }
         }
-
-        try (FileOutputStream fos = new FileOutputStream(outFile)) {
-            MAPPER.writerWithDefaultPrettyPrinter().writeValue(fos, jaxbObject);
-        } catch (DatabindException e) {
-            throw new IOException(e);
-        }
+        return jaxbObject;
     }
 
     public static @Nullable SRX loadSrxFile(URI rulesUri) {
@@ -209,6 +234,62 @@ public final class SRXManager {
     }
 
     /**
+     * Parses segmentation rules from SRX text.
+     *
+     * @param content
+     *            the rules as SRX text
+     * @return the parsed rules
+     * @throws IOException
+     *             if the text cannot be parsed
+     */
+    public static SRX loadSrxFromString(String content) throws IOException {
+        return loadSrxInputStream(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    /**
+     * Like {@link #loadFromDir}, but free of side effects: a legacy
+     * {@link #CONF_SENTSEG} file is converted in memory instead of being
+     * replaced by a {@link #SRX_SENTSEG} file on disk, so the directory can
+     * be inspected without being modified.
+     *
+     * @param configDir
+     *            the directory holding the segmentation files
+     * @return the effective rules, or null when neither file is present or
+     *         readable
+     */
+    public static @Nullable SRX loadFromDirNoMigrate(File configDir) {
+        File inFile = new File(configDir, SRX_SENTSEG);
+        if (inFile.exists()) {
+            return loadSrxFile(inFile.toURI());
+        }
+        inFile = new File(configDir, CONF_SENTSEG);
+        if (inFile.exists()) {
+            return loadConfFileNoMigrate(inFile);
+        }
+        return null;
+    }
+
+    /**
+     * Parses a legacy {@link #CONF_SENTSEG} file in memory, without writing
+     * or deleting anything on disk.
+     *
+     * @param confFile
+     *            the legacy file
+     * @return the parsed rules, or null when the file is unreadable
+     */
+    public static @Nullable SRX loadConfFileNoMigrate(File confFile) {
+        try {
+            ByteArrayOutputStream converted = new ByteArrayOutputStream();
+            confToSrxTransformer().transform(new StreamSource(confFile), new StreamResult(converted));
+            return loadSrxInputStream(new ByteArrayInputStream(converted.toByteArray()));
+        } catch (Exception e) {
+            Log.logDebug("Error loading segmentation rules from file: {0}\n{1}", confFile,
+                    e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Loads segmentation rules from an XML file. If there's an error loading a
      * file, it calls <code>getDefault</code>.
      * <p>
@@ -218,14 +299,7 @@ public final class SRXManager {
      */
     static @Nullable SRX loadConfFile(File configFile, File configDir) throws Exception {
         try {
-            TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            transformerFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "");
-            transformerFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet",
-                    "");
-            // add XSLT in Transformer
-            Transformer transformer = transformerFactory.newTransformer(new StreamSource(SRX.class
-                    .getClassLoader().getResourceAsStream("org/omegat/core/segmentation/java2srx.xsl")));
+            Transformer transformer = confToSrxTransformer();
             File dest = new File(configDir, SRX_SENTSEG);
             try (FileOutputStream fos = new FileOutputStream(dest)) {
                 transformer.transform(new StreamSource(configFile), new StreamResult(fos));
@@ -243,6 +317,15 @@ public final class SRXManager {
                 throw e;
             }
         }
+    }
+
+    private static Transformer confToSrxTransformer() throws Exception {
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        transformerFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "");
+        transformerFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet", "");
+        return transformerFactory.newTransformer(new StreamSource(SRX.class.getClassLoader()
+                .getResourceAsStream("org/omegat/core/segmentation/java2srx.xsl")));
     }
 
     public static SRX loadSrxInputStream(InputStream io) throws IOException {

--- a/src/main/java/org/omegat/core/team2/RemoteReachabilityProbe.java
+++ b/src/main/java/org/omegat/core/team2/RemoteReachabilityProbe.java
@@ -1,0 +1,219 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jspecify.annotations.Nullable;
+
+import gen.core.project.RepositoryDefinition;
+
+/**
+ * Quick reachability check for the remote repositories of a team project: a
+ * plain TCP connect with a short timeout per remote host, name resolution
+ * capped by the same timeout. The auto-save thread uses it, outside the
+ * project lock, to decide whether an offline project should attempt to
+ * restore team synchronization; the full version control machinery is only
+ * started once the hosts answer, so a dead network can never stall editing.
+ * The probe connects directly: in an environment that reaches the remote
+ * side only through a proxy it stays negative, and a manual save remains the
+ * way to go back online there.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public final class RemoteReachabilityProbe {
+
+    /** Connect timeout for the probe of one host. */
+    static final int TIMEOUT_MS = 3000;
+
+    /** Matches the scp-like git syntax with user, e.g. "git@host:path". */
+    private static final Pattern SCP_LIKE_WITH_USER = Pattern
+            .compile("^[^@/\\s]+@([A-Za-z0-9][A-Za-z0-9._\\-]+):.+");
+
+    /**
+     * Matches the scp-like git syntax without user, e.g. "host.tld:path". The
+     * host needs a dot and the path must not look like one, so drive letters
+     * and odd schemes stay out.
+     */
+    private static final Pattern SCP_LIKE_NO_USER = Pattern
+            .compile("^([A-Za-z0-9][A-Za-z0-9_\\-]*(?:\\.[A-Za-z0-9._\\-]+)+):[^/\\\\].*");
+
+    private RemoteReachabilityProbe() {
+    }
+
+    /**
+     * Check with the default timeout, see {@link #canReachAll(List, int)}.
+     */
+    public static boolean canReachAll(List<RepositoryDefinition> repositories) {
+        return canReachAll(repositories, TIMEOUT_MS);
+    }
+
+    /**
+     * Check whether every remote host of the given repository definitions
+     * accepts a TCP connection. URLs without a recognizable network host
+     * (file URLs, local paths, unknown schemes) count as reachable: they
+     * cannot hang on a dead network, and the sync itself is the authority on
+     * whether they work.
+     *
+     * @param repositories
+     *            repository definitions of the project
+     * @param timeoutMs
+     *            resolve and connect timeout per host
+     * @return true when no probed host refused
+     */
+    public static boolean canReachAll(List<RepositoryDefinition> repositories, int timeoutMs) {
+        return repositories.stream().map(RepositoryDefinition::getUrl).distinct()
+                .allMatch(url -> canReach(url, timeoutMs));
+    }
+
+    static boolean canReach(@Nullable String url, int timeoutMs) {
+        InetSocketAddress target = toSocketAddress(url);
+        if (target == null) {
+            return true;
+        }
+        InetSocketAddress resolved = resolve(target, timeoutMs);
+        if (resolved == null || resolved.isUnresolved()) {
+            return false;
+        }
+        try (Socket socket = new Socket()) {
+            socket.connect(resolved, timeoutMs);
+            return true;
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Resolve with a deadline: the platform resolver has no timeout of its
+     * own and may block far longer than the probe should.
+     */
+    @Nullable
+    private static InetSocketAddress resolve(InetSocketAddress target, int timeoutMs) {
+        try {
+            return CompletableFuture
+                    .supplyAsync(() -> new InetSocketAddress(target.getHostString(), target.getPort()))
+                    .get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (ExecutionException | TimeoutException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Extract host and port to probe from a repository URL, null when the URL
+     * carries no probeable network host. Pure parse: the returned address is
+     * unresolved, name resolution happens only in the actual probe.
+     */
+    @Nullable
+    static InetSocketAddress toSocketAddress(@Nullable String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        String trimmed = url.trim();
+        try {
+            URI uri = new URI(trimmed);
+            String scheme = uri.getScheme();
+            if (scheme != null) {
+                int schemePort = defaultPort(scheme);
+                String host = uri.getHost();
+                if (host != null) {
+                    int port = uri.getPort() != -1 ? uri.getPort() : schemePort;
+                    return port == -1 ? null : InetSocketAddress.createUnresolved(host, port);
+                }
+                // Hosts the URI class refuses (e.g. with underscores) are
+                // still probeable through the raw authority.
+                InetSocketAddress fromAuthority = fromAuthority(uri.getAuthority(), schemePort);
+                if (fromAuthority != null) {
+                    return fromAuthority;
+                }
+            }
+        } catch (URISyntaxException ignored) {
+            // not a URI - try the scp-like forms below
+        }
+        Matcher withUser = SCP_LIKE_WITH_USER.matcher(trimmed);
+        if (withUser.matches()) {
+            return InetSocketAddress.createUnresolved(withUser.group(1), 22);
+        }
+        Matcher noUser = SCP_LIKE_NO_USER.matcher(trimmed);
+        if (noUser.matches()) {
+            return InetSocketAddress.createUnresolved(noUser.group(1), 22);
+        }
+        return null;
+    }
+
+    @Nullable
+    private static InetSocketAddress fromAuthority(@Nullable String authority, int defaultPort) {
+        if (authority == null || authority.isEmpty() || defaultPort == -1 || authority.indexOf('[') >= 0) {
+            return null;
+        }
+        String hostPort = authority.substring(authority.lastIndexOf('@') + 1);
+        String host = hostPort;
+        int port = defaultPort;
+        int colon = hostPort.lastIndexOf(':');
+        if (colon >= 0) {
+            host = hostPort.substring(0, colon);
+            try {
+                port = Integer.parseInt(hostPort.substring(colon + 1));
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return host.isEmpty() ? null : InetSocketAddress.createUnresolved(host, port);
+    }
+
+    private static int defaultPort(String scheme) {
+        switch (scheme.toLowerCase(Locale.ENGLISH)) {
+        case "http":
+            return 80;
+        case "https":
+            return 443;
+        case "ssh":
+        case "git+ssh":
+        case "svn+ssh":
+            return 22;
+        case "git":
+            return 9418;
+        case "svn":
+            return 3690;
+        default:
+            return -1;
+        }
+    }
+}

--- a/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -28,6 +28,7 @@ package org.omegat.core.team2;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -196,6 +197,60 @@ public class RemoteRepositoryProvider {
         return !getMappings(path).isEmpty();
     }
 
+    /**
+     * Whether every checked-out repository copy of the given project file is
+     * byte-identical to the file in the project directory, i.e. committing
+     * it would be a no-op. Only meaningful for files that are copied without
+     * EOL conversion, and after the repositories have been switched to a
+     * version.
+     */
+    public boolean isIdenticalInRepositories(String localPath) throws IOException {
+        File localFile = new File(projectRoot, localPath);
+        boolean found = false;
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile == null) {
+                continue;
+            }
+            if (!repoFile.exists() || !FileUtils.contentEquals(localFile, repoFile)) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
+    /**
+     * Like {@link #isIdenticalInRepositories}, but treating CRLF and LF line
+     * endings as equal: repository checkouts may re-line-end text files (git
+     * autocrlf on Windows), and that must not disguise an unchanged file as
+     * a change, whose empty commit then reports like a rejected push.
+     */
+    public boolean isIdenticalInRepositoriesIgnoringEol(String localPath) throws IOException {
+        File localFile = new File(projectRoot, localPath);
+        boolean found = false;
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile == null) {
+                continue;
+            }
+            if (!repoFile.exists() || !contentEqualsIgnoringEol(localFile, repoFile)) {
+                return false;
+            }
+            found = true;
+        }
+        return found;
+    }
+
+    private static boolean contentEqualsIgnoringEol(File a, File b) throws IOException {
+        return normalizeEol(FileUtils.readFileToByteArray(a))
+                .equals(normalizeEol(FileUtils.readFileToByteArray(b)));
+    }
+
+    private static String normalizeEol(byte[] content) {
+        return new String(content, StandardCharsets.ISO_8859_1).replace("\r\n", "\n");
+    }
+
     public void cleanPrepared() throws IOException {
         FileUtils.deleteDirectory(new File(projectRoot, REPO_PREPARE_SUBDIR));
     }
@@ -297,6 +352,23 @@ public class RemoteRepositoryProvider {
         for (IRemoteRepository2 repo : repos.values()) {
             repo.commit(null, commentText);
         }
+    }
+
+    /**
+     * Same as commitFiles, but reports whether every affected repository
+     * accepted the commit: a rejected push (for example non-fast-forward)
+     * makes IRemoteRepository2.commit return null instead of throwing.
+     */
+    public boolean commitFilesChecked(String path, String commentText) throws Exception {
+        Map<String, IRemoteRepository2> repos = new TreeMap<>();
+        for (Mapping m : getMappings(path)) {
+            repos.put(m.repoDefinition.getUrl(), m.repo);
+        }
+        boolean accepted = true;
+        for (IRemoteRepository2 repo : repos.values()) {
+            accepted &= repo.commit(null, commentText) != null;
+        }
+        return accepted;
     }
 
     /**
@@ -509,6 +581,29 @@ public class RemoteRepositoryProvider {
          */
         public boolean matches() {
             return filterPrefix != null;
+        }
+
+        /**
+         * The file for the given project path inside this mapping's
+         * checked-out repository copy, or null when the path is outside the
+         * mapping.
+         */
+        @Nullable
+        File fileInRepository(String path) {
+            String p = withLeadingSlash(withoutTrailingSlash(path));
+            String local = withSlashes(repoMapping.getLocal());
+            String relative;
+            if (withTrailingSlash(p).equals(local)) {
+                // file mapping: the repository part is the file itself
+                relative = "";
+            } else if (p.startsWith(local)) {
+                relative = p.substring(local.length());
+            } else {
+                return null;
+            }
+            File base = new File(getRepositoryDir(repoDefinition),
+                    withoutLeadingSlash(repoMapping.getRepository()));
+            return new File(base, relative);
         }
 
         public void copyFromRepoToProject(final String postfix) throws IOException {

--- a/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
+++ b/src/main/java/org/omegat/core/team2/RemoteRepositoryProvider.java
@@ -32,11 +32,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -251,6 +254,69 @@ public class RemoteRepositoryProvider {
         return new String(content, StandardCharsets.ISO_8859_1).replace("\r\n", "\n");
     }
 
+    /**
+     * One resolver per repository carrying any of the given paths, mapping
+     * a project path to the file in that repository's checkout - null when
+     * the path is outside the repository's mappings. Lets callers read the
+     * team-side state of a group of files repository by repository,
+     * independent of the file formatting a byte comparison would need.
+     */
+    public List<Function<String, @Nullable File>> repositoryFileViews(List<String> paths) {
+        Map<String, List<Mapping>> byRepo = new TreeMap<>();
+        for (String path : paths) {
+            for (Mapping m : getMappings(path)) {
+                byRepo.computeIfAbsent(m.repoDefinition.getUrl(), k -> new ArrayList<>()).add(m);
+            }
+        }
+        List<Function<String, @Nullable File>> views = new ArrayList<>();
+        for (List<Mapping> mappings : byRepo.values()) {
+            views.add(path -> {
+                List<File> candidates = mappings.stream().map(m -> m.fileInRepository(path))
+                        .filter(Objects::nonNull).collect(Collectors.toList());
+                // several mappings may cover the path; an existing file
+                // beats the mere possibility of one
+                return candidates.stream().filter(File::exists).findFirst()
+                        .orElse(candidates.isEmpty() ? null : candidates.get(0));
+            });
+        }
+        return views;
+    }
+
+    /**
+     * Whether any checked-out repository copy of the given project file
+     * exists, i.e. the team carries the file even when the checkout does
+     * not.
+     */
+    public boolean existsInRepositories(String localPath) {
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            if (repoFile != null && repoFile.exists()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Stages the given project file for deletion in every repository that
+     * carries it, the counterpart of copyFilesFromProjectToRepos for a file
+     * that no longer exists in the checkout. The deletion becomes effective
+     * with the next commit of the affected repositories.
+     */
+    public void deleteFilesFromRepos(String localPath) throws Exception {
+        for (Mapping m : getMappings(localPath)) {
+            File repoFile = m.fileInRepository(localPath);
+            String repoRelative = m.pathInRepository(localPath);
+            if (repoFile != null && repoFile.exists() && repoRelative != null) {
+                m.repo.addForDeletion(repoRelative);
+                // Version control staged the deletion; make sure the
+                // checkout copy is gone even when it only unstaged the
+                // file.
+                FileUtils.deleteQuietly(repoFile);
+            }
+        }
+    }
+
     public void cleanPrepared() throws IOException {
         FileUtils.deleteDirectory(new File(projectRoot, REPO_PREPARE_SUBDIR));
     }
@@ -360,9 +426,20 @@ public class RemoteRepositoryProvider {
      * makes IRemoteRepository2.commit return null instead of throwing.
      */
     public boolean commitFilesChecked(String path, String commentText) throws Exception {
+        return commitFilesChecked(Collections.singletonList(path), commentText);
+    }
+
+    /**
+     * Like {@link #commitFilesChecked(String, String)} for several paths at
+     * once: every affected repository commits a single time, covering all
+     * of its staged paths.
+     */
+    public boolean commitFilesChecked(List<String> paths, String commentText) throws Exception {
         Map<String, IRemoteRepository2> repos = new TreeMap<>();
-        for (Mapping m : getMappings(path)) {
-            repos.put(m.repoDefinition.getUrl(), m.repo);
+        for (String path : paths) {
+            for (Mapping m : getMappings(path)) {
+                repos.put(m.repoDefinition.getUrl(), m.repo);
+            }
         }
         boolean accepted = true;
         for (IRemoteRepository2 repo : repos.values()) {
@@ -604,6 +681,32 @@ public class RemoteRepositoryProvider {
             File base = new File(getRepositoryDir(repoDefinition),
                     withoutLeadingSlash(repoMapping.getRepository()));
             return new File(base, relative);
+        }
+
+        /**
+         * The repository-root-relative path for the given project path,
+         * following the same conventions as the addForCommit calls of
+         * copyFromProjectToRepo, or null when the path is outside the
+         * mapping.
+         */
+        @Nullable
+        String pathInRepository(String path) {
+            String p = withLeadingSlash(withoutTrailingSlash(path));
+            String local = withSlashes(repoMapping.getLocal());
+            String relative;
+            if (withTrailingSlash(p).equals(local)) {
+                // file mapping: the repository part is the file itself
+                return withoutSlashes(repoMapping.getRepository());
+            } else if (p.startsWith(local)) {
+                relative = p.substring(local.length());
+            } else {
+                return null;
+            }
+            String repoSubdir = withoutLeadingSlash(repoMapping.getRepository());
+            if (!repoSubdir.isEmpty()) {
+                repoSubdir = withTrailingSlash(repoSubdir);
+            }
+            return repoSubdir + withoutSlashes(relative);
         }
 
         public void copyFromRepoToProject(final String postfix) throws IOException {

--- a/src/main/java/org/omegat/core/threads/SaveThread.java
+++ b/src/main/java/org/omegat/core/threads/SaveThread.java
@@ -8,6 +8,7 @@
                2012 Didier Briel
                2015 Aaron Madlon-Kay
                2026 Hiroshi Miura
+               2026 Stephan Pakebusch
                Home page: https://www.omegat.org/
                Support center: https://omegat.org/support
 
@@ -146,9 +147,22 @@ public class SaveThread implements IAutoSave {
 
     private static void executeSave() {
         IProject dataEngine = Core.getProject();
+        // Probed outside the project lock: a dead network may block this
+        // thread up to the probe timeout per host, but never editing. When
+        // the remote hosts answer again, one save with team sync restores the
+        // lost synchronization and switches the project back to online mode.
+        boolean restoreTeamSync = dataEngine.canRestoreTeamSync();
         try {
             Core.executeExclusively(false, () -> {
-                dataEngine.saveProject(false);
+                if (dataEngine != Core.getProject()) {
+                    // closed or replaced while the probe was running
+                    return;
+                }
+                if (restoreTeamSync) {
+                    dataEngine.restoreTeamSync();
+                } else {
+                    dataEngine.saveProject(false);
+                }
                 dataEngine.teamSyncPrepare();
             });
             Core.getMainWindow().showStatusMessageRB("ST_PROJECT_AUTOSAVED",

--- a/src/main/java/org/omegat/filters2/master/FilterMaster.java
+++ b/src/main/java/org/omegat/filters2/master/FilterMaster.java
@@ -529,6 +529,60 @@ public class FilterMaster {
         }
     }
 
+    /**
+     * Serializes a filter configuration to the same XML text that
+     * {@link #saveConfig} writes, for content comparisons that must not
+     * depend on file formatting.
+     *
+     * @param config
+     *            the configuration to serialize
+     * @return the configuration as pretty-printed XML
+     * @throws IOException
+     *             if the configuration cannot be serialized
+     */
+    public static String writeConfigToString(Filters config) throws IOException {
+        try {
+            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(config);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Parses a filter configuration from XML text. Unlike
+     * {@link #loadConfig}, this neither adds newly available filters nor
+     * rewrites any file, so it is free of side effects.
+     *
+     * @param content
+     *            the configuration as XML text
+     * @return the parsed configuration
+     * @throws IOException
+     *             if the text cannot be parsed
+     */
+    public static Filters loadConfigFromString(String content) throws IOException {
+        try {
+            return MAPPER.readValue(content, Filters.class);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Adds the filters available in this installation that the given
+     * configuration lacks, the same completion {@link #loadConfig} applies
+     * when reading a file - but in memory only. Lets callers bring
+     * configurations from other sources (a team repository, an older
+     * OmegaT version) to the form this installation works with.
+     *
+     * @param config
+     *            the configuration to complete; modified in place
+     * @return the same configuration, completed
+     */
+    public static Filters completeWithAvailableFilters(Filters config) {
+        addNewFiltersToConfig(config);
+        return config;
+    }
+
     // ////////////////////////////////////////////////////////////////////////
     // Static Utility Methods
     // ////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialog.java
@@ -391,6 +391,14 @@ public class ProjectPropertiesDialog extends JDialog {
         gbc.anchor = GridBagConstraints.LINE_END;
         optionsBox.add(externalFinderButton, gbc);
 
+        // Project-specific custom tag and removed-text expressions
+        Mnemonics.setLocalizedText(tagDefinitionsButton, OStrings.getString("PP_LOCAL_TAG_DEFINITIONS"));
+        tagDefinitionsButton.setName(TAG_DEFINITIONS_BUTTON_NAME);
+        gbc.gridx = 1;
+        gbc.gridy = 4;
+        gbc.anchor = GridBagConstraints.LINE_END;
+        optionsBox.add(tagDefinitionsButton, gbc);
+
         // multiple translations
         Mnemonics.setLocalizedText(allowDefaultsCheckBox, OStrings.getString("PP_ALLOW_DEFAULTS"));
         allowDefaultsCheckBox.setName(ALLOW_DEFAULTS_CB_NAME);
@@ -667,6 +675,7 @@ public class ProjectPropertiesDialog extends JDialog {
         allowDefaultsCheckBox.setEnabled(false);
         removeTagsCheckBox.setEnabled(false);
         matchNumbersCheckBox.setEnabled(false);
+        tagDefinitionsButton.setEnabled(false);
         externalCommandTextArea.setEnabled(false);
         insertButton.setEnabled(false);
         variablesList.setEnabled(false);
@@ -776,6 +785,9 @@ public class ProjectPropertiesDialog extends JDialog {
 
     // Numbers in fuzzy matching
     JCheckBox matchNumbersCheckBox = new JCheckBox();
+
+    // Project-specific tag patterns
+    JButton tagDefinitionsButton = new JButton();
     JButton exportTMBrowse = new JButton();
     JButton sentenceSegmentingButton = new JButton();
 
@@ -839,6 +851,7 @@ public class ProjectPropertiesDialog extends JDialog {
     public static final String ALLOW_DEFAULTS_CB_NAME = "project_properties_allow_defaults_cb";
     public static final String REMOVE_TAGS_CB_NAME = "project_properties_remove_tags_cb";
     public static final String MATCH_NUMBERS_CB_NAME = "project_properties_match_numbers_cb";
+    public static final String TAG_DEFINITIONS_BUTTON_NAME = "project_properties_tag_definitions_button";
     public static final String EXPORT_TM_BROWSE_BUTTON_NAME = "project_properties_export_tm_browse_button";
     public static final String FILE_FILTER_BUTTON_NAME = "project_properties_file_filter_button";
     public static final String EXPORT_TM_ROOT_FIELD_NAME = "project_properties_export_tm_root_field";

--- a/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
+++ b/src/main/java/org/omegat/gui/dialogs/ProjectPropertiesDialogController.java
@@ -47,6 +47,8 @@ import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import org.jspecify.annotations.Nullable;
+
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.segmentation.SRX;
 import org.omegat.externalfinder.ExternalFinder;
@@ -60,6 +62,7 @@ import org.omegat.gui.segmentation.SegmentationCustomizer;
 import org.omegat.util.Language;
 import org.omegat.util.OConsts;
 import org.omegat.util.OStrings;
+import org.omegat.util.PatternConsts;
 import org.omegat.util.Preferences;
 import org.omegat.util.StringUtil;
 import org.omegat.util.gui.OmegaTFileChooser;
@@ -87,6 +90,17 @@ public class ProjectPropertiesDialogController {
      * Whether the user canceled the dialog.
      */
     private boolean dialogCancelled;
+    /** The project's custom-tag expression; null means the global preference applies. */
+    private @Nullable String customTagPattern;
+    /** The project's removed-text expression; null means the global preference applies. */
+    private @Nullable String removeTextPattern;
+    /**
+     * Whether the user confirmed the tag definitions editor. The stored
+     * expressions are only rewritten in that case, so a routine OK neither
+     * touches them nor lifts the load-failure guard of a broken
+     * tag_patterns.xml.
+     */
+    private boolean tagPatternsEdited;
 
     private final Frame parent;
     private final ProjectPropertiesDialog dialog;
@@ -136,6 +150,19 @@ public class ProjectPropertiesDialogController {
         dialog.targetTokenizerField.setSelectedItem(projectProperties.getTargetTokenizer());
 
         dialog.externalCommandTextArea.setText(projectProperties.getExternalCommand());
+
+        customTagPattern = projectProperties.getCustomTagPattern();
+        removeTextPattern = projectProperties.getRemoveTextPattern();
+    }
+
+    private static String globalCustomTagPattern() {
+        return Preferences.existsPreference(Preferences.CHECK_CUSTOM_PATTERN)
+                ? Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN)
+                : PatternConsts.CHECK_CUSTOM_PATTERN_DEFAULT;
+    }
+
+    private static String globalRemoveTextPattern() {
+        return Preferences.getPreference(Preferences.CHECK_REMOVE_PATTERN);
     }
 
     private void initializeActions(ProjectPropertiesDialog.Mode dialogType) {
@@ -189,6 +216,16 @@ public class ProjectPropertiesDialogController {
             ExternalFinderCustomizer dlg = new ExternalFinderCustomizer(true, externalFinderConfig);
             if (dlg.show(dialog)) {
                 externalFinderConfig = dlg.getResult();
+            }
+        });
+        dialog.tagDefinitionsButton.addActionListener(e -> {
+            TagDefinitionsDialog dlg = new TagDefinitionsDialog(customTagPattern, removeTextPattern,
+                    globalCustomTagPattern(), globalRemoveTextPattern(),
+                    projectProperties.isTagPatternsLoadFailed());
+            if (dlg.show(dialog)) {
+                customTagPattern = dlg.getCustomTagPattern();
+                removeTextPattern = dlg.getRemoveTextPattern();
+                tagPatternsEdited = true;
             }
         });
         dialog.cancelButton.addActionListener(e -> doCancel());
@@ -641,6 +678,14 @@ public class ProjectPropertiesDialogController {
 
         projectProperties.setProjectSRX(srx);
         projectProperties.setProjectFilters(filters);
+        if (tagPatternsEdited) {
+            // Only past every validation above: an earlier write would let a
+            // failed-then-abandoned OK lift the load-failure guard of a
+            // broken tag_patterns.xml without the user's decision.
+            projectProperties.setCustomTagPattern(customTagPattern);
+            projectProperties.setRemoveTextPattern(removeTextPattern);
+            projectProperties.resetTagPatternsLoadFailed();
+        }
         projectProperties.getSourceRootExcludes().clear();
         projectProperties.getSourceRootExcludes().addAll(srcExcludes);
 

--- a/src/main/java/org/omegat/gui/dialogs/TagDefinitionsDialog.java
+++ b/src/main/java/org/omegat/gui/dialogs/TagDefinitionsDialog.java
@@ -1,0 +1,267 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.gui.dialogs;
+
+import java.awt.BorderLayout;
+import java.awt.Dialog;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Window;
+import java.text.MessageFormat;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.UIManager;
+import javax.swing.WindowConstants;
+
+import org.jspecify.annotations.Nullable;
+import org.openide.awt.Mnemonics;
+
+import org.omegat.util.OStrings;
+import org.omegat.util.gui.StaticUIUtils;
+
+/**
+ * Editor for the project-specific custom tag and removed-text expressions,
+ * opened from the "Local Tag Definitions..." button of the project
+ * properties dialog. A {@code null} expression means the project follows the
+ * global preference; an empty one switches the expression off.
+ *
+ * @author Stephan Pakebusch
+ */
+public class TagDefinitionsDialog {
+
+    public static final String USE_LOCAL_CB_NAME = "tag_definitions_use_local_cb";
+    public static final String CUSTOM_TAG_PATTERN_FIELD_NAME = "tag_definitions_custom_tag_pattern_field";
+    public static final String REMOVE_TEXT_PATTERN_FIELD_NAME = "tag_definitions_remove_text_pattern_field";
+
+    private final String globalCustomTagPattern;
+    private final String globalRemoveTextPattern;
+    private final boolean storedFileUnreadable;
+    private @Nullable String customTagPattern;
+    private @Nullable String removeTextPattern;
+    private boolean userDidConfirm;
+    /** The prefill runs at most once, so emptied fields stay empty on a re-tick. */
+    private boolean prefilled;
+
+    /**
+     * @param customTagPattern
+     *            the project's custom-tag expression, or {@code null} when
+     *            the project follows the global preference
+     * @param removeTextPattern
+     *            the project's removed-text expression, or {@code null} when
+     *            the project follows the global preference
+     * @param globalCustomTagPattern
+     *            the global custom-tag expression, used to prefill the field
+     * @param globalRemoveTextPattern
+     *            the global removed-text expression, used to prefill the
+     *            field
+     * @param storedFileUnreadable
+     *            whether the project carries a tag_patterns.xml that could
+     *            not be read; the editor then warns that confirming it
+     *            replaces the file
+     */
+    public TagDefinitionsDialog(@Nullable String customTagPattern, @Nullable String removeTextPattern,
+            String globalCustomTagPattern, String globalRemoveTextPattern,
+            boolean storedFileUnreadable) {
+        this.customTagPattern = customTagPattern;
+        this.removeTextPattern = removeTextPattern;
+        this.globalCustomTagPattern = globalCustomTagPattern;
+        this.globalRemoveTextPattern = globalRemoveTextPattern;
+        this.storedFileUnreadable = storedFileUnreadable;
+    }
+
+    /**
+     * Shows the modal editor. Returns true when the user confirmed it; the
+     * edited expressions are then available from {@link #getCustomTagPattern()}
+     * and {@link #getRemoveTextPattern()}.
+     */
+    public boolean show(Window parent) {
+        JDialog dialog = new JDialog(parent, Dialog.ModalityType.APPLICATION_MODAL);
+        dialog.setTitle(OStrings.getString("PP_TAG_PATTERNS"));
+        dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        StaticUIUtils.setEscapeClosable(dialog);
+        StaticUIUtils.setWindowIcon(dialog);
+
+        boolean overriddenAtOpen = customTagPattern != null || removeTextPattern != null;
+
+        JCheckBox useLocalCheckBox = new JCheckBox();
+        Mnemonics.setLocalizedText(useLocalCheckBox, OStrings.getString("PP_TAG_PATTERNS_PROJECT_SPECIFIC"));
+        useLocalCheckBox.setName(USE_LOCAL_CB_NAME);
+        useLocalCheckBox.setSelected(overriddenAtOpen);
+
+        // Show the effective expressions: a pattern the project does not
+        // override is displayed (and on OK pinned) at its global value, so
+        // merely confirming the editor never changes behavior.
+        JTextField customTagPatternField = new JTextField(30);
+        customTagPatternField.setName(CUSTOM_TAG_PATTERN_FIELD_NAME);
+        JTextField removeTextPatternField = new JTextField(30);
+        removeTextPatternField.setName(REMOVE_TEXT_PATTERN_FIELD_NAME);
+        if (overriddenAtOpen) {
+            customTagPatternField.setText(customTagPattern != null ? customTagPattern
+                    : globalCustomTagPattern);
+            removeTextPatternField.setText(removeTextPattern != null ? removeTextPattern
+                    : globalRemoveTextPattern);
+        }
+        customTagPatternField.setEnabled(overriddenAtOpen);
+        removeTextPatternField.setEnabled(overriddenAtOpen);
+
+        // Ticking the override for the first time starts from the global
+        // expressions, so the usual case is editing them, not retyping them.
+        // A project that already overrides the expressions keeps its values,
+        // even when they are deliberately empty, so the prefill stays out of
+        // the way after an accidental toggle.
+        useLocalCheckBox.addActionListener(e -> {
+            if (!overriddenAtOpen && !prefilled && useLocalCheckBox.isSelected()
+                    && customTagPatternField.getText().isEmpty()
+                    && removeTextPatternField.getText().isEmpty()) {
+                prefilled = true;
+                customTagPatternField.setText(globalCustomTagPattern);
+                removeTextPatternField.setText(globalRemoveTextPattern);
+            }
+            customTagPatternField.setEnabled(useLocalCheckBox.isSelected());
+            removeTextPatternField.setEnabled(useLocalCheckBox.isSelected());
+        });
+
+        JPanel contentPanel = new JPanel(new GridBagLayout());
+        contentPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 0, 10));
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(3, 3, 3, 3);
+        gbc.anchor = GridBagConstraints.LINE_START;
+
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.gridwidth = 2;
+        contentPanel.add(useLocalCheckBox, gbc);
+
+        JLabel customTagPatternLabel = new JLabel();
+        Mnemonics.setLocalizedText(customTagPatternLabel, OStrings.getString("TV_OPTION_CUSTOMPATTERN"));
+        customTagPatternLabel.setLabelFor(customTagPatternField);
+        gbc.gridy = 1;
+        gbc.gridwidth = 1;
+        contentPanel.add(customTagPatternLabel, gbc);
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+        contentPanel.add(customTagPatternField, gbc);
+
+        JLabel removeTextPatternLabel = new JLabel();
+        Mnemonics.setLocalizedText(removeTextPatternLabel, OStrings.getString("TV_OPTION_REMOVEPATTERN"));
+        removeTextPatternLabel.setLabelFor(removeTextPatternField);
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.weightx = 0;
+        contentPanel.add(removeTextPatternLabel, gbc);
+        gbc.gridx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+        contentPanel.add(removeTextPatternField, gbc);
+
+        if (storedFileUnreadable) {
+            // Deleting or replacing the still repairable file must be an
+            // informed decision, not a side effect of a curiosity OK.
+            JLabel warningLabel = new JLabel(OStrings.getString("PP_TAG_PATTERNS_LOAD_FAILED"));
+            warningLabel.setIcon(UIManager.getIcon("OptionPane.warningIcon"));
+            gbc.gridx = 0;
+            gbc.gridy = 3;
+            gbc.gridwidth = 2;
+            gbc.fill = GridBagConstraints.HORIZONTAL;
+            contentPanel.add(warningLabel, gbc);
+        }
+
+        JButton okButton = new JButton();
+        Mnemonics.setLocalizedText(okButton, OStrings.getString("BUTTON_OK"));
+        JButton cancelButton = new JButton();
+        Mnemonics.setLocalizedText(cancelButton, OStrings.getString("BUTTON_CANCEL"));
+        Box buttonBox = Box.createHorizontalBox();
+        buttonBox.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        buttonBox.add(Box.createHorizontalGlue());
+        buttonBox.add(okButton);
+        buttonBox.add(Box.createHorizontalStrut(5));
+        buttonBox.add(cancelButton);
+
+        okButton.addActionListener(e -> {
+            if (!useLocalCheckBox.isSelected()) {
+                customTagPattern = null;
+                removeTextPattern = null;
+            } else {
+                for (JTextField field : new JTextField[] { customTagPatternField,
+                        removeTextPatternField }) {
+                    try {
+                        Pattern.compile(field.getText());
+                    } catch (PatternSyntaxException ex) {
+                        JOptionPane.showMessageDialog(dialog,
+                                MessageFormat.format(OStrings.getString("PP_TAG_PATTERN_INVALID"),
+                                        ex.getLocalizedMessage()),
+                                OStrings.getString("TF_ERROR"), JOptionPane.ERROR_MESSAGE);
+                        field.requestFocusInWindow();
+                        return;
+                    }
+                }
+                customTagPattern = customTagPatternField.getText();
+                removeTextPattern = removeTextPatternField.getText();
+            }
+            userDidConfirm = true;
+            StaticUIUtils.closeWindowByEvent(dialog);
+        });
+        cancelButton.addActionListener(e -> StaticUIUtils.closeWindowByEvent(dialog));
+
+        dialog.getContentPane().setLayout(new BorderLayout());
+        dialog.getContentPane().add(contentPanel, BorderLayout.CENTER);
+        dialog.getContentPane().add(buttonBox, BorderLayout.SOUTH);
+        dialog.getRootPane().setDefaultButton(okButton);
+        dialog.pack();
+        dialog.setLocationRelativeTo(parent);
+        dialog.setVisible(true);
+        return userDidConfirm;
+    }
+
+    /**
+     * The confirmed custom-tag expression, or {@code null} when the project
+     * follows the global preference.
+     */
+    public @Nullable String getCustomTagPattern() {
+        return customTagPattern;
+    }
+
+    /**
+     * The confirmed removed-text expression, or {@code null} when the project
+     * follows the global preference.
+     */
+    public @Nullable String getRemoveTextPattern() {
+        return removeTextPattern;
+    }
+}

--- a/src/main/java/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/main/java/org/omegat/gui/main/ProjectUICommands.java
@@ -63,6 +63,7 @@ import org.omegat.core.KnownException;
 import org.omegat.core.data.IProject;
 import org.omegat.core.data.ProjectFactory;
 import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectSettingsStorage;
 import org.omegat.core.data.RuntimePreferenceStore;
 import org.omegat.core.data.TeamSetting;
 import org.omegat.core.data.TeamSettingsRegistry;
@@ -221,7 +222,9 @@ public final class ProjectUICommands {
                 remoteRepositoryProvider.switchAllToLatest();
                 for (String file : new String[] { OConsts.FILE_PROJECT,
                         OConsts.DEFAULT_INTERNAL + '/' + FilterMaster.FILE_FILTERS,
-                        OConsts.DEFAULT_INTERNAL + '/' + SRXManager.CONF_SENTSEG }) {
+                        OConsts.DEFAULT_INTERNAL + '/' + SRXManager.CONF_SENTSEG,
+                        OConsts.DEFAULT_INTERNAL + '/' + SRXManager.SRX_SENTSEG,
+                        OConsts.DEFAULT_INTERNAL + '/' + ProjectSettingsStorage.FILE_PROJECT_SETTINGS }) {
                     remoteRepositoryProvider.copyFilesFromReposToProject(file);
                 }
 
@@ -999,11 +1002,27 @@ public final class ProjectUICommands {
         int res = JOptionPane.showConfirmDialog(frame, OStrings.getString("MW_REOPEN_QUESTION"),
                 OStrings.getString("MW_REOPEN_TITLE"), JOptionPane.YES_NO_OPTION);
         if (res != JOptionPane.YES_OPTION) {
-            if (!settingsToShare.isEmpty()) {
+            if (!changedTeamSettings.isEmpty()) {
                 new SwingWorker<Void, Void>() {
                     @Override
                     protected Void doInBackground() throws Exception {
-                        Core.executeExclusively(true, () -> publishSettingsLoggingErrors(settingsToShare));
+                        Core.executeExclusively(true, () -> {
+                            publishSettingsLoggingErrors(settingsToShare);
+                            changedTeamSettings.forEach((key, value) -> {
+                                if (!settingsToShare.containsKey(key)) {
+                                    // Declined share, no reload: the edit
+                                    // must still reach the local storage,
+                                    // and a pending divergence question on
+                                    // the same setting must not keep
+                                    // suppressing that write.
+                                    try {
+                                        Core.getProject().useLocalProjectSetting(key, value);
+                                    } catch (Exception ex) {
+                                        Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                                    }
+                                }
+                            });
+                        });
                         return null;
                     }
 

--- a/src/main/java/org/omegat/gui/main/ProjectUICommands.java
+++ b/src/main/java/org/omegat/gui/main/ProjectUICommands.java
@@ -40,7 +40,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
@@ -58,9 +60,12 @@ import org.omegat.convert.ConvertProject;
 import org.omegat.core.Core;
 import org.omegat.core.CoreEvents;
 import org.omegat.core.KnownException;
+import org.omegat.core.data.IProject;
 import org.omegat.core.data.ProjectFactory;
 import org.omegat.core.data.ProjectProperties;
 import org.omegat.core.data.RuntimePreferenceStore;
+import org.omegat.core.data.TeamSetting;
+import org.omegat.core.data.TeamSettingsRegistry;
 import org.omegat.core.events.IProjectEventListener;
 import org.omegat.core.segmentation.Segmenter;
 import org.omegat.core.segmentation.SRXManager;
@@ -329,13 +334,104 @@ public final class ProjectUICommands {
             protected void done() {
                 try {
                     get();
-                    SwingUtilities.invokeLater(Core.getEditor()::requestFocus);
+                    SwingUtilities.invokeLater(() -> {
+                        Core.getEditor().requestFocus();
+                        promptForSupersededSettings();
+                    });
                 } catch (Exception ex) {
                     Log.logErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                     Core.getMainWindow().displayErrorRB(ex, "PP_ERROR_UNABLE_TO_READ_PROJECT_FILE");
                 }
             }
         }.execute();
+    }
+
+    /**
+     * The team's project settings file of the just opened team project
+     * carried different values than this checkout, and the team values are
+     * now active. Asks the user per setting what to do with the local value:
+     * share it with the team, use the team's value, or restore it for this
+     * session only - the next open supersedes and asks again. Dismissing a
+     * dialog leaves the team's value active.
+     */
+    private static void promptForSupersededSettings() {
+        IProject project = Core.getProject();
+        if (!project.isProjectLoaded()) {
+            return;
+        }
+        for (Map.Entry<String, @Nullable String> entry : project.getSupersededLocalSettings().entrySet()) {
+            TeamSetting setting = TeamSettingsRegistry.byKey(entry.getKey());
+            if (setting == null) {
+                continue;
+            }
+            String localValue = entry.getValue();
+            String teamValue = setting.read(project.getProjectProperties());
+            String[] options = { OStrings.getString("TEAM_SETTING_SHARE"),
+                    OStrings.getString("TEAM_SETTING_TAKE_TEAM"),
+                    OStrings.getString("TEAM_SETTING_KEEP_THIS_TIME") };
+            int answer = JOptionPane.showOptionDialog(Core.getMainWindow().getApplicationFrame(),
+                    OStrings.getString("TEAM_SETTING_DIVERGED_MESSAGE", setting.getDisplayName(),
+                            setting.describe(localValue), setting.describe(teamValue)),
+                    OStrings.getString("TEAM_SETTING_DIVERGED_TITLE"), JOptionPane.DEFAULT_OPTION,
+                    JOptionPane.QUESTION_MESSAGE, null, options, options[1]);
+            if (answer != 0 && answer != 1 && answer != 2) {
+                // Dismissed: the team's value stays active for this session,
+                // the local file keeps the local value, and the next open
+                // asks again.
+                continue;
+            }
+            boolean share = answer == 0;
+            String value = answer == 1 ? teamValue : localValue;
+            // The repository work must stay off the EDT and must not run
+            // beside the auto-save thread. Taking the team's value persists
+            // it locally, so the divergence is settled instead of
+            // resurfacing on every open.
+            new SwingWorker<Void, Void>() {
+                @Override
+                protected Void doInBackground() throws Exception {
+                    Core.executeExclusively(true, () -> {
+                        try {
+                            if (share) {
+                                project.publishProjectSetting(entry.getKey(), value);
+                            } else {
+                                project.useLocalProjectSetting(entry.getKey(), value);
+                            }
+                        } catch (Exception ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    });
+                    return null;
+                }
+
+                @Override
+                protected void done() {
+                    try {
+                        get();
+                    } catch (Exception ex) {
+                        String key = share ? "TEAM_SETTING_SHARE_ERROR" : "TEAM_SETTING_APPLY_ERROR";
+                        Log.logErrorRB(ex, key);
+                        Core.getMainWindow().displayErrorRB(ex, key);
+                    }
+                }
+            }.execute();
+        }
+    }
+
+    /** Session values of all registered team settings, keyed by setting key. */
+    private static Map<String, @Nullable String> readSessionTeamSettings() {
+        Map<String, @Nullable String> values = new HashMap<>();
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            values.put(setting.getKey(), setting.read(props));
+        }
+        return values;
+    }
+
+    private static void applySessionTeamSettings(Map<String, @Nullable String> values) {
+        ProjectProperties props = Core.getProject().getProjectProperties();
+        for (TeamSetting setting : TeamSettingsRegistry.all()) {
+            setting.apply(props, values.get(setting.getKey()));
+        }
     }
 
     private static @Nullable File selectProjectRootFolder(File projectDirectory) {
@@ -864,18 +960,64 @@ public final class ProjectUICommands {
         // commit the current entry first
         Core.getEditor().commitAndLeave();
 
+        // The dialog edits the live properties, so the current values have
+        // to be captured before it is shown.
+        final Map<String, @Nullable String> teamSettingsBefore = readSessionTeamSettings();
+
         // displaying the dialog to change paths and other properties
         final ProjectProperties newProps =
                 ProjectPropertiesDialogController.showDialog(frame, Core.getProject().getProjectProperties(),
                 Core.getProject().getProjectProperties().getProjectName(),
                 ProjectPropertiesDialog.Mode.EDIT_PROJECT);
         if (newProps == null) {
+            // The dialog edits the live properties even before a validation
+            // stops its OK, so cancelling must not leave flipped values.
+            applySessionTeamSettings(teamSettingsBefore);
             return;
         }
+
+        // Changing a team setting right here is the natural moment to offer
+        // its distribution; declining keeps it local, and the next open of
+        // the project asks again.
+        final Map<String, @Nullable String> changedTeamSettings = new HashMap<>();
+        if (Core.getProject().isRemoteProject()) {
+            for (TeamSetting setting : TeamSettingsRegistry.all()) {
+                String after = setting.read(newProps);
+                if (!Objects.equals(teamSettingsBefore.get(setting.getKey()), after)) {
+                    changedTeamSettings.put(setting.getKey(), after);
+                }
+            }
+        }
+        final Map<String, @Nullable String> settingsToShare = new HashMap<>();
+        changedTeamSettings.forEach((key, value) -> {
+            TeamSetting setting = TeamSettingsRegistry.byKey(key);
+            if (setting != null && promptToShareSettingChange(setting, value)) {
+                settingsToShare.put(key, value);
+            }
+        });
 
         int res = JOptionPane.showConfirmDialog(frame, OStrings.getString("MW_REOPEN_QUESTION"),
                 OStrings.getString("MW_REOPEN_TITLE"), JOptionPane.YES_NO_OPTION);
         if (res != JOptionPane.YES_OPTION) {
+            if (!settingsToShare.isEmpty()) {
+                new SwingWorker<Void, Void>() {
+                    @Override
+                    protected Void doInBackground() throws Exception {
+                        Core.executeExclusively(true, () -> publishSettingsLoggingErrors(settingsToShare));
+                        return null;
+                    }
+
+                    @Override
+                    protected void done() {
+                        try {
+                            get();
+                        } catch (Exception ex) {
+                            Log.logErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                            Core.getMainWindow().displayErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                        }
+                    }
+                }.execute();
+            }
             return;
         }
 
@@ -885,10 +1027,30 @@ public final class ProjectUICommands {
             @Override
             protected Void doInBackground() throws Exception {
                 Core.executeExclusively(true, () -> {
+                    if (!settingsToShare.isEmpty()) {
+                        // A failed share must not abort the reload; the
+                        // local file keeps the value, so the next open
+                        // offers the distribution again.
+                        publishSettingsLoggingErrors(settingsToShare);
+                    }
                     Core.getProject().saveProject(true);
                     ProjectFactory.closeProject();
 
                     ProjectFactory.loadProject(newProps, true);
+                    changedTeamSettings.forEach((key, value) -> {
+                        if (!settingsToShare.containsKey(key)) {
+                            // The share was declined, so the freshly chosen
+                            // value must stay local: without this, the
+                            // reload would classify it as local-only
+                            // divergence and fall back to the team default
+                            // without a word.
+                            try {
+                                Core.getProject().useLocalProjectSetting(key, value);
+                            } catch (Exception ex) {
+                                Log.logErrorRB(ex, "TEAM_SETTING_APPLY_ERROR");
+                            }
+                        }
+                    });
                 });
                 return null;
             }
@@ -908,6 +1070,32 @@ public final class ProjectUICommands {
                 }
             }
         }.execute();
+    }
+
+    /**
+     * The properties dialog of a team project just changed a registered
+     * team setting; asks whether to distribute the change.
+     */
+    private static boolean promptToShareSettingChange(TeamSetting setting, @Nullable String value) {
+        String[] options = { OStrings.getString("TEAM_SETTING_SHARE"),
+                OStrings.getString("TEAM_SETTING_KEEP_FOR_NOW") };
+        return JOptionPane.showOptionDialog(Core.getMainWindow().getApplicationFrame(),
+                OStrings.getString("TEAM_SETTING_CHANGED_MESSAGE", setting.getDisplayName(),
+                        setting.describe(value)),
+                OStrings.getString("TEAM_SETTING_DIVERGED_TITLE"), JOptionPane.DEFAULT_OPTION,
+                JOptionPane.QUESTION_MESSAGE, null, options, options[0]) == 0;
+    }
+
+    private static void publishSettingsLoggingErrors(Map<String, @Nullable String> settings) {
+        settings.forEach((key, value) -> {
+            try {
+                Core.getProject().publishProjectSetting(key, value);
+            } catch (Exception ex) {
+                Log.logErrorRB(ex, "TEAM_SETTING_SHARE_ERROR");
+                SwingUtilities.invokeLater(
+                        () -> Core.getMainWindow().displayErrorRB(ex, "TEAM_SETTING_SHARE_ERROR"));
+            }
+        });
     }
 
     public static void projectCompile() {

--- a/src/main/java/org/omegat/util/PatternConsts.java
+++ b/src/main/java/org/omegat/util/PatternConsts.java
@@ -32,6 +32,7 @@
 package org.omegat.util;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Constant patterns, used in different other classes.
@@ -227,15 +228,61 @@ public final class PatternConsts {
     /**
      * combined pattern for all placeholder tags
      */
-    private static Pattern placeholders;
+    private static volatile Pattern placeholders;
     /**
      * pattern for text that should be removed from translation. Can be null!
      */
-    private static Pattern remove;
+    private static volatile Pattern remove;
     /**
      * Pattern for text that should be considered a custom tag. Can be null!
      */
-    private static Pattern customTags;
+    private static volatile Pattern customTags;
+    /**
+     * Project-specific overrides for the custom tag and removed-text
+     * regular expressions. Null means the global preference applies; an
+     * empty string is a real override that turns the pattern off for the
+     * project.
+     */
+    private static volatile String projectCustomTagPattern;
+    private static volatile String projectRemoveTextPattern;
+
+    /**
+     * Installs the project-specific tag patterns when a project is opened.
+     * A null argument keeps the global preference for that pattern. An
+     * expression that does not compile is refused and logged, so a broken
+     * project file cannot take the whole tag pipeline down.
+     */
+    public static void applyProjectPatterns(String customTagPattern, String removeTextPattern) {
+        projectCustomTagPattern = validated(customTagPattern);
+        projectRemoveTextPattern = validated(removeTextPattern);
+        resetCachedPatterns();
+    }
+
+    /** Removes the project-specific tag patterns when the project is closed. */
+    public static void clearProjectPatterns() {
+        projectCustomTagPattern = null;
+        projectRemoveTextPattern = null;
+        resetCachedPatterns();
+    }
+
+    private static String validated(String regex) {
+        if (regex == null) {
+            return null;
+        }
+        try {
+            Pattern.compile(regex);
+            return regex;
+        } catch (PatternSyntaxException e) {
+            Log.logWarningRB("LOG_PROJECT_TAG_PATTERN_INVALID", regex, e.getLocalizedMessage());
+            return null;
+        }
+    }
+
+    private static void resetCachedPatterns() {
+        updatePlaceholderPattern();
+        updateRemovePattern();
+        updateCustomTagPattern();
+    }
 
     /**
      * Returns the placeholder pattern (OmegaT tags, printf tags, java
@@ -256,7 +303,9 @@ public final class PatternConsts {
                 regexp += "|" + RE_SIMPLE_JAVA_MESSAGEFORMAT_PATTERN_VARS;
             }
             String customRegExp;
-            if (Preferences.existsPreference(Preferences.CHECK_CUSTOM_PATTERN)) {
+            if (projectCustomTagPattern != null) {
+                customRegExp = projectCustomTagPattern;
+            } else if (Preferences.existsPreference(Preferences.CHECK_CUSTOM_PATTERN)) {
                 customRegExp = Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN);
             } else {
                 // assume default
@@ -281,7 +330,8 @@ public final class PatternConsts {
 
     public static Pattern getRemovePattern() {
         if (remove == null) {
-            String removeRegExp = Preferences.getPreference(Preferences.CHECK_REMOVE_PATTERN);
+            String removeRegExp = projectRemoveTextPattern != null ? projectRemoveTextPattern
+                    : Preferences.getPreference(Preferences.CHECK_REMOVE_PATTERN);
             if (!"".equalsIgnoreCase(removeRegExp)) {
                 remove = Pattern.compile(removeRegExp);
             }
@@ -298,7 +348,8 @@ public final class PatternConsts {
 
     public static Pattern getCustomTagPattern() {
         if (customTags == null) {
-            String customTagsRegex = Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN);
+            String customTagsRegex = projectCustomTagPattern != null ? projectCustomTagPattern
+                    : Preferences.getPreference(Preferences.CHECK_CUSTOM_PATTERN);
             if (!"".equalsIgnoreCase(customTagsRegex)) {
                 customTags = Pattern.compile(customTagsRegex);
             }

--- a/src/main/java/org/omegat/util/TagPatternsStorage.java
+++ b/src/main/java/org/omegat/util/TagPatternsStorage.java
@@ -1,0 +1,165 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Storage for the project-specific custom tag and removed-text regular
+ * expressions (feature requests #926, #1427, #824).
+ *
+ * The expressions live in their own file in the project's omegat folder, like
+ * filters.xml and segmentation.conf, so that older OmegaT versions can still
+ * open the project: they simply never read the file.
+ *
+ * @author Stephan Pakebusch
+ */
+public final class TagPatternsStorage {
+
+    /** Name of the tag patterns file in the project's omegat folder. */
+    public static final String FILE_TAG_PATTERNS = "tag_patterns.xml";
+
+    private static final XmlMapper MAPPER;
+
+    static {
+        MAPPER = XmlMapper.xmlBuilder().build();
+        MAPPER.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        // An absent element means the global preference applies, while an
+        // empty element is a real override, so nulls must be omitted but
+        // empty strings written.
+        MAPPER.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+        MAPPER.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    private TagPatternsStorage() {
+    }
+
+    /**
+     * Loads the tag patterns file. Returns null when the file does not
+     * exist. A file that cannot be parsed raises an IOException, so the
+     * caller can fall back to the global preferences while the file stays
+     * in place for repair.
+     */
+    public static @Nullable TagPatterns load(File configFile) throws IOException {
+        if (!configFile.exists()) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(configFile, TagPatterns.class);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Parses tag patterns from XML content, as written by
+     * {@link #writeToString}. A file's content that cannot be parsed raises
+     * an IOException, like {@link #load}.
+     */
+    public static TagPatterns loadFromString(String content) throws IOException {
+        try {
+            return MAPPER.readValue(content, TagPatterns.class);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Serializes the tag patterns to the canonical XML content of the tag
+     * patterns file. Together with {@link #loadFromString} this yields a
+     * canonical form: differently formatted files with equal expressions
+     * serialize identically.
+     */
+    public static String writeToString(TagPatterns patterns) throws IOException {
+        return MAPPER.writeValueAsString(patterns);
+    }
+
+    /**
+     * Saves the tag patterns to the given file, or deletes the file when both
+     * expressions are null, i.e. the project inherits the global preferences.
+     */
+    public static void save(@Nullable TagPatterns patterns, File configFile) throws IOException {
+        if (patterns == null || patterns.isEmpty()) {
+            Files.deleteIfExists(configFile.toPath());
+            return;
+        }
+        MAPPER.writeValue(configFile, patterns);
+    }
+
+    /**
+     * The content of the tag patterns file. Null fields mean the global
+     * preference applies; an empty string is a real override that switches
+     * the expression off for the project.
+     */
+    @JacksonXmlRootElement(localName = "tag_patterns")
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TagPatterns {
+
+        @JacksonXmlProperty(localName = "custom_tag_pattern")
+        private @Nullable String customTagPattern;
+
+        @JacksonXmlProperty(localName = "remove_text_pattern")
+        private @Nullable String removeTextPattern;
+
+        public @Nullable String getCustomTagPattern() {
+            return customTagPattern;
+        }
+
+        public void setCustomTagPattern(@Nullable String customTagPattern) {
+            this.customTagPattern = customTagPattern;
+        }
+
+        public @Nullable String getRemoveTextPattern() {
+            return removeTextPattern;
+        }
+
+        public void setRemoveTextPattern(@Nullable String removeTextPattern) {
+            this.removeTextPattern = removeTextPattern;
+        }
+
+        @JsonIgnore
+        public boolean isEmpty() {
+            return customTagPattern == null && removeTextPattern == null;
+        }
+    }
+}

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -2318,6 +2318,18 @@ TEAM_HTTP_UNAUTHORIZED=Authentication error when trying to access {0}.
 TEAM_HTTP_NOT_FOUND=No content found at {0}.
 TEAM_HTTP_OTHER_ERRORS=HTTP connection {1} responded with code: {2}.
 
+TEAM_SETTING_DIVERGED_TITLE=Team Project Setting
+TEAM_SETTING_DIVERGED_MESSAGE=The project setting "{0}" is {1} on this computer but {2} in the team project. The team version is now active.\nWhat do you want to do with the local version?
+TEAM_SETTING_SHARE=Share with the team
+TEAM_SETTING_TAKE_TEAM=Use the team version
+TEAM_SETTING_KEEP_THIS_TIME=Use the local version this time
+TEAM_SETTING_CHANGED_MESSAGE=You changed the project setting "{0}" to {1}. Share the change with the team? Without sharing it stays local, and the next open of the project asks again.
+TEAM_SETTING_KEEP_FOR_NOW=Keep it local for now
+TEAM_SETTING_VALUE_ON=enabled
+TEAM_SETTING_VALUE_OFF=disabled
+TEAM_SETTING_SHARE_ERROR=The setting could not be committed to the team project.
+TEAM_SETTING_APPLY_ERROR=The local setting could not be applied.
+
 # Save options
 SAVE_DIALOG_TITLE=Saving and Output Options
 PREFS_TITLE_SAVING_AND_OUTPUT=Saving and Output

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -793,6 +793,12 @@ PP_EXTERN_CMD_DISABLED=Local post-processing commands (disabled):
 
 PP_EXTERN_CMD_DISABLED_TOOLTIP=Local post-processing commands are disabled and will not be executed. Enable them in Preferences > Saving and Output....
 
+PP_LOCAL_TAG_DEFINITIONS=Local Tag &Definitions...
+PP_TAG_PATTERNS=Local Tag Definitions
+PP_TAG_PATTERNS_PROJECT_SPECIFIC=Use local &tag definitions
+PP_TAG_PATTERN_INVALID=The regular expression is not valid: {0}
+PP_TAG_PATTERNS_LOAD_FAILED=The existing tag definitions file could not be read. Confirming this editor replaces it.
+
 PP_BUTTON_BROWSE_SRC=&Browse...
 PP_BUTTON_BROWSE_SRC_EXCLUDES=E&xclusions...
 
@@ -1963,6 +1969,8 @@ LOG_DATAENGINE_COMPILE_END=Project compiling end
 LOG_DATAENGINE_CREATE_START=Project creating start
 LOG_DATAENGINE_CREATE_END=Project creating end
 LOG_ERROR_DELETE_FILE=Could not delete {0} 
+LOG_PROJECT_TAG_PATTERN_INVALID=The project tag expression "{0}" is not a valid regular expression and was ignored: {1}
+LOG_PROJECT_TAG_PATTERNS_LOAD_ERROR=The project tag expressions file {0} could not be read and was ignored.
 
 # Spellchecker
 
@@ -2331,6 +2339,10 @@ TEAM_SETTING_VALUE_FILE_CUSTOM=a project version ({0})
 TEAM_SETTING_VALUE_FILE_NONE=not present (global settings apply)
 TEAM_SETTING_NAME_FILTERS=file filter settings (omegat/filters.xml)
 TEAM_SETTING_NAME_SEGMENTATION=segmentation rules (omegat/segmentation.srx)
+TEAM_SETTING_NAME_TAG_PATTERNS=tag definitions (omegat/tag_patterns.xml)
+TEAM_SETTING_VALUE_TAG_PATTERNS=a project version (custom tags {0}, removed text {1})
+TEAM_SETTING_VALUE_TAG_PATTERNS_GLOBAL=(global settings)
+TEAM_SETTING_VALUE_TAG_PATTERNS_OFF=(disabled)
 TEAM_SETTING_SHARE_ERROR=The setting could not be committed to the team project.
 TEAM_SETTING_APPLY_ERROR=The local setting could not be applied.
 

--- a/src/main/resources/org/omegat/Bundle.properties
+++ b/src/main/resources/org/omegat/Bundle.properties
@@ -2327,6 +2327,10 @@ TEAM_SETTING_CHANGED_MESSAGE=You changed the project setting "{0}" to {1}. Share
 TEAM_SETTING_KEEP_FOR_NOW=Keep it local for now
 TEAM_SETTING_VALUE_ON=enabled
 TEAM_SETTING_VALUE_OFF=disabled
+TEAM_SETTING_VALUE_FILE_CUSTOM=a project version ({0})
+TEAM_SETTING_VALUE_FILE_NONE=not present (global settings apply)
+TEAM_SETTING_NAME_FILTERS=file filter settings (omegat/filters.xml)
+TEAM_SETTING_NAME_SEGMENTATION=segmentation rules (omegat/segmentation.srx)
 TEAM_SETTING_SHARE_ERROR=The setting could not be committed to the team project.
 TEAM_SETTING_APPLY_ERROR=The local setting could not be applied.
 

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -2187,6 +2187,18 @@ TEAM_HTTP_UNAUTHORIZED=Authentifizierungsfehler beim Zugriff auf {0}.
 TEAM_HTTP_NOT_FOUND=Kein Inhalt gefunden bei {0}.
 TEAM_HTTP_OTHER_ERRORS=HTTP-Verbindung {1} antwortet mit Code: {2}.
 
+TEAM_SETTING_DIVERGED_TITLE=Team-Projekteinstellung
+TEAM_SETTING_DIVERGED_MESSAGE=Die Projekteinstellung "{0}" ist auf diesem Rechner {1}, im Teamprojekt {2}. Die Team-Fassung ist jetzt aktiv.\nWas soll mit der lokalen Fassung geschehen?
+TEAM_SETTING_SHARE=Ans Team verteilen
+TEAM_SETTING_TAKE_TEAM=Team-Fassung \u00FCbernehmen
+TEAM_SETTING_KEEP_THIS_TIME=Diesmal die lokale Fassung verwenden
+TEAM_SETTING_CHANGED_MESSAGE=Die Projekteinstellung "{0}" wurde auf {1} ge\u00E4ndert. Soll die \u00C4nderung ans Team verteilt werden? Ohne Verteilung bleibt sie lokal, und das n\u00E4chste \u00D6ffnen des Projekts fragt erneut.
+TEAM_SETTING_KEEP_FOR_NOW=Vorerst lokal belassen
+TEAM_SETTING_VALUE_ON=aktiviert
+TEAM_SETTING_VALUE_OFF=deaktiviert
+TEAM_SETTING_SHARE_ERROR=Die Einstellung konnte nicht ins Teamprojekt \u00FCbertragen werden.
+TEAM_SETTING_APPLY_ERROR=Die lokale Einstellung konnte nicht angewendet werden.
+
 # Save options
 SAVE_DIALOG_TITLE=Speichern und Ausgabe
 PREFS_TITLE_SAVING_AND_OUTPUT=Speichern und Ausgabe

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -759,6 +759,12 @@ PP_EXTERN_CMD_DISABLED=Lokale Nachbearbeitungsbefehle (deaktiviert):
 
 PP_EXTERN_CMD_DISABLED_TOOLTIP=Lokale Nachbearbeitungsbefehle sind deaktiviert und werden nicht ausgef\u00FChrt. Aktivieren Sie sie unter "Einstellungen > Speichern und Ausgabe..."
 
+PP_LOCAL_TAG_DEFINITIONS=Lokale Tag-&Definitionen...
+PP_TAG_PATTERNS=Lokale Tag-Definitionen
+PP_TAG_PATTERNS_PROJECT_SPECIFIC=Lokale &Tag-Definitionen verwenden
+PP_TAG_PATTERN_INVALID=Der regul\u00E4re Ausdruck ist ung\u00FCltig: {0}
+PP_TAG_PATTERNS_LOAD_FAILED=Die vorhandene Tag-Definitionsdatei konnte nicht gelesen werden. Best\u00E4tigen dieses Editors ersetzt sie.
+
 PP_BUTTON_BROWSE_SRC=Du&rchsuchen...
 PP_BUTTON_BROWSE_SRC_EXCLUDES=Ausnah&men...
 
@@ -1855,6 +1861,8 @@ LOG_DATAENGINE_COMPILE_END=Beenden der Projektkompilierung
 LOG_DATAENGINE_CREATE_START=Starten der Projekterstellung
 LOG_DATAENGINE_CREATE_END=Beenden der Projekterstellung
 LOG_ERROR_DELETE_FILE=Konnte {0} nicht l\u00F6schen 
+LOG_PROJECT_TAG_PATTERN_INVALID=Der projektspezifische Tag-Ausdruck "{0}" ist kein g\u00FCltiger regul\u00E4rer Ausdruck und wurde ignoriert: {1}
+LOG_PROJECT_TAG_PATTERNS_LOAD_ERROR=Die Datei mit den projektspezifischen Tag-Ausdr\u00FCcken {0} konnte nicht gelesen werden und wurde ignoriert.
 
 # Spellchecker
 
@@ -2200,6 +2208,10 @@ TEAM_SETTING_VALUE_FILE_CUSTOM=eine Projektfassung ({0})
 TEAM_SETTING_VALUE_FILE_NONE=nicht vorhanden (globale Einstellungen gelten)
 TEAM_SETTING_NAME_FILTERS=Dateifilter-Einstellungen (omegat/filters.xml)
 TEAM_SETTING_NAME_SEGMENTATION=Segmentierungsregeln (omegat/segmentation.srx)
+TEAM_SETTING_NAME_TAG_PATTERNS=Tag-Definitionen (omegat/tag_patterns.xml)
+TEAM_SETTING_VALUE_TAG_PATTERNS=eine Projektfassung (benutzerdefinierte Tags {0}, entfernter Text {1})
+TEAM_SETTING_VALUE_TAG_PATTERNS_GLOBAL=(globale Einstellungen)
+TEAM_SETTING_VALUE_TAG_PATTERNS_OFF=(deaktiviert)
 TEAM_SETTING_SHARE_ERROR=Die Einstellung konnte nicht ins Teamprojekt \u00FCbertragen werden.
 TEAM_SETTING_APPLY_ERROR=Die lokale Einstellung konnte nicht angewendet werden.
 

--- a/src/main/resources/org/omegat/Bundle_de.properties
+++ b/src/main/resources/org/omegat/Bundle_de.properties
@@ -2196,6 +2196,10 @@ TEAM_SETTING_CHANGED_MESSAGE=Die Projekteinstellung "{0}" wurde auf {1} ge\u00E4
 TEAM_SETTING_KEEP_FOR_NOW=Vorerst lokal belassen
 TEAM_SETTING_VALUE_ON=aktiviert
 TEAM_SETTING_VALUE_OFF=deaktiviert
+TEAM_SETTING_VALUE_FILE_CUSTOM=eine Projektfassung ({0})
+TEAM_SETTING_VALUE_FILE_NONE=nicht vorhanden (globale Einstellungen gelten)
+TEAM_SETTING_NAME_FILTERS=Dateifilter-Einstellungen (omegat/filters.xml)
+TEAM_SETTING_NAME_SEGMENTATION=Segmentierungsregeln (omegat/segmentation.srx)
 TEAM_SETTING_SHARE_ERROR=Die Einstellung konnte nicht ins Teamprojekt \u00FCbertragen werden.
 TEAM_SETTING_APPLY_ERROR=Die lokale Einstellung konnte nicht angewendet werden.
 

--- a/src/test/java/org/omegat/core/data/ConfigFilesTeamRoundTripTest.java
+++ b/src/test/java/org/omegat/core/data/ConfigFilesTeamRoundTripTest.java
@@ -1,0 +1,223 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.segmentation.SRXManager;
+import org.omegat.core.team2.RemoteRepositoryProvider;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.filters.Filter;
+import gen.core.filters.Filters;
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that the file-backed team settings distribute the project's
+ * filters.xml and segmentation files through the team repository: sharing a
+ * configuration delivers the file to the next member, sharing "no
+ * project-specific configuration" deletes it there, and sharing migrated
+ * segmentation rules replaces the legacy conf file with the srx file.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ConfigFilesTeamRoundTripTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "README").toPath(), "team project\n",
+                StandardCharsets.UTF_8);
+        commitRemote("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        Files.createDirectories(new File(config.getProjectInternal()).toPath());
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    private static String sampleFiltersRaw() throws Exception {
+        Filters filters = new Filters();
+        Filter filter = new Filter();
+        filter.setClassName("org.omegat.filters2.text.TextFilter");
+        filter.setEnabled(false);
+        filters.getFilters().add(filter);
+        // the canonical form completes the configuration with the filters
+        // available in this installation, so the baseline must too
+        return FilterMaster.writeConfigToString(FilterMaster.completeWithAvailableFilters(filters));
+    }
+
+    @Test
+    public void testShareDeliversTheFiltersFileToTheTeam() throws Exception {
+        String raw = sampleFiltersRaw();
+        TeamSettingFiles.FILTERS.saveStored(config, raw);
+
+        RealProject.commitProjectSettings(provider, config, TeamSettingFiles.FILTERS);
+
+        ProjectProperties member = syncNewMember("member2");
+        assertEquals("the team must receive the configuration", raw,
+                TeamSettingFiles.FILTERS.loadStored(member));
+    }
+
+    @Test
+    public void testShareDistributesTheRemovalOfTheFiltersFile() throws Exception {
+        Files.writeString(remoteFile(FilterMaster.FILE_FILTERS).toPath(), sampleFiltersRaw(),
+                StandardCharsets.UTF_8);
+        commitRemote("team with a filters file");
+
+        // the checkout carries no filters.xml: sharing distributes exactly
+        // that state, so the repository copy has to go
+        RealProject.commitProjectSettings(provider, config, TeamSettingFiles.FILTERS);
+
+        RemoteRepositoryProvider member = newProvider(folder.newFolder("member2"), remoteDir);
+        member.switchAllToLatest();
+        assertFalse("the removal must reach the team",
+                member.existsInRepositories(filtersPathUnderRoot()));
+    }
+
+    @Test
+    public void testSharingAnIdenticalFileSkipsTheCommit() throws Exception {
+        String raw = sampleFiltersRaw();
+        TeamSettingFiles.FILTERS.saveStored(config, raw);
+        RealProject.commitProjectSettings(provider, config, TeamSettingFiles.FILTERS);
+
+        // another member shared the same content in the meantime: the no-op
+        // commit would report like a rejected push, so it must be skipped
+        RealProject.commitProjectSettings(provider, config, TeamSettingFiles.FILTERS);
+
+        ProjectProperties member = syncNewMember("member2");
+        assertEquals(raw, TeamSettingFiles.FILTERS.loadStored(member));
+    }
+
+    @Test
+    public void testShareReplacesTheLegacyConfWithTheSrxFile() throws Exception {
+        // the team still carries segmentation.conf from an older OmegaT
+        try (InputStream in = ConfigFilesTeamRoundTripTest.class
+                .getResourceAsStream("/data/segmentation/migrate/ext/segmentation.conf")) {
+            assertNotNull(in);
+            Files.copy(in, remoteFile(SRXManager.CONF_SENTSEG).toPath());
+        }
+        commitRemote("team with legacy segmentation");
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+        String raw = TeamSettingFiles.SEGMENTATION.loadStored(config);
+        assertNotNull(raw);
+
+        // opening the checkout migrates conf to srx on disk (existing
+        // OmegaT behavior), without changing the stored value
+        config.loadProjectSRX();
+        File internal = new File(config.getProjectInternal());
+        assertTrue(new File(internal, SRXManager.SRX_SENTSEG).isFile());
+        assertFalse(new File(internal, SRXManager.CONF_SENTSEG).isFile());
+        assertEquals("the migration must not change the value", raw,
+                TeamSettingFiles.SEGMENTATION.loadStored(config));
+
+        // sharing mirrors the migrated checkout in the team repository
+        RealProject.commitProjectSettings(provider, config, TeamSettingFiles.SEGMENTATION);
+
+        ProjectProperties member = syncNewMember("member2");
+        File memberInternal = new File(member.getProjectInternal());
+        assertTrue("the srx file must reach the team",
+                new File(memberInternal, SRXManager.SRX_SENTSEG).isFile());
+        assertFalse("the legacy file must be gone",
+                new File(memberInternal, SRXManager.CONF_SENTSEG).isFile());
+        assertEquals("the rules must survive the trip", raw,
+                TeamSettingFiles.SEGMENTATION.loadStored(member));
+    }
+
+    private String filtersPathUnderRoot() {
+        return OConsts.DEFAULT_INTERNAL + "/" + FilterMaster.FILE_FILTERS;
+    }
+
+    private File remoteFile(String nameUnderInternal) throws Exception {
+        File f = new File(remoteDir, OConsts.DEFAULT_INTERNAL + "/" + nameUnderInternal);
+        Files.createDirectories(f.getParentFile().toPath());
+        return f;
+    }
+
+    private void commitRemote(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    /** Sync a fresh member checkout and hand back its configuration view. */
+    private ProjectProperties syncNewMember(String name) throws Exception {
+        File memberDir = folder.newFolder(name);
+        RemoteRepositoryProvider member = newProvider(memberDir, remoteDir);
+        member.switchAllToLatest();
+        member.copyFilesFromReposToProject("");
+        return new ProjectProperties(memberDir);
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}

--- a/src/test/java/org/omegat/core/data/ConfigFilesTeamRoundTripTest.java
+++ b/src/test/java/org/omegat/core/data/ConfigFilesTeamRoundTripTest.java
@@ -48,6 +48,7 @@ import org.omegat.core.team2.RemoteRepositoryProvider;
 import org.omegat.core.team2.impl.GITRemoteRepository2;
 import org.omegat.filters2.master.FilterMaster;
 import org.omegat.util.OConsts;
+import org.omegat.util.TagPatternsStorage;
 import org.omegat.util.TestPreferencesInitializer;
 
 import gen.core.filters.Filter;
@@ -57,7 +58,8 @@ import gen.core.project.RepositoryMapping;
 
 /**
  * Proves that the file-backed team settings distribute the project's
- * filters.xml and segmentation files through the team repository: sharing a
+ * filters.xml, segmentation and tag_patterns.xml files through the team
+ * repository: sharing a
  * configuration delivers the file to the next member, sharing "no
  * project-specific configuration" deletes it there, and sharing migrated
  * segmentation rules replaces the legacy conf file with the srx file.
@@ -143,6 +145,36 @@ public class ConfigFilesTeamRoundTripTest {
 
         ProjectProperties member = syncNewMember("member2");
         assertEquals(raw, TeamSettingFiles.FILTERS.loadStored(member));
+    }
+
+    @Test
+    public void testShareDeliversTheTagPatternsFileToTheTeam() throws Exception {
+        TagPatternsStorage.TagPatterns patterns = new TagPatternsStorage.TagPatterns();
+        patterns.setCustomTagPattern("<x\\d+>");
+        String raw = TagPatternsStorage.writeToString(patterns);
+        TeamSettingFiles.TAG_PATTERNS.saveStored(config, raw);
+
+        RealProject.commitProjectSettings(provider, config, TeamSettingFiles.TAG_PATTERNS);
+
+        ProjectProperties member = syncNewMember("member2");
+        assertEquals("the team must receive the tag definitions", raw,
+                TeamSettingFiles.TAG_PATTERNS.loadStored(member));
+    }
+
+    @Test
+    public void testShareDistributesTheRemovalOfTheTagPatternsFile() throws Exception {
+        TagPatternsStorage.TagPatterns patterns = new TagPatternsStorage.TagPatterns();
+        patterns.setRemoveTextPattern("\\[note]");
+        Files.writeString(remoteFile(TagPatternsStorage.FILE_TAG_PATTERNS).toPath(),
+                TagPatternsStorage.writeToString(patterns), StandardCharsets.UTF_8);
+        commitRemote("team with a tag patterns file");
+
+        RealProject.commitProjectSettings(provider, config, TeamSettingFiles.TAG_PATTERNS);
+
+        RemoteRepositoryProvider member = newProvider(folder.newFolder("member2"), remoteDir);
+        member.switchAllToLatest();
+        assertFalse("the removal must reach the team", member.existsInRepositories(
+                OConsts.DEFAULT_INTERNAL + "/" + TagPatternsStorage.FILE_TAG_PATTERNS));
     }
 
     @Test

--- a/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
@@ -92,7 +92,7 @@ public class ProjectSettingsPublishTest {
     public void testPublishDeliversTheSettingsFileToTheTeam() throws Exception {
         ProjectSettingsStorage.save(config, KEY, "true");
 
-        RealProject.commitProjectSettings(provider, config);
+        RealProject.commitProjectSettings(provider, config, sidecarSetting());
 
         assertEquals("the team must receive the value", "true", loadDeliveredValue("member2"));
         assertFalse("omegat.project must stay untouched for older versions",
@@ -106,7 +106,7 @@ public class ProjectSettingsPublishTest {
         commitAll("team with the option");
 
         ProjectSettingsStorage.save(config, KEY, "false");
-        RealProject.commitProjectSettings(provider, config);
+        RealProject.commitProjectSettings(provider, config, sidecarSetting());
 
         assertEquals("the team must receive the new value", "false", loadDeliveredValue("member2"));
     }
@@ -121,7 +121,7 @@ public class ProjectSettingsPublishTest {
         commitAll("team already carries the value");
 
         ProjectSettingsStorage.save(config, KEY, "true");
-        RealProject.commitProjectSettings(provider, config);
+        RealProject.commitProjectSettings(provider, config, sidecarSetting());
 
         assertEquals("true", loadDeliveredValue("member2"));
     }
@@ -155,8 +155,9 @@ public class ProjectSettingsPublishTest {
         assertResolved(null, null, RealProject.resolveSetting(null, null, false, false));
         assertResolved("true", null, RealProject.resolveSetting(null, "true", false, false));
         // team: remote delivered a value over an absent local file - first
-        // arrival activates and asks once
-        assertAsks("true", null, RealProject.resolveSetting(null, "true", true, true));
+        // arrival activates quietly, there is no local value to rescue and
+        // nothing a fresh checkout should question
+        assertResolved("true", null, RealProject.resolveSetting(null, "true", true, true));
         // team: remote delivered a differing value - team wins, asks
         assertAsks("false", "true", RealProject.resolveSetting("true", "false", true, true));
         // team: local-only survivor - team default stays active, asks
@@ -226,6 +227,13 @@ public class ProjectSettingsPublishTest {
         assertEquals("foreign key must survive the rewrite unchanged", before.getProperty("future key=x"),
                 after.getProperty("future key=x"));
         assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    /** Sidecar-backed setting under KEY, for the commit calls. */
+    private static TeamSetting sidecarSetting() {
+        return TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false, p -> true,
+                (p, v) -> {
+                });
     }
 
     private Properties loadRaw() throws Exception {

--- a/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
+++ b/src/test/java/org/omegat/core/data/ProjectSettingsPublishTest.java
@@ -1,0 +1,274 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.team2.RemoteRepositoryProvider;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that sharing a team project setting commits the sidecar settings
+ * file and leaves omegat.project untouched, so team members on older OmegaT
+ * versions can still open the project.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectSettingsPublishTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "README").toPath(), "team project\n",
+                StandardCharsets.UTF_8);
+        commitAll("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    @Test
+    public void testPublishDeliversTheSettingsFileToTheTeam() throws Exception {
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("the team must receive the value", "true", loadDeliveredValue("member2"));
+        assertFalse("omegat.project must stay untouched for older versions",
+                new File(projectDir, OConsts.FILE_PROJECT).exists());
+    }
+
+    @Test
+    public void testPublishCanAlsoOverwriteAValue() throws Exception {
+        Files.createDirectories(new File(remoteDir, OConsts.DEFAULT_INTERNAL).toPath());
+        Files.writeString(remoteSettingsFile().toPath(), KEY + "=true\n", StandardCharsets.UTF_8);
+        commitAll("team with the option");
+
+        ProjectSettingsStorage.save(config, KEY, "false");
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("the team must receive the new value", "false", loadDeliveredValue("member2"));
+    }
+
+    @Test
+    public void testPublishingAnAlreadySharedValueIsNotAnError() throws Exception {
+        // Another team member shared the same value in the meantime: the git
+        // commit would be a no-op, which reports the same way as a rejected
+        // push - so publishing must recognise the identical file and skip.
+        Files.createDirectories(new File(remoteDir, OConsts.DEFAULT_INTERNAL).toPath());
+        Files.writeString(remoteSettingsFile().toPath(), KEY + "=true\n", StandardCharsets.UTF_8);
+        commitAll("team already carries the value");
+
+        ProjectSettingsStorage.save(config, KEY, "true");
+        RealProject.commitProjectSettings(provider, config);
+
+        assertEquals("true", loadDeliveredValue("member2"));
+    }
+
+    @Test
+    public void testStorageRoundTripAndDefaults() throws Exception {
+        assertNull("unconfigured project reads as null", ProjectSettingsStorage.load(config, KEY));
+        // removing an unset key must not materialise the file
+        ProjectSettingsStorage.save(config, KEY, null);
+        assertFalse("removing from an absent file must stay a no-op",
+                ProjectSettingsStorage.getFile(config).isFile());
+        ProjectSettingsStorage.save(config, KEY, "true");
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+        // deterministic content, so team no-op detection can compare bytes
+        assertEquals(KEY + "=true\n",
+                Files.readString(ProjectSettingsStorage.getFile(config).toPath(), StandardCharsets.UTF_8));
+        ProjectSettingsStorage.save(config, KEY, "false");
+        assertEquals("false", ProjectSettingsStorage.load(config, KEY));
+        // null removes the key but keeps the file and foreign keys
+        Files.writeString(ProjectSettingsStorage.getFile(config).toPath(),
+                "future_setting=x\n" + KEY + "=false\n", StandardCharsets.UTF_8);
+        ProjectSettingsStorage.save(config, KEY, null);
+        assertNull(ProjectSettingsStorage.load(config, KEY));
+        assertTrue(Files.readString(ProjectSettingsStorage.getFile(config).toPath(),
+                StandardCharsets.UTF_8).contains("future_setting=x"));
+    }
+
+    @Test
+    public void testResolveSettingTruthTable() {
+        // non-team / offline: the local file rules, never a question
+        assertResolved(null, null, RealProject.resolveSetting(null, null, false, false));
+        assertResolved("true", null, RealProject.resolveSetting(null, "true", false, false));
+        // team: remote delivered a value over an absent local file - first
+        // arrival activates and asks once
+        assertAsks("true", null, RealProject.resolveSetting(null, "true", true, true));
+        // team: remote delivered a differing value - team wins, asks
+        assertAsks("false", "true", RealProject.resolveSetting("true", "false", true, true));
+        // team: local-only survivor - team default stays active, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", "true", false, true));
+        // team: both agree (shared value) - quiet
+        assertResolved("true", null, RealProject.resolveSetting("true", "true", true, true));
+        // team: nothing anywhere - quiet
+        assertResolved(null, null, RealProject.resolveSetting(null, null, false, true));
+        // team: remote carries only foreign future keys - like absent, quiet
+        assertResolved(null, null, RealProject.resolveSetting(null, null, true, true));
+        // team: the sync deleted the key - team default wins, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", null, true, true));
+        // team: diverged and not identical - local-only, team default, asks
+        assertAsks(null, "true", RealProject.resolveSetting("true", "false", false, true));
+    }
+
+    private static void assertResolved(String effective, String superseded,
+            RealProject.SettingResolution state) {
+        assertEquals(effective, state.effective);
+        assertFalse("expected quiet resolution", state.asks);
+        assertEquals(superseded, state.supersededLocal);
+    }
+
+    private static void assertAsks(String effective, String superseded,
+            RealProject.SettingResolution state) {
+        assertEquals(effective, state.effective);
+        assertTrue("expected a question", state.asks);
+        assertEquals(superseded, state.supersededLocal);
+    }
+
+    @Test
+    public void testPersistSessionSettingsSkipsSupersededAndDefaults() throws Exception {
+        AtomicBoolean first = new AtomicBoolean(true);
+        AtomicBoolean second = new AtomicBoolean(true);
+        TeamSettingsRegistry.register(TeamSetting.ofBoolean("first_option",
+                "TEAM_SETTING_DIVERGED_TITLE", false, p -> first.get(), (p, v) -> first.set(v)));
+        TeamSettingsRegistry.register(TeamSetting.ofBoolean("second_option",
+                "TEAM_SETTING_DIVERGED_TITLE", false, p -> second.get(), (p, v) -> second.set(v)));
+        try {
+            // superseded key keeps the file untouched for its setting, the
+            // other one still persists
+            RealProject.persistSessionSettings(config, Collections.singleton("first_option"));
+            assertNull(ProjectSettingsStorage.load(config, "first_option"));
+            assertEquals("true", ProjectSettingsStorage.load(config, "second_option"));
+
+            // default values stay unmaterialised unless the file exists
+            Files.delete(ProjectSettingsStorage.getFile(config).toPath());
+            first.set(false);
+            second.set(false);
+            RealProject.persistSessionSettings(config, Collections.emptySet());
+            assertFalse("defaults must not materialise the file",
+                    ProjectSettingsStorage.getFile(config).isFile());
+        } finally {
+            TeamSettingsRegistry.unregister("first_option");
+            TeamSettingsRegistry.unregister("second_option");
+        }
+    }
+
+    @Test
+    public void testEscapingWriterRoundTripsForeignKeys() throws Exception {
+        Files.createDirectories(ProjectSettingsStorage.getFile(config).getParentFile().toPath());
+        Files.writeString(ProjectSettingsStorage.getFile(config).toPath(),
+                "future\\ key\\=x=va\\\\lue\\=1\n" + KEY + "=false\n", StandardCharsets.UTF_8);
+        Properties before = loadRaw();
+        ProjectSettingsStorage.save(config, KEY, "true");
+        Properties after = loadRaw();
+        assertEquals("foreign key must survive the rewrite unchanged", before.getProperty("future key=x"),
+                after.getProperty("future key=x"));
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    private Properties loadRaw() throws Exception {
+        Properties p = new Properties();
+        try (java.io.Reader in = Files.newBufferedReader(
+                ProjectSettingsStorage.getFile(config).toPath(), StandardCharsets.UTF_8)) {
+            p.load(in);
+        }
+        return p;
+    }
+
+    private File remoteSettingsFile() {
+        return new File(remoteDir,
+                OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+    }
+
+    private void commitAll(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    /** Fetch the settings file the way a second member's open does. */
+    private String loadDeliveredValue(String memberDirName) throws Exception {
+        File memberDir = folder.newFolder(memberDirName);
+        RemoteRepositoryProvider member = newProvider(memberDir, remoteDir);
+        member.switchAllToLatest();
+        member.copyFilesFromReposToProject("");
+        return ProjectSettingsStorage.load(new ProjectProperties(memberDir), KEY);
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}

--- a/src/test/java/org/omegat/core/data/TeamSettingFilesTest.java
+++ b/src/test/java/org/omegat/core/data/TeamSettingFilesTest.java
@@ -46,6 +46,7 @@ import org.junit.rules.TemporaryFolder;
 
 import org.omegat.core.segmentation.SRXManager;
 import org.omegat.filters2.master.FilterMaster;
+import org.omegat.util.TagPatternsStorage;
 import org.omegat.util.TestPreferencesInitializer;
 
 import gen.core.filters.Filter;
@@ -53,9 +54,10 @@ import gen.core.filters.Filters;
 
 /**
  * Proves that the built-in file-backed team settings expose the project's
- * filters.xml and segmentation files as canonical raw values: differently
- * formatted files with equal content read as the same value, reading never
- * modifies the checkout, and storing null removes the files.
+ * filters.xml, segmentation and tag_patterns.xml files as canonical raw
+ * values: differently formatted files with equal content read as the same
+ * value, reading never modifies the checkout, and storing null removes the
+ * files.
  *
  * @author stephan.pakebusch at zollsoft.de
  */
@@ -190,6 +192,109 @@ public class TeamSettingFilesTest {
                 TeamSettingFiles.FILTERS.describe("content one"));
         assertTrue("the description must carry the fingerprint",
                 one.contains(TeamSettingFiles.fingerprint("content one")));
+    }
+
+    private static String sampleTagPatternsRaw() throws Exception {
+        TagPatternsStorage.TagPatterns patterns = new TagPatternsStorage.TagPatterns();
+        patterns.setCustomTagPattern("<x\\d+>");
+        patterns.setRemoveTextPattern("\\[remove]");
+        return TagPatternsStorage.writeToString(patterns);
+    }
+
+    @Test
+    public void testTagPatternsValueIsCanonicalRegardlessOfFileFormatting() throws Exception {
+        String raw = sampleTagPatternsRaw();
+        TeamSettingFiles.TAG_PATTERNS.saveStored(config, raw);
+        assertEquals("stored value must read back unchanged", raw,
+                TeamSettingFiles.TAG_PATTERNS.loadStored(config));
+
+        File file = new File(internalDir, TagPatternsStorage.FILE_TAG_PATTERNS);
+        String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+        String sep = content.contains("\r\n") ? "\r\n" : "\n";
+        String reformatted = content.replace(">" + sep, ">" + sep + sep);
+        assertNotEquals("the reformatting must change the file", reformatted,
+                Files.readString(file.toPath(), StandardCharsets.UTF_8));
+        Files.writeString(file.toPath(), reformatted, StandardCharsets.UTF_8);
+        assertEquals("formatting must not count as divergence", raw,
+                TeamSettingFiles.TAG_PATTERNS.loadStored(config));
+    }
+
+    @Test
+    public void testTagPatternsEmptyStringOverrideIsARealValue() throws Exception {
+        // an empty expression switches the pattern off for the project,
+        // unlike an absent one, which means the global preference applies
+        TagPatternsStorage.TagPatterns patterns = new TagPatternsStorage.TagPatterns();
+        patterns.setCustomTagPattern("");
+        String raw = TagPatternsStorage.writeToString(patterns);
+        TeamSettingFiles.TAG_PATTERNS.saveStored(config, raw);
+        assertTrue(TeamSettingFiles.TAG_PATTERNS.storageMaterialized(config));
+        assertEquals("the switched-off expression must survive the round trip", raw,
+                TeamSettingFiles.TAG_PATTERNS.loadStored(config));
+    }
+
+    @Test
+    public void testTagPatternsNullRemovesTheFile() throws Exception {
+        TeamSettingFiles.TAG_PATTERNS.saveStored(config, sampleTagPatternsRaw());
+        assertTrue(TeamSettingFiles.TAG_PATTERNS.storageMaterialized(config));
+        TeamSettingFiles.TAG_PATTERNS.saveStored(config, null);
+        assertFalse("null must remove the file",
+                new File(internalDir, TagPatternsStorage.FILE_TAG_PATTERNS).isFile());
+        assertNull(TeamSettingFiles.TAG_PATTERNS.loadStored(config));
+    }
+
+    @Test
+    public void testTagPatternsBrokenFileSurvivesRoutineSaves() throws Exception {
+        File file = new File(internalDir, TagPatternsStorage.FILE_TAG_PATTERNS);
+        Files.writeString(file.toPath(), "<tag_patterns><unclosed", StandardCharsets.UTF_8);
+        config.loadProjectTagPatterns();
+        assertTrue(config.isTagPatternsLoadFailed());
+        assertNull("a broken file must read as no value",
+                TeamSettingFiles.TAG_PATTERNS.loadStored(config));
+
+        // the null session value does not represent the unreadable file, so
+        // a routine save must leave it in place for repair
+        TeamSettingFiles.TAG_PATTERNS.saveStored(config, null);
+        assertTrue("the broken file must survive the routine save", file.isFile());
+
+        // writing real content replaces the broken file and ends the guard
+        String raw = sampleTagPatternsRaw();
+        TeamSettingFiles.TAG_PATTERNS.saveStored(config, raw);
+        assertFalse(config.isTagPatternsLoadFailed());
+        assertEquals(raw, TeamSettingFiles.TAG_PATTERNS.loadStored(config));
+        TeamSettingFiles.TAG_PATTERNS.saveStored(config, null);
+        assertFalse("after the repair null must remove the file again", file.isFile());
+    }
+
+    @Test
+    public void testTagPatternsSessionRoundTrip() throws Exception {
+        config.setCustomTagPattern("<x\\d+>");
+        config.setRemoveTextPattern(null);
+        String raw = TeamSettingFiles.TAG_PATTERNS.read(config);
+        assertNotNull(raw);
+
+        ProjectProperties other = new ProjectProperties(folder.newFolder("other"));
+        TeamSettingFiles.TAG_PATTERNS.apply(other, raw);
+        assertEquals("<x\\d+>", other.getCustomTagPattern());
+        assertNull(other.getRemoveTextPattern());
+
+        TeamSettingFiles.TAG_PATTERNS.apply(other, null);
+        assertNull(other.getCustomTagPattern());
+        assertNull("a default session must read as no value",
+                TeamSettingFiles.TAG_PATTERNS.read(other));
+    }
+
+    @Test
+    public void testTagPatternsDescribeNamesTheExpressions() throws Exception {
+        String noFile = TeamSettingFiles.TAG_PATTERNS.describe(null);
+        String named = TeamSettingFiles.TAG_PATTERNS.describe(sampleTagPatternsRaw());
+        assertNotEquals(noFile, named);
+        assertTrue("the description must show the expressions", named.contains("<x\\d+>"));
+
+        TagPatternsStorage.TagPatterns off = new TagPatternsStorage.TagPatterns();
+        off.setCustomTagPattern("");
+        assertNotEquals("a switched-off expression must describe differently "
+                + "than an inherited one", named,
+                TeamSettingFiles.TAG_PATTERNS.describe(TagPatternsStorage.writeToString(off)));
     }
 
     @Test

--- a/src/test/java/org/omegat/core/data/TeamSettingFilesTest.java
+++ b/src/test/java/org/omegat/core/data/TeamSettingFilesTest.java
@@ -1,0 +1,217 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.segmentation.SRXManager;
+import org.omegat.filters2.master.FilterMaster;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.filters.Filter;
+import gen.core.filters.Filters;
+
+/**
+ * Proves that the built-in file-backed team settings expose the project's
+ * filters.xml and segmentation files as canonical raw values: differently
+ * formatted files with equal content read as the same value, reading never
+ * modifies the checkout, and storing null removes the files.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class TeamSettingFilesTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File projectDir;
+    private File internalDir;
+    private ProjectProperties config;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        internalDir = new File(config.getProjectInternal());
+        Files.createDirectories(internalDir.toPath());
+    }
+
+    private static String sampleFiltersRaw() throws Exception {
+        Filters filters = new Filters();
+        Filter filter = new Filter();
+        filter.setClassName("org.omegat.filters2.text.TextFilter");
+        filter.setEnabled(false);
+        filters.getFilters().add(filter);
+        // the canonical form completes the configuration with the filters
+        // available in this installation, so the baseline must too
+        return FilterMaster.writeConfigToString(FilterMaster.completeWithAvailableFilters(filters));
+    }
+
+    @Test
+    public void testFiltersValueIsCanonicalRegardlessOfFileFormatting() throws Exception {
+        String raw = sampleFiltersRaw();
+        TeamSettingFiles.FILTERS.saveStored(config, raw);
+        assertEquals("stored value must read back unchanged", raw,
+                TeamSettingFiles.FILTERS.loadStored(config));
+
+        // a differently formatted file with equal content is the same value
+        File file = new File(internalDir, FilterMaster.FILE_FILTERS);
+        String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+        // the writer uses the platform line separator
+        String sep = content.contains("\r\n") ? "\r\n" : "\n";
+        String reformatted = content.replace(">" + sep, ">" + sep + sep);
+        assertNotEquals("the reformatting must change the file", reformatted,
+                Files.readString(file.toPath(), StandardCharsets.UTF_8));
+        Files.writeString(file.toPath(), reformatted, StandardCharsets.UTF_8);
+        assertEquals("formatting must not count as divergence", raw,
+                TeamSettingFiles.FILTERS.loadStored(config));
+    }
+
+    @Test
+    public void testFiltersNullRemovesTheFile() throws Exception {
+        TeamSettingFiles.FILTERS.saveStored(config, sampleFiltersRaw());
+        assertTrue(TeamSettingFiles.FILTERS.storageMaterialized(config));
+        TeamSettingFiles.FILTERS.saveStored(config, null);
+        assertFalse("null must remove the file",
+                new File(internalDir, FilterMaster.FILE_FILTERS).isFile());
+        assertNull(TeamSettingFiles.FILTERS.loadStored(config));
+    }
+
+    @Test
+    public void testSegmentationLegacyConfReadsWithoutMigratingTheCheckout() throws Exception {
+        File conf = new File(internalDir, SRXManager.CONF_SENTSEG);
+        try (InputStream in = TeamSettingFilesTest.class
+                .getResourceAsStream("/data/segmentation/migrate/ext/segmentation.conf")) {
+            assertNotNull(in);
+            Files.copy(in, conf.toPath());
+        }
+        byte[] confBytes = Files.readAllBytes(conf.toPath());
+
+        String raw = TeamSettingFiles.SEGMENTATION.loadStored(config);
+        assertNotNull("the legacy file must read as a value", raw);
+        assertTrue("reading must not migrate the checkout", conf.isFile());
+        assertFalse("reading must not create the srx file",
+                new File(internalDir, SRXManager.SRX_SENTSEG).isFile());
+        assertEquals("reading must not touch the legacy file bytes",
+                new String(confBytes, StandardCharsets.UTF_8),
+                Files.readString(conf.toPath(), StandardCharsets.UTF_8));
+
+        // once stored as srx, the value stays the same: the conversion is
+        // part of the canonical form, not of the storage format
+        TeamSettingFiles.SEGMENTATION.saveStored(config, raw);
+        assertTrue(new File(internalDir, SRXManager.SRX_SENTSEG).isFile());
+        assertEquals(raw, TeamSettingFiles.SEGMENTATION.loadStored(config));
+
+        TeamSettingFiles.SEGMENTATION.saveStored(config, null);
+        assertFalse("null must remove both segmentation files",
+                new File(internalDir, SRXManager.SRX_SENTSEG).isFile());
+        assertFalse(new File(internalDir, SRXManager.CONF_SENTSEG).isFile());
+    }
+
+    @Test
+    public void testRepositoryViewReadsLegacyConfAsTheSameValue() throws Exception {
+        // the checkout was migrated to srx while the repository still
+        // carries the legacy conf: same rules must read as the same value,
+        // or every open would report a bogus divergence
+        File conf = folder.newFile("repo-segmentation.conf");
+        try (InputStream in = TeamSettingFilesTest.class
+                .getResourceAsStream("/data/segmentation/migrate/ext/segmentation.conf")) {
+            assertNotNull(in);
+            Files.copy(in, conf.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+        String confPath = config.getProjectInternalRelative() + SRXManager.CONF_SENTSEG;
+        String fromRepoView = TeamSettingFiles.SEGMENTATION.loadStoredFrom(config,
+                path -> path.equals(confPath) ? conf : null);
+        assertNotNull(fromRepoView);
+
+        Files.copy(conf.toPath(), new File(internalDir, SRXManager.CONF_SENTSEG).toPath());
+        String raw = TeamSettingFiles.SEGMENTATION.loadStored(config);
+        TeamSettingFiles.SEGMENTATION.saveStored(config, null);
+        TeamSettingFiles.SEGMENTATION.saveStored(config, raw);
+        assertTrue(new File(internalDir, SRXManager.SRX_SENTSEG).isFile());
+        assertEquals("conf in the repository and migrated srx in the checkout "
+                + "must count as the same value", fromRepoView,
+                TeamSettingFiles.SEGMENTATION.loadStored(config));
+    }
+
+    @Test
+    public void testDescribeNamesStateAndFingerprintsContent() throws Exception {
+        String noFile = TeamSettingFiles.FILTERS.describe(null);
+        String one = TeamSettingFiles.FILTERS.describe("content one");
+        String other = TeamSettingFiles.FILTERS.describe("content two");
+        assertNotEquals("distinct contents must describe distinctly", one, other);
+        assertNotEquals(noFile, one);
+        assertEquals("equal content must describe stably", one,
+                TeamSettingFiles.FILTERS.describe("content one"));
+        assertTrue("the description must carry the fingerprint",
+                one.contains(TeamSettingFiles.fingerprint("content one")));
+    }
+
+    @Test
+    public void testPersistSessionSettingsWritesTheProjectFiles() throws Exception {
+        TeamSettingFiles.ensureRegistered();
+        String raw = sampleFiltersRaw();
+        config.setProjectFilters(FilterMaster.loadConfigFromString(raw));
+
+        RealProject.persistSessionSettings(config, Collections.emptySet());
+        assertEquals("the session configuration must reach the file", raw,
+                TeamSettingFiles.FILTERS.loadStored(config));
+
+        // a superseded setting keeps the stored local value while the
+        // session runs on the team value
+        config.setProjectFilters(null);
+        RealProject.persistSessionSettings(config,
+                Collections.singleton(TeamSettingFiles.FILTERS_KEY));
+        assertEquals("a pending question must keep the stored value", raw,
+                TeamSettingFiles.FILTERS.loadStored(config));
+
+        RealProject.persistSessionSettings(config, Collections.emptySet());
+        assertNull("without the pending question the default deletes the file",
+                TeamSettingFiles.FILTERS.loadStored(config));
+    }
+}

--- a/src/test/java/org/omegat/core/data/TeamSettingTest.java
+++ b/src/test/java/org/omegat/core/data/TeamSettingTest.java
@@ -1,0 +1,122 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Contract of the boolean team setting descriptor and the registry: absent
+ * key means default, only the non-default value materialises, normalization
+ * folds explicit default values back to null so divergence detection never
+ * confuses "explicitly default" with "not configured".
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class TeamSettingTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @After
+    public final void tearDown() {
+        TeamSettingsRegistry.unregister(KEY);
+    }
+
+    @Test
+    public void testOptInBooleanContract() throws Exception {
+        AtomicBoolean holder = new AtomicBoolean(false);
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false,
+                config -> holder.get(), (config, value) -> holder.set(value));
+        ProjectProperties config = new ProjectProperties(folder.newFolder("p"));
+
+        assertNull("default reads as not configured", setting.read(config));
+        holder.set(true);
+        assertEquals("only the non-default value materialises", "true", setting.read(config));
+
+        setting.apply(config, null);
+        assertEquals("null applies the default", false, holder.get());
+        setting.apply(config, "true");
+        assertTrue(holder.get());
+
+        assertNull("explicit default folds back to null", setting.normalize("false"));
+        assertEquals("true", setting.normalize("true"));
+        assertNull(setting.normalize(null));
+    }
+
+    @Test
+    public void testOptOutBooleanContract() throws Exception {
+        AtomicBoolean holder = new AtomicBoolean(true);
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", true,
+                config -> holder.get(), (config, value) -> holder.set(value));
+        ProjectProperties config = new ProjectProperties(folder.newFolder("p"));
+
+        assertNull("default reads as not configured", setting.read(config));
+        holder.set(false);
+        assertEquals("false", setting.read(config));
+
+        setting.apply(config, null);
+        assertTrue("null applies the default", holder.get());
+        assertNull("explicit default folds back to null", setting.normalize("true"));
+        assertEquals("false", setting.normalize("false"));
+    }
+
+    @Test
+    public void testDisplayNameStripsMnemonicMarker() {
+        // existing label keys carry mnemonic markers; dialogs must not show them
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "PP_REMOVE_TAGS", false,
+                config -> false, (config, value) -> {
+                });
+        assertFalse("marker key must resolve to a non-empty name", setting.getDisplayName().isEmpty());
+        assertEquals("mnemonic marker must be stripped", -1, setting.getDisplayName().indexOf('&'));
+    }
+
+    @Test
+    public void testRegistryRejectsDuplicatesAndUnregisters() {
+        TeamSetting setting = TeamSetting.ofBoolean(KEY, "TEAM_SETTING_DIVERGED_TITLE", false,
+                config -> false, (config, value) -> {
+                });
+        TeamSettingsRegistry.register(setting);
+        assertNotNull(TeamSettingsRegistry.byKey(KEY));
+        assertThrows(IllegalArgumentException.class, () -> TeamSettingsRegistry.register(setting));
+        TeamSettingsRegistry.unregister(KEY);
+        assertNull(TeamSettingsRegistry.byKey(KEY));
+        assertTrue(TeamSettingsRegistry.all().stream().noneMatch(s -> s.getKey().equals(KEY)));
+    }
+}

--- a/src/test/java/org/omegat/core/team2/ProjectSettingsTeamRoundTripTest.java
+++ b/src/test/java/org/omegat/core/team2/ProjectSettingsTeamRoundTripTest.java
@@ -1,0 +1,168 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.omegat.core.data.ProjectProperties;
+import org.omegat.core.data.ProjectSettingsStorage;
+import org.omegat.core.team2.impl.GITRemoteRepository2;
+import org.omegat.util.OConsts;
+import org.omegat.util.TestPreferencesInitializer;
+
+import gen.core.project.RepositoryDefinition;
+import gen.core.project.RepositoryMapping;
+
+/**
+ * Proves that a per-project team setting survives the team project round
+ * trip in its sidecar file omegat/project_settings.properties: the routine
+ * full sync distributes and supersedes it like any other configuration file,
+ * a purely local file survives the sync and is recognisable as local-only
+ * divergence through the repository comparison.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class ProjectSettingsTeamRoundTripTest {
+
+    private static final String KEY = "test_option";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File remoteDir;
+    private File projectDir;
+    private ProjectProperties config;
+    private RemoteRepositoryProvider provider;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        TestPreferencesInitializer.init();
+        GITRemoteRepository2.loadPlugins();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteDir = folder.newFolder("remote");
+        Files.writeString(new File(remoteDir, "readme.txt").toPath(), "team project",
+                StandardCharsets.UTF_8);
+        // the provider detects the repository type at construction time, so
+        // the remote must be a git repository before newProvider runs
+        commitRemote("initial team state");
+        projectDir = folder.newFolder("project");
+        config = new ProjectProperties(projectDir);
+        provider = newProvider(projectDir, remoteDir);
+    }
+
+    @Test
+    public void testTeamOpenDeliversTheRemoteSettingsFile() throws Exception {
+        writeRemoteSettings(KEY + "=true\n");
+        commitRemote("team with the option");
+
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("the full sync must deliver the settings file", "true",
+                ProjectSettingsStorage.load(config, KEY));
+        assertTrue("a delivered file is identical to the repository copy",
+                provider.isIdenticalInRepositories(settingsPathUnderRoot()));
+    }
+
+    @Test
+    public void testRemoteFileSupersedesADivergingLocalFile() throws Exception {
+        writeRemoteSettings(KEY + "=false\n");
+        commitRemote("team without the option");
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        // the pre-sync snapshot is what the open uses to notice and report
+        // the superseded local value
+        assertEquals("true", ProjectSettingsStorage.load(config, KEY));
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("on open, the team's file wins", "false", ProjectSettingsStorage.load(config, KEY));
+    }
+
+    @Test
+    public void testLocalOnlyFileSurvivesTheSyncAndReadsAsDivergence() throws Exception {
+        commitRemote("team without a settings file");
+        ProjectSettingsStorage.save(config, KEY, "true");
+
+        provider.switchAllToLatest();
+        provider.copyFilesFromReposToProject("");
+
+        assertEquals("a file the team never had survives the full sync", "true",
+                ProjectSettingsStorage.load(config, KEY));
+        assertFalse("the survivor is recognisable as local-only, so the open "
+                + "keeps the team default active and asks",
+                provider.isIdenticalInRepositories(settingsPathUnderRoot()));
+    }
+
+    private String settingsPathUnderRoot() {
+        return OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS;
+    }
+
+    private void writeRemoteSettings(String content) throws Exception {
+        File f = new File(remoteDir,
+                OConsts.DEFAULT_INTERNAL + "/" + ProjectSettingsStorage.FILE_PROJECT_SETTINGS);
+        Files.createDirectories(f.getParentFile().toPath());
+        Files.writeString(f.toPath(), content, StandardCharsets.UTF_8);
+    }
+
+    private void commitRemote(String message) throws Exception {
+        try (Git git = new File(remoteDir, ".git").exists() ? Git.open(remoteDir)
+                : Git.init().setDirectory(remoteDir).call()) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage(message).setAuthor("OmegaT unit test", "test@test.nl").setSign(false)
+                    .call();
+        }
+    }
+
+    private static RemoteRepositoryProvider newProvider(File projectRoot, File remote) {
+        RepositoryDefinition def = new RepositoryDefinition();
+        def.setType("git");
+        def.setUrl("file://" + remote.getAbsolutePath());
+        RepositoryMapping mapping = new RepositoryMapping();
+        mapping.setLocal("");
+        mapping.setRepository("");
+        def.getMapping().add(mapping);
+        return new RemoteRepositoryProvider(projectRoot, Collections.singletonList(def),
+                new ProjectProperties(projectRoot));
+    }
+}

--- a/src/test/java/org/omegat/core/team2/RemoteReachabilityProbeTest.java
+++ b/src/test/java/org/omegat/core/team2/RemoteReachabilityProbeTest.java
@@ -1,0 +1,158 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.core.team2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.List;
+
+import org.junit.Test;
+
+import gen.core.project.RepositoryDefinition;
+
+/**
+ * Tests for the reachability probe used by the team sync auto-reconnect.
+ *
+ * @author stephan.pakebusch at zollsoft.de
+ */
+public class RemoteReachabilityProbeTest {
+
+    @Test
+    public void testDefaultPorts() {
+        assertEquals(address("github.com", 443),
+                RemoteReachabilityProbe.toSocketAddress("https://github.com/omegat-org/omegat.git"));
+        assertEquals(address("example.org", 80),
+                RemoteReachabilityProbe.toSocketAddress("http://example.org/repo"));
+        assertEquals(address("example.org", 22),
+                RemoteReachabilityProbe.toSocketAddress("ssh://git@example.org/repo.git"));
+        assertEquals(address("example.org", 22),
+                RemoteReachabilityProbe.toSocketAddress("git+ssh://example.org/repo.git"));
+        assertEquals(address("example.org", 22),
+                RemoteReachabilityProbe.toSocketAddress("svn+ssh://example.org/repo"));
+        assertEquals(address("example.org", 9418),
+                RemoteReachabilityProbe.toSocketAddress("git://example.org/repo.git"));
+        assertEquals(address("example.org", 3690),
+                RemoteReachabilityProbe.toSocketAddress("svn://example.org/repo"));
+    }
+
+    @Test
+    public void testExplicitPortWins() {
+        assertEquals(address("example.org", 8443),
+                RemoteReachabilityProbe.toSocketAddress("https://example.org:8443/repo"));
+    }
+
+    @Test
+    public void testScpLikeSyntax() {
+        assertEquals(address("github.com", 22),
+                RemoteReachabilityProbe.toSocketAddress("git@github.com:omegat-org/omegat.git"));
+        // absolute path and no user are also valid scp-like forms
+        assertEquals(address("github.com", 22),
+                RemoteReachabilityProbe.toSocketAddress("git@github.com:/srv/omegat.git"));
+        assertEquals(address("example.org", 22),
+                RemoteReachabilityProbe.toSocketAddress("example.org:repos/project.git"));
+    }
+
+    @Test
+    public void testHostTheUriClassRefuses() {
+        // underscores make URI.getHost() return null; the authority still
+        // names a probeable host
+        assertEquals(address("host_x", 80),
+                RemoteReachabilityProbe.toSocketAddress("http://host_x/repo"));
+        assertEquals(address("host_x", 8080),
+                RemoteReachabilityProbe.toSocketAddress("https://user@host_x:8080/repo"));
+    }
+
+    @Test
+    public void testIpv6Literal() {
+        assertEquals(address("[::1]", 8443),
+                RemoteReachabilityProbe.toSocketAddress("https://[::1]:8443/repo"));
+    }
+
+    @Test
+    public void testUppercaseScheme() {
+        assertEquals(address("example.org", 443),
+                RemoteReachabilityProbe.toSocketAddress("HTTPS://example.org/repo"));
+    }
+
+    @Test
+    public void testLocalUrlsHaveNoHost() {
+        assertNull(RemoteReachabilityProbe.toSocketAddress("file:///repos/project.git"));
+        assertNull(RemoteReachabilityProbe.toSocketAddress("/repos/project.git"));
+        assertNull(RemoteReachabilityProbe.toSocketAddress("C:\\repos\\project"));
+        assertNull(RemoteReachabilityProbe.toSocketAddress("C:/repos/project"));
+        assertNull(RemoteReachabilityProbe.toSocketAddress(null));
+        assertNull(RemoteReachabilityProbe.toSocketAddress("  "));
+        // unknown scheme: not probeable, counts as reachable by design
+        assertNull(RemoteReachabilityProbe.toSocketAddress("ftp://example.org/repo"));
+    }
+
+    @Test
+    public void testLocalUrlsCountAsReachable() {
+        assertTrue(RemoteReachabilityProbe.canReach("file:///repos/project.git", 100));
+        assertTrue(RemoteReachabilityProbe.canReach(null, 100));
+    }
+
+    @Test
+    public void testUnresolvableHost() {
+        // .invalid is reserved (RFC 2606) and never resolves
+        assertFalse(RemoteReachabilityProbe.canReach("https://no-such-host.invalid/repo", 100));
+    }
+
+    @Test
+    public void testReachableAndRefused() throws Exception {
+        // Window between close and probe: another process could rebind the
+        // port; accepted as negligible for an ephemeral port.
+        int port;
+        try (ServerSocket server = new ServerSocket(0)) {
+            port = server.getLocalPort();
+            assertTrue(RemoteReachabilityProbe.canReach("http://127.0.0.1:" + port + "/repo", 2000));
+        }
+        // the socket is closed now: same port refuses
+        assertFalse(RemoteReachabilityProbe.canReach("http://127.0.0.1:" + port + "/repo", 2000));
+    }
+
+    @Test
+    public void testCanReachAllProbesEveryUrl() throws Exception {
+        RepositoryDefinition local = new RepositoryDefinition();
+        local.setUrl("file:///repos/project.git");
+        RepositoryDefinition dead;
+        try (ServerSocket server = new ServerSocket(0)) {
+            dead = new RepositoryDefinition();
+            dead.setUrl("http://127.0.0.1:" + server.getLocalPort() + "/repo");
+            assertTrue(RemoteReachabilityProbe.canReachAll(List.of(local, dead), 2000));
+        }
+        assertFalse(RemoteReachabilityProbe.canReachAll(List.of(local, dead), 2000));
+    }
+
+    private static InetSocketAddress address(String host, int port) {
+        return InetSocketAddress.createUnresolved(host, port);
+    }
+}

--- a/src/test/java/org/omegat/util/PatternConstsTest.java
+++ b/src/test/java/org/omegat/util/PatternConstsTest.java
@@ -26,6 +26,7 @@
 package org.omegat.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -75,4 +76,37 @@ public class PatternConstsTest {
         assertEquals("Wrong country extracted", "abc", m.group(2));
     }
 
+    @Test
+    public void testProjectSpecificPatternsOverrideTheGlobals() throws Exception {
+        TestPreferencesInitializer.init();
+        try {
+            Preferences.setPreference(Preferences.CHECK_CUSTOM_PATTERN, "\\d+");
+            Preferences.setPreference(Preferences.CHECK_REMOVE_PATTERN, "foo");
+            PatternConsts.clearProjectPatterns();
+            assertTrue(PatternConsts.getPlaceholderPattern().matcher("42").find());
+            assertEquals("foo", PatternConsts.getRemovePattern().pattern());
+            assertEquals("\\d+", PatternConsts.getCustomTagPattern().pattern());
+
+            PatternConsts.applyProjectPatterns("%[a-z]+", "bar");
+            assertFalse(PatternConsts.getPlaceholderPattern().matcher("42").find());
+            assertTrue(PatternConsts.getPlaceholderPattern().matcher("%s").find());
+            assertEquals("bar", PatternConsts.getRemovePattern().pattern());
+            assertEquals("%[a-z]+", PatternConsts.getCustomTagPattern().pattern());
+
+            // An empty expression is a real override that switches custom
+            // tags off; one that does not compile is refused and the global
+            // expression stays in force.
+            PatternConsts.applyProjectPatterns("", "[");
+            assertFalse(PatternConsts.getPlaceholderPattern().matcher("42").find());
+            assertNull(PatternConsts.getCustomTagPattern());
+            assertEquals("foo", PatternConsts.getRemovePattern().pattern());
+        } finally {
+            // Leave neither the project overrides nor the mutated global
+            // expressions behind for later tests in the same JVM. Writing ""
+            // would not restore the pristine state - the key would then
+            // exist - so the preferences store is re-initialized instead.
+            TestPreferencesInitializer.init();
+            PatternConsts.clearProjectPatterns();
+        }
+    }
 }

--- a/src/test/java/org/omegat/util/TagPatternsStorageTest.java
+++ b/src/test/java/org/omegat/util/TagPatternsStorageTest.java
@@ -1,0 +1,125 @@
+/**************************************************************************
+ OmegaT - Computer Assisted Translation (CAT) tool
+          with fuzzy matching, translation memory, keyword search,
+          glossaries, and translation leveraging into updated projects.
+
+ Copyright (C) 2026 Stephan Pakebusch
+               Home page: https://www.omegat.org/
+               Support center: https://omegat.org/support
+
+ This file is part of OmegaT.
+
+ OmegaT is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OmegaT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+package org.omegat.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Stephan Pakebusch
+ */
+public class TagPatternsStorageTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private File configFile;
+
+    @Before
+    public void setUp() throws Exception {
+        configFile = new File(folder.getRoot(), TagPatternsStorage.FILE_TAG_PATTERNS);
+    }
+
+    @Test
+    public void testRoundTrip() throws Exception {
+        TagPatternsStorage.TagPatterns patterns = new TagPatternsStorage.TagPatterns();
+        patterns.setCustomTagPattern("%[a-z]+");
+        patterns.setRemoveTextPattern("\\{[0-9]+\\}");
+        TagPatternsStorage.save(patterns, configFile);
+        assertTrue(configFile.exists());
+
+        TagPatternsStorage.TagPatterns loaded = TagPatternsStorage.load(configFile);
+        assertEquals("%[a-z]+", loaded.getCustomTagPattern());
+        assertEquals("\\{[0-9]+\\}", loaded.getRemoveTextPattern());
+    }
+
+    @Test
+    public void testEmptyStringSurvivesTheRoundTrip() throws Exception {
+        // The whole null-vs-empty semantics rests on an empty element coming
+        // back as an empty string: null means the global preference applies,
+        // while the empty string switches the expression off.
+        TagPatternsStorage.TagPatterns patterns = new TagPatternsStorage.TagPatterns();
+        patterns.setCustomTagPattern("");
+        TagPatternsStorage.save(patterns, configFile);
+
+        TagPatternsStorage.TagPatterns loaded = TagPatternsStorage.load(configFile);
+        assertEquals("", loaded.getCustomTagPattern());
+        assertNull(loaded.getRemoveTextPattern());
+    }
+
+    @Test
+    public void testInheritingProjectLeavesNoFile() throws Exception {
+        TagPatternsStorage.TagPatterns patterns = new TagPatternsStorage.TagPatterns();
+        patterns.setCustomTagPattern("%[a-z]+");
+        TagPatternsStorage.save(patterns, configFile);
+        assertTrue(configFile.exists());
+
+        TagPatternsStorage.save(new TagPatternsStorage.TagPatterns(), configFile);
+        assertFalse(configFile.exists());
+        assertNull(TagPatternsStorage.load(configFile));
+    }
+
+    @Test
+    public void testUnreadableFileRaisesAndStaysInPlace() throws Exception {
+        // The caller falls back to the global preferences but must know
+        // about the failure, so a routine save does not delete a file the
+        // user could still repair.
+        Files.write(configFile.toPath(), "no xml at all".getBytes(StandardCharsets.UTF_8));
+        try {
+            TagPatternsStorage.load(configFile);
+            fail("An unparseable file must raise an IOException");
+        } catch (IOException expected) {
+        }
+        assertTrue(configFile.exists());
+    }
+
+    @Test
+    public void testUnknownElementsAreTolerated() throws Exception {
+        // Forward compatibility: a file written by a newer OmegaT with
+        // additional elements must still load in this version.
+        Files.write(configFile.toPath(),
+                ("<?xml version='1.0' encoding='UTF-8'?>\n" + "<tag_patterns>\n"
+                        + "  <custom_tag_pattern>%[a-z]+</custom_tag_pattern>\n"
+                        + "  <shiny_future_pattern>x</shiny_future_pattern>\n" + "</tag_patterns>\n")
+                        .getBytes(StandardCharsets.UTF_8));
+        TagPatternsStorage.TagPatterns loaded = TagPatternsStorage.load(configFile);
+        assertEquals("%[a-z]+", loaded.getCustomTagPattern());
+        assertNull(loaded.getRemoveTextPattern());
+    }
+}


### PR DESCRIPTION
## Pull request type

- Feature enhancement -> [enhancement]

## Which ticket is resolved?

- "Put Team Project in Offline Mode" (discussion describes automatic resume as former behaviour)
  * https://sourceforge.net/p/omegat/feature-requests/1006/

## What does this PR change?

- Team project in offline mode resumes synchronization automatically once remote host answers again; restores behaviour described in SF-RFE-1006 discussion, lost with prepare-based sync architecture
- Auto-save thread probes remote host via plain TCP connect (3s timeout, DNS resolution capped too), outside project lock; on success runs one regular save with team sync, switches back to online mode, existing "working online" banner signals it
- Also heals work left behind by earlier offline session at first auto-save with network
- Non-network failure of automatic restore logs and backs off 30 min instead of repeating modal error dialog; network failure retries silently next interval
- New `RemoteReachabilityProbe`; `IProject.canRestoreTeamSync()`/`restoreTeamSync()` default methods; probe skips URLs without network host (file, local paths); direct connect means proxy-only setups still need manual save
- Unit tests for URL parsing (scp syntax, underscore hosts, IPv6, ports) and socket probe

## Other information

stacking chain (or stack, depends on how you look at it, from above or from sideways…): #2319 -> #2335 -> #2248 -> this one here, so this remains a draft until the previous PRs are cleared