### PR TITLE
docs(developer): add Process Decision Records and PDR 0001

### DIFF
--- a/src/docs/developer/index.md
+++ b/src/docs/developer/index.md
@@ -80,6 +80,7 @@
 ## Architecture Designs/change log 
 
 * [Architecture Decisional Records](adr/index.md)
+* [Process Decision Records](pdr/index.md)
 * [Changelog](changes/index.md)
 
 ## Other information

--- a/src/docs/developer/pdr/0001.DecisionMakingProcess.md
+++ b/src/docs/developer/pdr/0001.DecisionMakingProcess.md
@@ -1,0 +1,94 @@
+# PDR 0001: How This Project Settles Decisions
+
+## Status
+**Proposed**
+
+## Context
+
+Several recent threads on the developer mailing list and in pull request
+review settled disagreements the same way, without that pattern being
+written down anywhere:
+
+- The developer documentation numbering scheme, now recorded in
+  `48.DeveloperDocumentation.md` (PR #2275), was settled not by agreeing
+  on categories in the abstract, but by putting a concrete diff to
+  `index.md` in front of the list and asking for confirmation or
+  correction against that text.
+- Architecture Decision Records themselves follow this pattern by
+  construction: a proposal is drafted as a concrete document, objections
+  attach to specific sections of that document, and the ADR is marked
+  Accepted once the pull request adding it is merged, not once every
+  participant has stated agreement in words.
+- Other structural decisions on this project (build system conventions,
+  code signing procedure) were reached the same way: a document or diff
+  was produced first, and discussion converged on that artifact.
+
+This project currently has no written description of this pattern. A new
+contributor or a returning reviewer has no way to know, in advance, what
+form a proposal needs to take to be decided on, or when a discussion is
+considered closed.
+
+A related failure has also been observed: a contributor proposes a code
+change without having read the discussion already recorded on the
+SourceForge ticket for that feature or bug, the change is not reviewed,
+the contributor is directed to the developer mailing list instead, and
+the ensuing list discussion faults them for not having accounted for
+points already settled earlier. The contributor is not at fault for
+failing to infer a discussion history that was never pointed out to
+them. This is made worse by ticket write-ups themselves often being
+sparse, since they are authored by the reporting contributor rather than
+a core member, and may not reflect the fuller discussion that followed
+in comments.
+
+## Decision
+
+This project settles decisions about developer-facing process,
+documentation, and build/release conventions as follows:
+
+1. A decision is proposed as a concrete artifact: a diff, a draft
+   document, or a pull request, not a description of an idea.
+2. Objections and discussion attach to that artifact. Abstract
+   disagreement not tied to specific text in the artifact does not by
+   itself block a decision.
+3. The decision is closed when the accountable reviewer for that area
+   confirms the artifact as-is, or the artifact is revised and
+   re-confirmed. It is not closed by a show of verbal agreement, and it
+   is not blocked by the absence of one. This PDR does not assign who is
+   accountable for which area.
+4. An artifact is expected to account for relevant prior discussion:
+   linked SourceForge ticket comments, earlier mailing list threads, or
+   related ADRs/PDRs. When a reviewer finds that a proposal overlooks
+   prior discussion, the reviewer points to the specific ticket comment
+   or thread being overlooked, rather than asserting in general that
+   prior discussion was not read. A proposal is not faulted for missing
+   context that no one pointed it to.
+
+## Consequences
+
+### Positive
+- New contributors can see, in advance, what form a proposal needs to
+  take and how a discussion concludes.
+- Disagreements are resolved against specific text, which keeps review
+  scoped and avoids repeated abstract debate.
+- The pattern already in use is made visible and citable, rather than
+  depending on participants having witnessed enough prior threads to
+  infer it.
+
+### Negative
+- Proposals that are not yet in artifact form (an idea without a draft)
+  do not have a clear path to decision under this PDR; they must first be
+  turned into a concrete document or diff.
+- This PDR does not resolve who is accountable for areas where that role
+  is currently unclear or unfilled; it only states how decisions are
+  reached once an accountable reviewer exists.
+- Pointing a proposal to specific prior discussion places a burden on
+  reviewers to locate that discussion themselves when ticket write-ups
+  are sparse. This PDR does not address ticket write-up quality; that is
+  a separate concern.
+
+## Related Documents
+- [48. Developer Documentation](../48.DeveloperDocumentation.md) — the
+  numbering scheme settled by PR #2275, the immediate precedent for this
+  PDR.
+- [ADR index](../adr/index.md) — the same artifact-first pattern, applied
+  to architectural decisions.

--- a/src/docs/developer/pdr/index.md
+++ b/src/docs/developer/pdr/index.md
@@ -1,0 +1,25 @@
+# Process Decision Record
+
+Process Decision Records (PDR) record decisions about how this project
+works: decision-making process, roles and responsibilities, and other
+administrative or governance matters. They are distinct from
+[Architecture Decision Records](../adr/index.md), which record decisions
+about the software's architecture.
+
+They are also distinct from the numbered pages of the developer manual.
+A numbered page describes procedures and conventions that a contributor
+can act on directly. A PDR records a decision the project has already
+taken about its own process, and the reasoning behind it. When a
+numbered page says "do this", the PDR that justifies it, if any, is
+linked from that page.
+
+A PDR follows the same Status / Context / Decision / Consequences
+structure as an ADR. A PDR is **Proposed** while the pull request that
+adds it is open, and **Accepted** once that pull request is merged. The
+review of that pull request is where the decision is discussed.
+
+# Table of contents
+
+## Decision-making process
+
+- 0001 [How This Project Settles Decisions](0001.DecisionMakingProcess.md)


### PR DESCRIPTION
Add Process Decision Records (PDR) as a document category next to the
ADRs, and PDR 0001, which writes down how this project settles decisions.

## Pull request type

- Documentation -> [documentation]

## Which ticket is resolved?

none

## What does this PR change?

- `src/docs/developer/pdr/index.md` (new): defines PDRs as records of
  decisions about process and governance, distinct from ADRs (architecture)
  and from the numbered manual pages (procedures a contributor acts on).
  Same Status / Context / Decision / Consequences structure as an ADR.
- `src/docs/developer/pdr/0001.DecisionMakingProcess.md` (new): states a
  pattern this project already follows but has never written down. A
  proposal is a concrete artifact (a diff, a draft, a PR); objections
  attach to that artifact; the decision closes when the accountable
  reviewer confirms or the artifact is revised and re-confirmed, not when
  everyone has said they agree in words. The numbering scheme in
  `48.DeveloperDocumentation.md` (PR #2275) is cited as the most recent
  example. It also states that a proposal is expected to account
  for relevant prior discussion (ticket comments, earlier list threads,
  related ADRs/PDRs), and that a reviewer who finds prior discussion
  overlooked points to the specific thread or comment rather than saying
  in general that it was not read.
- `src/docs/developer/index.md`: one line added under "Architecture
  Designs/change log" pointing to the new PDR index. No other change to
  the index.

## Other information

Out of scope, stated in the document itself: who is the accountable
reviewer for which area, and the quality of ticket write-ups. Both are
left for later entries.

Status: Proposed. This PR is itself the kind of artifact PDR 0001
describes; it will be marked Accepted once confirmed.