### PR TITLE
chore(doc-devel): git workflow to add guide of a smart assistant

### DIFF
--- a/.github/workflows/developer-docs-diagram-source.yml
+++ b/.github/workflows/developer-docs-diagram-source.yml
@@ -1,0 +1,34 @@
+name: Developer docs diagram source check
+
+on:
+  pull_request:
+    paths:
+      - 'src/docs/developer/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Require editable source next to added SVG files
+        run: |
+          missing=""
+          for svg in $(git diff --name-only --diff-filter=A \
+                         "origin/${GITHUB_BASE_REF}...HEAD" -- src/docs/developer \
+                       | grep -Ei '\.svg$' || true); do
+            base="${svg%.*}"
+            found=""
+            for ext in drawio excalidraw puml dot mmd; do
+              [ -f "$base.$ext" ] && found=1 && break
+            done
+            [ -z "$found" ] && missing="$missing$svg"$'\n'
+          done
+          if [ -n "$missing" ]; then
+            echo "These SVG files have no editable source (.drawio, .excalidraw, .puml, .dot, .mmd)"
+            echo "with the same base name. Commit the source, or write the diagram as Mermaid."
+            echo "See src/docs/developer/48.DeveloperDocumentation.md, section Diagrams."
+            printf '%s' "$missing"
+            exit 1
+          fi

--- a/src/docs/developer/06.GitWorkFlows.md
+++ b/src/docs/developer/06.GitWorkFlows.md
@@ -69,7 +69,7 @@ Such names do not give any indication of what your work is about.
    git switch topic/your-username/area/short-description
 ```
 
-### If you work with Github
+### If you work with GitHub
 
 1. **Fork the OmegaT repository**  
    Visit: https://github.com/omegat-org/omegat
@@ -170,6 +170,13 @@ You’re supposed to have discussed your code on the [development list](https://
   - Click “Compare & pull request”
   - Add a clear title and explanation
   - Link to any related issues or discussions
+
+If you used an AI coding assistant, write the explanation yourself in plain
+text: what the change does and why. Do not paste the assistant's own draft
+description unedited, and do not attach generated diagrams or infographics to
+explain the change. A reviewer reading many PRs pays a real cost, in time and
+attention, for each one, and a plain sentence is cheaper to read than an image
+generated to explain it.
 
 Tip: You can open a **draft pull request** if you’re still working on it but want feedback early.
 

--- a/src/docs/developer/06.GitWorkFlows.md
+++ b/src/docs/developer/06.GitWorkFlows.md
@@ -170,13 +170,14 @@ You’re supposed to have discussed your code on the [development list](https://
   - Click “Compare & pull request”
   - Add a clear title and explanation
   - Link to any related issues or discussions
-
-If you used an AI coding assistant, write the explanation yourself in plain
-text: what the change does and why. Do not paste the assistant's own draft
-description unedited, and do not attach generated diagrams or infographics to
-explain the change. A reviewer reading many PRs pays a real cost, in time and
-attention, for each one, and a plain sentence is cheaper to read than an image
-generated to explain it.
+ 
+A few plain sentences are enough for the explanation: what the change does,
+and why. If you used an AI coding assistant, write those sentences yourself
+rather than pasting the assistant's draft unedited. If the change is easier
+to understand with a diagram, put it in the developer documentation as
+Mermaid, or as an SVG together with its editable source; see
+[48.DeveloperDocumentation.md](48.DeveloperDocumentation.md), section
+Diagrams. An image file added on its own will fail the CI check.
 
 Tip: You can open a **draft pull request** if you’re still working on it but want feedback early.
 

--- a/src/docs/developer/48.DeveloperDocumentation.md
+++ b/src/docs/developer/48.DeveloperDocumentation.md
@@ -212,12 +212,17 @@ locally before opening a pull request.
 Diagrams help explain architecture, workflows, and data flow. The developer
 documentation supports both static SVG images and Mermaid diagrams.
 
-Use the format that best fits the contribution:
+Start from the cheapest form that carries the information:
 
-- Use SVG for polished infographics, screenshots, and diagrams prepared with
-  drawing tools.
-- Use Mermaid for diagrams that are easier to maintain as text in version
-  control.
+- Use plain Markdown text or a list when the content is a sequence or a set
+  of items. Do not turn a list into an image.
+- Use Mermaid for structural diagrams (flows, dependencies, state, sequence).
+  Mermaid is text, so it is reviewed as a diff and can be edited later by
+  anyone.
+- Use SVG for drawings prepared with a drawing tool, and commit the tool's
+  editable source next to it with the same base name (for example
+  `build-pipeline-overview.svg` with `build-pipeline-overview.drawio`).
+  An SVG without its source cannot be maintained and is rejected by CI.
 
 ### Embedding SVG images
 

--- a/src/docs/developer/96.ContinuousIntegration.md
+++ b/src/docs/developer/96.ContinuousIntegration.md
@@ -104,17 +104,18 @@ The following workflows run on every push to `master` / `releases/*` and on ever
 providing continuous quality feedback. Most workflows skip `ci/`, `src/docs/`, and `*.md` changes
 to avoid unnecessary runs on non-code changes.
 
-| Workflow file                  | Name                     | What it checks                                                                                                                                                                                      |
-|--------------------------------|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `acceptance-master.yml`        | Acceptance Tests         | Runs the UI acceptance test suite under a virtual framebuffer (`Xvfb`).                                                                                                                             |
-| `checkstyle-annotate.yml`      | Run checkstyle           | Runs `checkstyleMain` and `checkstyleTest` Gradle tasks and annotates violations inline.                                                                                                            |
-| `gradle-check-master.yml`      | Quality checks           | Runs the full Gradle `check` task and verifies the Git working tree is clean after the build.                                                                                                       |
-| `manuals-builds-master.yml`    | Check manuals build      | Builds the HTML manuals with `manualHtmls`; triggered only when manual source files change.                                                                                                         |
-| `pmd-annotate.yml`             | Run PMD                  | Runs `pmdMain` and `pmdTest` Gradle tasks and annotates findings inline.                                                                                                                            |
-| `qodana-code-quality.yml`      | Qodana                   | Runs a nightly JetBrains Qodana static analysis scan and uploads results to the Qodana cloud.                                                                                                       |
-| `semgrep.yml`                  | Run Semgrep              | Runs Semgrep SAST analysis on every pull request and on pushes to `master`.                                                                                                                         |
-| `source-distribution-test.yml` | Source Distribution Test | Builds the source distribution with `installSourceDist`, then compiles it from scratch and checks for duplicate dependencies — this catches any missing or incorrectly declared build dependencies. |
-| `spotbugs-annotate.yml`        | Run SpotBugs             | Runs `spotbugsMain` and `spotbugsTest` Gradle tasks and annotates findings inline.                                                                                                                  |
+| Workflow file                       | Name                                 | What it checks                                                                                                                                                                                      |
+|-------------------------------------|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `acceptance-master.yml`             | Acceptance Tests                     | Runs the UI acceptance test suite under a virtual framebuffer (`Xvfb`).                                                                                                                             |
+| `checkstyle-annotate.yml`           | Run checkstyle                       | Runs `checkstyleMain` and `checkstyleTest` Gradle tasks and annotates violations inline.                                                                                                            |
+| `gradle-check-master.yml`           | Quality checks                       | Runs the full Gradle `check` task and verifies the Git working tree is clean after the build.                                                                                                       |
+| `manuals-builds-master.yml`         | Check manuals build                  | Builds the HTML manuals with `manualHtmls`; triggered only when manual source files change.                                                                                                         |
+| `pmd-annotate.yml`                  | Run PMD                              | Runs `pmdMain` and `pmdTest` Gradle tasks and annotates findings inline.                                                                                                                            |
+| `qodana-code-quality.yml`           | Qodana                               | Runs a nightly JetBrains Qodana static analysis scan and uploads results to the Qodana cloud.                                                                                                       |
+| `semgrep.yml`                       | Run Semgrep                          | Runs Semgrep SAST analysis on every pull request and on pushes to `master`.                                                                                                                         |
+| `source-distribution-test.yml`      | Source Distribution Test             | Builds the source distribution with `installSourceDist`, then compiles it from scratch and checks for duplicate dependencies — this catches any missing or incorrectly declared build dependencies. |
+| `spotbugs-annotate.yml`             | Run SpotBugs                         | Runs `spotbugsMain` and `spotbugsTest` Gradle tasks and annotates findings inline.                                                                                                                  |
+| `developer-docs-diagram-source.yml` | Developer docs diagram source check  | Fails if an SVG is added under `src/docs/developer/` without an editable source file (`.drawio` etc.) of the same base name.                                                                         |
 
 ### Notes on specific checks
 
@@ -156,6 +157,7 @@ ci/
   workflows/
     acceptance-master.yml                  # UI acceptance tests
     checkstyle-annotate.yml                # Checkstyle
+    developer-docs-diagram-source.yml      # Developer docs diagram source check
     gradle-check-master.yml                # Gradle check + clean tree verification
     manuals-builds-master.yml              # Manuals HTML build check
     pmd-annotate.yml                       # PMD static analysis


### PR DESCRIPTION
Require an editable source next to SVG diagrams in the developer
documentation, and tell contributors how to write the PR explanation.

the Diagrams section already expects SVGs to be prepared with drawing
tools, but nothing asks for the tool's file. Without it the SVG cannot be
edited later. Requiring the source keeps SVG available for drawings Mermaid
cannot express, while keeping every diagram maintainable. Only SVG files
added under `src/docs/developer/` are checked; existing files, PNG/JPEG
screenshots, and the user manual are unaffected.

## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

none;
## What does this PR change?


- `48.DeveloperDocumentation.md`, section "Diagrams": states the order
  of preference (plain text or list, then Mermaid, then SVG), and
  requires that an SVG be committed together with the editable source
  it was exported from, under the same base name.
- `06.GitWorkFlows.md`, "Open a Pull Request": a short paragraph on the
  PR explanation (a few plain sentences, written by the author even
  when an AI assistant was used) with a pointer to the diagram rule.
- `.github/workflows/developer-docs-diagram-source.yml`: new check on pull
  requests touching `src/docs/developer/`. Fails if an SVG is added
  without a matching `.drawio`, `.excalidraw`, `.puml`, `.dot`, or
  `.mmd` file.
- `96.ContinuousIntegration.md`: the new workflow added to the table
  and file listing.

## Other information

<!-- Any other information that is important to this PR, such as
before-and-after screenshots -->
